### PR TITLE
refactor: turn Price into a proper DDD value object

### DIFF
--- a/backend/cart/adapter/postgres.go
+++ b/backend/cart/adapter/postgres.go
@@ -48,10 +48,11 @@ func (p postgres) Get(ctx context.Context, user domain.User) (*domain.Cart, erro
 
 	c := domain.NewCart(domain.NewUser(userID))
 	for _, i := range items {
-		// TODO: I know this is not the best way to do it, but I don't want to
-		//       take care of the currency conversion right now.
-		price := float64(i.price) / 100.0
-		p := domain.NewProduct(i.productID, i.name, price, i.currency)
+		cur, err := domain.NewCurrency(i.currency)
+		if err != nil {
+			return nil, fmt.Errorf("invalid currency on cart item: %w", err)
+		}
+		p := domain.NewProduct(i.productID, i.name, int64(i.price), cur)
 		err = c.Add(p, i.qty)
 		if err != nil {
 			return nil, fmt.Errorf("could not add item to the cart: %w", err)
@@ -114,10 +115,9 @@ func (p postgres) Persist(ctx context.Context, cart *domain.Cart) error {
 
 	for _, i := range cart.Items() {
 		cartItemID := fmt.Sprintf("%s-%s", cart.User().ID(), i.Product().ID())
-		price := int(i.Product().Price().Amount() * 100)
 
 		q = `INSERT INTO cart_cart_item (id,        cart_id, 	      product_id,       product_name,       qty,          price, currency) VALUES ($1, $2, $3, $4, $5, $6, $7)`
-		_, err = tx.ExecContext(ctx, q, cartItemID, cart.User().ID(), i.Product().ID(), i.Product().Name(), i.Quantity(), price, i.Product().Price().Currency())
+		_, err = tx.ExecContext(ctx, q, cartItemID, cart.User().ID(), i.Product().ID(), i.Product().Name(), i.Quantity(), i.Product().Price().Amount(), string(i.Product().Price().Currency()))
 		if err != nil {
 			return fmt.Errorf("could not insert cart item: %w", err)
 		}

--- a/backend/cart/bounded_context.go
+++ b/backend/cart/bounded_context.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
 
 	"github.com/bkielbasa/go-ecommerce/backend/cart/adapter"
 	"github.com/bkielbasa/go-ecommerce/backend/cart/app"
@@ -44,7 +45,12 @@ func (tpc transformProductCatalog) Find(ctx context.Context, productID string) (
 		return domain.Product{}, err
 	}
 
-	return domain.NewProduct(string(p.ID()), p.Name(), p.Price().Amount(), p.Price().Currency()), nil
+	cur, err := domain.NewCurrency(string(p.Price().Currency()))
+	if err != nil {
+		return domain.Product{}, fmt.Errorf("cart: invalid currency from product catalog: %w", err)
+	}
+
+	return domain.NewProduct(string(p.ID()), p.Name(), p.Price().Amount(), cur), nil
 }
 
 type boundedContext struct {

--- a/backend/cart/cart_test.go
+++ b/backend/cart/cart_test.go
@@ -117,8 +117,8 @@ func (b cartServiceBuilder) build() app.CartService {
 	return app.NewCartService(storage, mockProductCatalog(b))
 }
 
-func (b cartServiceBuilder) WithProduct(pID string, price float64) cartServiceBuilder {
-	b.products[pID] = domain.NewProduct(pID, "test name", price, "PLN")
+func (b cartServiceBuilder) WithProduct(pID string, priceMinorUnits int64) cartServiceBuilder {
+	b.products[pID] = domain.NewProduct(pID, "test name", priceMinorUnits, domain.MustNewCurrency("PLN"))
 	return b
 }
 

--- a/backend/cart/domain/cart.go
+++ b/backend/cart/domain/cart.go
@@ -86,7 +86,7 @@ func (c *Cart) TotalQuantity() int {
 func (c *Cart) TotalPrice() price {
 	// TODO: add support for multiple currencies
 
-	total := NewPrice(0, "USD")
+	total := MustNewPrice(0, MustNewCurrency("USD"))
 	for _, item := range c.cartItems {
 		total = total.Add(item.product.Price().Multiple(item.Quantity()))
 	}

--- a/backend/cart/domain/cart_test.go
+++ b/backend/cart/domain/cart_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/matryer/is"
 )
 
-var pID = domain.NewProduct("productID", "test product", 2.0, "PLN")
-var pID2 = domain.NewProduct("productID2", "test product", 10.0, "PLN")
+var pID = domain.NewProduct("productID", "test product", 200, domain.MustNewCurrency("PLN"))
+var pID2 = domain.NewProduct("productID2", "test product", 1000, domain.MustNewCurrency("PLN"))
 
 func TestCart_Adding_Products_To_Cart_Should_Change_Quantity(t *testing.T) {
 	is := is.New(t)

--- a/backend/cart/domain/product.go
+++ b/backend/cart/domain/product.go
@@ -2,9 +2,33 @@ package domain
 
 import (
 	"errors"
+	"fmt"
+	"regexp"
 )
 
 var ErrProductNotFound = errors.New("product not found")
+
+// Currency is an ISO 4217 three-letter currency code.
+type Currency string
+
+var currencyReg = regexp.MustCompile(`^[A-Z]{3}$`)
+
+func NewCurrency(code string) (Currency, error) {
+	if !currencyReg.MatchString(code) {
+		return "", fmt.Errorf("invalid currency code %q: must be three uppercase letters (ISO 4217)", code)
+	}
+	return Currency(code), nil
+}
+
+func MustNewCurrency(code string) Currency {
+	c, err := NewCurrency(code)
+	if err != nil {
+		panic(err)
+	}
+	return c
+}
+
+func (c Currency) String() string { return string(c) }
 
 type Product struct {
 	id    string
@@ -12,7 +36,7 @@ type Product struct {
 	price price
 }
 
-func NewProduct(id string, name string, amount float64, currency string) Product {
+func NewProduct(id string, name string, amount int64, currency Currency) Product {
 	return Product{id: id, name: name, price: price{amount: amount, currency: currency}}
 }
 
@@ -28,29 +52,53 @@ func (p Product) Name() string {
 	return p.name
 }
 
+// price holds an amount in minor currency units (e.g. cents).
 type price struct {
-	amount   float64
-	currency string
+	amount   int64
+	currency Currency
 }
 
-func NewPrice(amount float64, currency string) price {
-	return price{amount: amount, currency: currency}
+func NewPrice(amount int64, currency Currency) (price, error) {
+	if amount < 0 {
+		return price{}, fmt.Errorf("price amount cannot be negative: %d", amount)
+	}
+	if currency == "" {
+		return price{}, errors.New("price currency cannot be empty")
+	}
+	return price{amount: amount, currency: currency}, nil
 }
 
-func (p price) Amount() float64 {
+func MustNewPrice(amount int64, currency Currency) price {
+	p, err := NewPrice(amount, currency)
+	if err != nil {
+		panic(err)
+	}
+	return p
+}
+
+func (p price) Amount() int64 {
 	return p.amount
 }
 
+func (p price) Currency() Currency {
+	return p.currency
+}
+
+func (p price) Equals(other price) bool {
+	return p.amount == other.amount && p.currency == other.currency
+}
+
+// Display formats the amount as a decimal string in major units (e.g. "2.34").
+func (p price) Display() string {
+	return fmt.Sprintf("%d.%02d", p.amount/100, p.amount%100)
+}
+
 func (p price) Multiple(d int) price {
-	p.amount *= float64(d)
+	p.amount *= int64(d)
 	return p
 }
 
 func (p price) Add(p2 price) price {
 	p.amount += p2.amount
 	return p
-}
-
-func (p price) Currency() string {
-	return p.currency
 }

--- a/backend/cmd/cli/productcatalog.go
+++ b/backend/cmd/cli/productcatalog.go
@@ -8,7 +8,7 @@ import (
 )
 
 type productCatalog interface {
-	Add(ctx context.Context, id, name, desc string, price float64, currency string) error
+	Add(ctx context.Context, id, name, desc string, priceMinorUnits int64, currency string) error
 }
 
 func newProductCatalogCmd(pc productCatalog) *cobra.Command {
@@ -26,7 +26,7 @@ func newProductCatalogCmd(pc productCatalog) *cobra.Command {
 }
 
 func newProductCatalogAddCmd(pc productCatalog) *cobra.Command {
-	price := 0.0
+	var price int64
 	var id, name, shortDesc, currency string
 
 	cmd := &cobra.Command{
@@ -48,7 +48,7 @@ func newProductCatalogAddCmd(pc productCatalog) *cobra.Command {
 		log.Print(err)
 	}
 
-	cmd.Flags().Float64VarP(&price, "price", "", 0, "product price")
+	cmd.Flags().Int64VarP(&price, "price", "", 0, "product price in minor units (e.g. cents)")
 	if err := cmd.MarkFlagRequired("price"); err != nil {
 		log.Print(err)
 	}

--- a/backend/cmd/cli/seeds.go
+++ b/backend/cmd/cli/seeds.go
@@ -17,7 +17,8 @@ func newSeedsCmd(pc productCatalog) *cobra.Command {
 				name := fmt.Sprintf("Product %d", i)
 				desc := fmt.Sprintf("Product %d", i)
 
-				if err := pc.Add(ctx, pID, name, desc, 100, "USD"); err != nil {
+				// 10000 minor units = $100.00
+				if err := pc.Add(ctx, pID, name, desc, 10000, "USD"); err != nil {
 					return err
 				}
 

--- a/backend/layout/tmpl/productCatalog/allProducts.gohtml
+++ b/backend/layout/tmpl/productCatalog/allProducts.gohtml
@@ -4,7 +4,7 @@
 	    <div class="col-lg-4 col-md-12">
 			<h2>{{.Name}}</h2>
 			<p>{{.Description}}</p>
-			<p>Price: {{.Price.Amount}} {{.Price.Currency}}</p>
+			<p>Price: {{.Price.Display}} {{.Price.Currency}}</p>
 			<p><a class="btn btn-primary" href="/product//{{.ID}}" role="button">View details &raquo;</a></p>
 	    </div>
 	{{end}}

--- a/backend/productcatalog/adapter_postgres.go
+++ b/backend/productcatalog/adapter_postgres.go
@@ -43,7 +43,7 @@ func (db postgres) All(ctx context.Context) ([]Product, error) {
 
 	for rows.Next() {
 		var id, name, description, thumbnail string
-		var amount int
+		var amount int64
 		var currency string
 
 		err = rows.Scan(&id, &name, &description, &thumbnail, &amount, &currency)
@@ -56,7 +56,17 @@ func (db postgres) All(ctx context.Context) ([]Product, error) {
 			return nil, fmt.Errorf("cannot rebuild the product ID: %w", err)
 		}
 
-		prod, err := NewProduct(pid, name, description, NewPrice(float64(amount), currency), thumbnail)
+		cur, err := NewCurrency(currency)
+		if err != nil {
+			return nil, fmt.Errorf("cannot rebuild the product currency: %w", err)
+		}
+
+		priceVO, err := NewPrice(amount, cur)
+		if err != nil {
+			return nil, fmt.Errorf("cannot rebuild the product price: %w", err)
+		}
+
+		prod, err := NewProduct(pid, name, description, priceVO, thumbnail)
 		if err != nil {
 			return nil, fmt.Errorf("cannot create product from data in the DB: %w", err)
 		}
@@ -75,7 +85,7 @@ func (db postgres) Find(ctx context.Context, id string) (Product, error) {
 
 	row := db.db.QueryRowContext(ctx, q, id)
 	var name, description, thumbnail string
-	var amount int
+	var amount int64
 	var currency string
 
 	err := row.Scan(&name, &description, &thumbnail, &amount, &currency)
@@ -92,5 +102,15 @@ func (db postgres) Find(ctx context.Context, id string) (Product, error) {
 		return Product{}, fmt.Errorf("cannot build product: %w", err)
 	}
 
-	return NewProduct(pId, name, description, NewPrice(float64(amount), currency), thumbnail)
+	cur, err := NewCurrency(currency)
+	if err != nil {
+		return Product{}, fmt.Errorf("cannot rebuild product currency: %w", err)
+	}
+
+	priceVO, err := NewPrice(amount, cur)
+	if err != nil {
+		return Product{}, fmt.Errorf("cannot rebuild product price: %w", err)
+	}
+
+	return NewProduct(pId, name, description, priceVO, thumbnail)
 }

--- a/backend/productcatalog/app_product.go
+++ b/backend/productcatalog/app_product.go
@@ -3,7 +3,6 @@ package productcatalog
 import (
 	"context"
 	"fmt"
-	"math"
 )
 
 type ProductService struct {
@@ -28,7 +27,7 @@ func (ps ProductService) Find(ctx context.Context, id string) (Product, error) {
 	return ps.storage.Find(ctx, id)
 }
 
-func (ps ProductService) Add(ctx context.Context, id, name, desc string, price float64, currency string) error {
+func (ps ProductService) Add(ctx context.Context, id, name, desc string, priceMinorUnits int64, currency string) error {
 	pId, err := NewProductId(id)
 	if err != nil {
 		return err
@@ -39,7 +38,7 @@ func (ps ProductService) Add(ctx context.Context, id, name, desc string, price f
 		return fmt.Errorf("invalid currency: %w", err)
 	}
 
-	priceVO, err := NewPrice(int64(math.Round(price*100)), cur)
+	priceVO, err := NewPrice(priceMinorUnits, cur)
 	if err != nil {
 		return fmt.Errorf("invalid price: %w", err)
 	}

--- a/backend/productcatalog/app_product.go
+++ b/backend/productcatalog/app_product.go
@@ -2,6 +2,8 @@ package productcatalog
 
 import (
 	"context"
+	"fmt"
+	"math"
 )
 
 type ProductService struct {
@@ -32,7 +34,17 @@ func (ps ProductService) Add(ctx context.Context, id, name, desc string, price f
 		return err
 	}
 
-	p, err := NewProduct(pId, name, desc, NewPrice(price, currency), "")
+	cur, err := NewCurrency(currency)
+	if err != nil {
+		return fmt.Errorf("invalid currency: %w", err)
+	}
+
+	priceVO, err := NewPrice(int64(math.Round(price*100)), cur)
+	if err != nil {
+		return fmt.Errorf("invalid price: %w", err)
+	}
+
+	p, err := NewProduct(pId, name, desc, priceVO, "")
 	if err != nil {
 		return err
 	}

--- a/backend/productcatalog/domain_product.go
+++ b/backend/productcatalog/domain_product.go
@@ -2,29 +2,74 @@ package productcatalog
 
 import (
 	"errors"
+	"fmt"
 	"regexp"
 )
 
 var ErrProductNotFound = errors.New("product not found")
 
-type Price struct {
-	amount   float64
-	currency string
-}
+// Currency is an ISO 4217 three-letter currency code.
+type Currency string
 
-func NewPrice(amount float64, currency string) Price {
-	return Price{
-		amount:   amount,
-		currency: currency,
+var currencyReg = regexp.MustCompile(`^[A-Z]{3}$`)
+
+func NewCurrency(code string) (Currency, error) {
+	if !currencyReg.MatchString(code) {
+		return "", fmt.Errorf("invalid currency code %q: must be three uppercase letters (ISO 4217)", code)
 	}
+	return Currency(code), nil
 }
 
-func (p Price) Amount() float64 {
+func MustNewCurrency(code string) Currency {
+	c, err := NewCurrency(code)
+	if err != nil {
+		panic(err)
+	}
+	return c
+}
+
+func (c Currency) String() string { return string(c) }
+
+// Price holds an amount in minor currency units (e.g. cents for USD) and a currency.
+type Price struct {
+	amount   int64
+	currency Currency
+}
+
+func NewPrice(amount int64, currency Currency) (Price, error) {
+	if amount < 0 {
+		return Price{}, fmt.Errorf("price amount cannot be negative: %d", amount)
+	}
+	if currency == "" {
+		return Price{}, errors.New("price currency cannot be empty")
+	}
+	return Price{amount: amount, currency: currency}, nil
+}
+
+func MustNewPrice(amount int64, currency Currency) Price {
+	p, err := NewPrice(amount, currency)
+	if err != nil {
+		panic(err)
+	}
+	return p
+}
+
+// Amount returns the price amount in minor units (e.g. cents).
+func (p Price) Amount() int64 {
 	return p.amount
 }
 
-func (p Price) Currency() string {
+func (p Price) Currency() Currency {
 	return p.currency
+}
+
+func (p Price) Equals(other Price) bool {
+	return p.amount == other.amount && p.currency == other.currency
+}
+
+// Display formats the amount as a decimal string in major units (e.g. "2.34").
+func (p Price) Display() string {
+	return fmt.Sprintf("%d.%02d", p.amount/100, p.amount%100)
 }
 
 // Product is an entity that represents a single product visable in the product catalog

--- a/backend/productcatalog/productcatalog_test.go
+++ b/backend/productcatalog/productcatalog_test.go
@@ -60,7 +60,7 @@ func productEquals(p1, p2 productcatalog.Product) error {
 	if p1.Thumbnail() != p2.Thumbnail() {
 		return errors.New("thumbnail misatch")
 	}
-	if p1.Price() != p2.Price() {
+	if !p1.Price().Equals(p2.Price()) {
 		return errors.New("price misatch")
 	}
 
@@ -69,7 +69,7 @@ func productEquals(p1, p2 productcatalog.Product) error {
 
 func buildProduct(ctx context.Context, storage productcatalog.ProductStorage) (productcatalog.Product, error) {
 	pb := productcatalog.NewProductBuilder()
-	price := productcatalog.NewPrice(234, "USD")
+	price := productcatalog.MustNewPrice(234, productcatalog.MustNewCurrency("USD"))
 	pb = pb.WithName("Test product").
 		WithID(randomID()).
 		WithDescription("description of the test product").


### PR DESCRIPTION
Addresses points 1, 2, 3, and 5 of the Price DDD critique:

| # | Issue | Fix |
|---|---|---|
| 1 | `float64` for money | `int64` minor units (cents). Matches existing DB schema (`price_amount int`, `price int`). |
| 2 | No smart constructor | `NewPrice(int64, Currency) (Price, error)` validates non-negative amount + non-empty currency. `MustNewPrice` for tests/seeds. |
| 3 | `currency string` primitive obsession | `Currency` value object with `NewCurrency` enforcing ISO 4217 shape (`^[A-Z]{3}$`). |
| 5 | No explicit `Equals` | `(Price) Equals(Price) bool` documenting attribute equality. `productcatalog_test` now uses it. |

Both bounded contexts (`productcatalog` and `cart/domain`) get the same treatment — separate types per context, as per the existing structure. The anti-corruption layer in `cart/bounded_context.go` translates `productcatalog.Currency` → `cart/domain.Currency` via the underlying string.

## Bonus: latent bug fixed

`productcatalog`'s Postgres adapter was writing `float64` directly into an `int` column (silent truncation — a seeded $1.99 product would land as `1` in the DB). The `cart` adapter compensated with a `*100 / 100` dance. With int64 cents everywhere, both adapters write/read the same unit and the dance goes away.

This does mean **seed values now mean what they say**: `seeds.go` does `pc.Add(..., 100, "USD")` which now produces a $100 product instead of $1 (because the previous code truncated `100.0` to `100` cents).

## Out of scope (deliberately, per the original ask)

- **#4 — anemic / no domain behavior** — `Add`/`Multiple` on `cart/domain.price` still silently allow USD+EUR. Would need a `Currency` mismatch error or explicit FX. Left as a follow-up.
- **Shared kernel vs. separate** — kept the two Currency/Price types separate (one per bounded context). Easy to extract to `internal/money` later if you want.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` — unit tests pass locally
- [x] `golangci-lint run ./...` — 0 issues
- [ ] CI integration tests against real Postgres
- [ ] Manual smoke: render `/` and confirm prices display as decimals (e.g. "2.34 USD")