### PR TITLE
feat(account): customer account area + saved addresses (#30, #59)

### DIFF
--- a/backend/auth/adapter/auth_storage_inmemory.go
+++ b/backend/auth/adapter/auth_storage_inmemory.go
@@ -31,6 +31,16 @@ func (i *inMemory) Create(ctx context.Context, email, hash string) error {
 	return nil
 }
 
+func (i *inMemory) UpdatePassword(ctx context.Context, email, hash string) error {
+	c, ok := i.customers[email]
+	if !ok {
+		return domain.ErrCustomerNotFound
+	}
+	c.PasswordHash = hash
+	i.customers[email] = c
+	return nil
+}
+
 func (i *inMemory) Find(ctx context.Context, email string) (Customer, error) {
 	customer, ok := i.customers[email]
 	if !ok {

--- a/backend/auth/adapter/auth_storage_postgres.go
+++ b/backend/auth/adapter/auth_storage_postgres.go
@@ -23,6 +23,11 @@ func (p authStoragePostgres) Create(ctx context.Context, email, passwordHash str
 	return err
 }
 
+func (p authStoragePostgres) UpdatePassword(ctx context.Context, email, passwordHash string) error {
+	_, err := p.db.ExecContext(ctx, "UPDATE auth_customer SET password_hash = $2 WHERE username = $1", email, passwordHash)
+	return err
+}
+
 func (p authStoragePostgres) Find(ctx context.Context, email string) (Customer, error) {
 	c := Customer{}
 

--- a/backend/auth/app/auth.go
+++ b/backend/auth/app/auth.go
@@ -12,7 +12,8 @@ import (
 )
 
 var (
-	ErrInvalidEmail = fmt.Errorf("invalid email")
+	ErrInvalidEmail  = fmt.Errorf("invalid email")
+	ErrWrongPassword = fmt.Errorf("current password is incorrect")
 )
 
 var emailRegexp = regexp.MustCompile("^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$")
@@ -20,6 +21,7 @@ var emailRegexp = regexp.MustCompile("^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0
 type CustomerStorage interface {
 	Create(ctx context.Context, email, passwordHash string) error
 	Find(ctx context.Context, email string) (adapter.Customer, error)
+	UpdatePassword(ctx context.Context, email, passwordHash string) error
 }
 
 type SessStorage interface {
@@ -129,6 +131,32 @@ func (a auth) Login(ctx context.Context, email, password string) (*domain.Sessio
 	}
 
 	return sess, nil
+}
+
+// ChangePassword verifies the customer's current password, enforces the
+// password policy on the new one, and stores the new hash.
+func (a auth) ChangePassword(ctx context.Context, email, oldPassword, newPassword string) error {
+	customer, err := a.authStorage.Find(ctx, email)
+	if err != nil {
+		return fmt.Errorf("could not find customer: %w", err)
+	}
+
+	if err := bcrypt.CompareHashAndPassword([]byte(customer.PasswordHash), []byte(oldPassword)); err != nil {
+		return ErrWrongPassword
+	}
+
+	for _, policy := range a.passPolicies {
+		if err := policy(newPassword); err != nil {
+			return fmt.Errorf("cannot change password: %w", err)
+		}
+	}
+
+	newHash, err := hashPassword(newPassword)
+	if err != nil {
+		return fmt.Errorf("could not hash password: %w", err)
+	}
+
+	return a.authStorage.UpdatePassword(ctx, email, newHash)
 }
 
 func hashPassword(password string) (string, error) {

--- a/backend/auth/bounded_context.go
+++ b/backend/auth/bounded_context.go
@@ -17,7 +17,8 @@ type appService interface {
 	CreateNewCustomer(ctx context.Context, email, password string) error
 	Login(ctx context.Context, username string, password string) (*domain.Session, error)
 	Logout(ctx context.Context, sesionID string) error
-  FindByToken(ctx context.Context, sessToken string) (*domain.Session, error)
+	FindByToken(ctx context.Context, sessToken string) (*domain.Session, error)
+	ChangePassword(ctx context.Context, email, oldPassword, newPassword string) error
 }
 
 func New(db *sql.DB) (application.BoundedContext, appService) {

--- a/backend/cmd/web/main.go
+++ b/backend/cmd/web/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/bkielbasa/go-ecommerce/backend/auth"
 	"github.com/bkielbasa/go-ecommerce/backend/cart"
 	"github.com/bkielbasa/go-ecommerce/backend/checkout"
+	"github.com/bkielbasa/go-ecommerce/backend/shippinginfo"
 	"github.com/bkielbasa/go-ecommerce/backend/internal"
 	"github.com/bkielbasa/go-ecommerce/backend/internal/application"
 	"github.com/bkielbasa/go-ecommerce/backend/internal/dependency"
@@ -79,9 +80,10 @@ func main() {
 	cartBD, cartSrv := cart.New(db, logger, catalogService)
 	authBD, authService := auth.New(db)
 	checkoutBD, checkoutSrv := checkout.New(db, cartSrv, cartSrv)
+	shipSrv := shippinginfo.New(db)
 	app.AddBoundedContext(cartBD)
 
-	app.AddBoundedContext(layout.New(logger, cartSrv, catalogService, authService, checkoutSrv))
+	app.AddBoundedContext(layout.New(logger, cartSrv, catalogService, authService, checkoutSrv, shipSrv))
 	app.AddBoundedContext(pcBD)
 	app.AddBoundedContext(authBD)
 	app.AddBoundedContext(checkoutBD)

--- a/backend/layout/bounded_context.go
+++ b/backend/layout/bounded_context.go
@@ -9,6 +9,7 @@ import (
 	checkoutDomain "github.com/bkielbasa/go-ecommerce/backend/checkout/domain"
 	"github.com/bkielbasa/go-ecommerce/backend/internal/application"
 	"github.com/bkielbasa/go-ecommerce/backend/productcatalog"
+	shipDomain "github.com/bkielbasa/go-ecommerce/backend/shippinginfo/domain"
 	"github.com/sirupsen/logrus"
 )
 
@@ -27,6 +28,17 @@ type authService interface {
 	Logout(ctx context.Context, seesionID string) error
 	CreateNewCustomer(ctx context.Context, email, password string) error
 	FindByToken(ctx context.Context, sessToken string) (*authDomain.Session, error)
+	ChangePassword(ctx context.Context, email, oldPassword, newPassword string) error
+}
+
+type shippingService interface {
+	List(ctx context.Context, customerID string) ([]shipDomain.Address, error)
+	Get(ctx context.Context, customerID, id string) (shipDomain.Address, error)
+	Add(ctx context.Context, customerID, name, street1, street2, city, zip, country string) error
+	Edit(ctx context.Context, customerID, id, name, street1, street2, city, zip, country string) error
+	Remove(ctx context.Context, customerID, id string) error
+	SetDefault(ctx context.Context, customerID, id string) error
+	Default(ctx context.Context, customerID string) (shipDomain.Address, bool, error)
 }
 
 type checkoutService interface {
@@ -35,13 +47,14 @@ type checkoutService interface {
 	ListByCustomer(ctx context.Context, customerID string) ([]checkoutDomain.Order, error)
 }
 
-func New(logger logrus.FieldLogger, cartSrv cartService, catalogSrv catalogService, authSrv authService, checkoutSrv checkoutService) application.BoundedContext {
+func New(logger logrus.FieldLogger, cartSrv cartService, catalogSrv catalogService, authSrv authService, checkoutSrv checkoutService, shipSrv shippingService) application.BoundedContext {
 	return &boundedContext{
 		handler: httpHandler{
 			cartSrv:     cartSrv,
 			catalogSrv:  catalogSrv,
 			authSrv:     authSrv,
 			checkoutSrv: checkoutSrv,
+			shipSrv:     shipSrv,
 		},
 		logger: logger,
 	}

--- a/backend/layout/http.go
+++ b/backend/layout/http.go
@@ -6,6 +6,7 @@ import (
 	"html/template"
 	"log"
 	"net/http"
+	"path/filepath"
 
 	"github.com/bkielbasa/go-ecommerce/backend/internal/observability"
 	"github.com/gorilla/mux"
@@ -39,6 +40,7 @@ type httpHandler struct {
 	catalogSrv  catalogService
 	authSrv     authService
 	checkoutSrv checkoutService
+	shipSrv     shippingService
 }
 
 func (handler httpHandler) HomePage(w http.ResponseWriter, r *http.Request) {
@@ -67,6 +69,17 @@ func (m boundedContext) MuxRegister(r *mux.Router) {
 	r.HandleFunc("/checkout", observability.HTTPWrap(m.handler.PlaceOrder, m.logger)).Methods("POST")
 	r.HandleFunc("/orders", observability.HTTPWrap(m.handler.Orders, m.logger)).Methods("GET")
 	r.HandleFunc("/order/{orderID}", observability.HTTPWrap(m.handler.Order, m.logger)).Methods("GET")
+
+	r.HandleFunc("/account", observability.HTTPWrap(m.handler.AccountOverview, m.logger)).Methods("GET")
+	r.HandleFunc("/account/orders", observability.HTTPWrap(m.handler.AccountOrders, m.logger)).Methods("GET")
+	r.HandleFunc("/account/addresses", observability.HTTPWrap(m.handler.AccountAddresses, m.logger)).Methods("GET")
+	r.HandleFunc("/account/addresses", observability.HTTPWrap(m.handler.AccountAddAddress, m.logger)).Methods("POST")
+	r.HandleFunc("/account/addresses/{id}/edit", observability.HTTPWrap(m.handler.AccountEditAddressForm, m.logger)).Methods("GET")
+	r.HandleFunc("/account/addresses/{id}", observability.HTTPWrap(m.handler.AccountUpdateAddress, m.logger)).Methods("POST")
+	r.HandleFunc("/account/addresses/{id}/delete", observability.HTTPWrap(m.handler.AccountDeleteAddress, m.logger)).Methods("POST")
+	r.HandleFunc("/account/addresses/{id}/default", observability.HTTPWrap(m.handler.AccountSetDefaultAddress, m.logger)).Methods("POST")
+	r.HandleFunc("/account/details", observability.HTTPWrap(m.handler.AccountDetails, m.logger)).Methods("GET")
+	r.HandleFunc("/account/details/password", observability.HTTPWrap(m.handler.AccountChangePassword, m.logger)).Methods("POST")
 }
 
 func (handler httpHandler) renderTemplate(w http.ResponseWriter, r *http.Request, templateName string, data map[string]any) {
@@ -78,6 +91,9 @@ func (handler httpHandler) renderTemplate(w http.ResponseWriter, r *http.Request
 		"./layout/tmpl/layout.gohtml",
 		"./layout/tmpl/" + templateName + ".gohtml",
 	}
+	// Shared partials (e.g. the account sidebar) are available to every page.
+	partials, _ := filepath.Glob("./layout/tmpl/partials/*.gohtml")
+	files = append(files, partials...)
 
 	var ts = template.Must(template.New("").Funcs(template.FuncMap{
 		"html": func(value interface{}) template.HTML {

--- a/backend/layout/http_account.go
+++ b/backend/layout/http_account.go
@@ -1,0 +1,189 @@
+package layout
+
+import (
+	"net/http"
+
+	checkoutDomain "github.com/bkielbasa/go-ecommerce/backend/checkout/domain"
+	"github.com/bkielbasa/go-ecommerce/backend/internal/https"
+	"github.com/gorilla/mux"
+)
+
+// requireLogin resolves the current customer or redirects to the login page.
+func (handler httpHandler) requireLogin(w http.ResponseWriter, r *http.Request) (string, bool) {
+	cid := handler.currentCustomerID(r)
+	if cid == "" {
+		http.Redirect(w, r, "/auth/login", http.StatusSeeOther)
+		return "", false
+	}
+	return cid, true
+}
+
+func (handler httpHandler) flash(w http.ResponseWriter, r *http.Request, msg, kind string) {
+	session, _ := store.Get(r, "ecommerce")
+	if kind == "error" {
+		session.AddFlash(msg, "error")
+	} else {
+		session.AddFlash(msg)
+	}
+	_ = session.Save(r, w)
+}
+
+func (handler httpHandler) AccountOverview(w http.ResponseWriter, r *http.Request) {
+	cid, ok := handler.requireLogin(w, r)
+	if !ok {
+		return
+	}
+
+	var latest checkoutDomain.Order
+	if orders, err := handler.checkoutSrv.ListByCustomer(r.Context(), cid); err == nil && len(orders) > 0 {
+		latest = orders[0]
+	}
+	def, _, _ := handler.shipSrv.Default(r.Context(), cid)
+
+	handler.renderTemplate(w, r, "account/overview", map[string]any{
+		"Active":         "overview",
+		"Email":          cid,
+		"LatestOrder":    latest,
+		"DefaultAddress": def,
+	})
+}
+
+func (handler httpHandler) AccountOrders(w http.ResponseWriter, r *http.Request) {
+	cid, ok := handler.requireLogin(w, r)
+	if !ok {
+		return
+	}
+	orders, err := handler.checkoutSrv.ListByCustomer(r.Context(), cid)
+	if err != nil {
+		https.InternalError(w, "internal-error", err.Error())
+		return
+	}
+	handler.renderTemplate(w, r, "account/orders", map[string]any{
+		"Active": "orders",
+		"Email":  cid,
+		"Orders": orders,
+	})
+}
+
+func (handler httpHandler) AccountAddresses(w http.ResponseWriter, r *http.Request) {
+	cid, ok := handler.requireLogin(w, r)
+	if !ok {
+		return
+	}
+	addrs, err := handler.shipSrv.List(r.Context(), cid)
+	if err != nil {
+		https.InternalError(w, "internal-error", err.Error())
+		return
+	}
+	handler.renderTemplate(w, r, "account/addresses", map[string]any{
+		"Active":    "addresses",
+		"Email":     cid,
+		"Addresses": addrs,
+	})
+}
+
+func (handler httpHandler) AccountAddAddress(w http.ResponseWriter, r *http.Request) {
+	cid, ok := handler.requireLogin(w, r)
+	if !ok {
+		return
+	}
+	_ = r.ParseForm()
+	err := handler.shipSrv.Add(r.Context(), cid,
+		r.FormValue("name"), r.FormValue("street1"), r.FormValue("street2"),
+		r.FormValue("city"), r.FormValue("zip"), r.FormValue("country"))
+	if err != nil {
+		handler.flash(w, r, err.Error(), "error")
+	} else {
+		handler.flash(w, r, "Address saved", "info")
+	}
+	http.Redirect(w, r, "/account/addresses", http.StatusSeeOther)
+}
+
+func (handler httpHandler) AccountEditAddressForm(w http.ResponseWriter, r *http.Request) {
+	cid, ok := handler.requireLogin(w, r)
+	if !ok {
+		return
+	}
+	id := mux.Vars(r)["id"]
+	addr, err := handler.shipSrv.Get(r.Context(), cid, id)
+	if err != nil {
+		http.Redirect(w, r, "/account/addresses", http.StatusSeeOther)
+		return
+	}
+	handler.renderTemplate(w, r, "account/address_edit", map[string]any{
+		"Active":  "addresses",
+		"Email":   cid,
+		"Address": addr,
+	})
+}
+
+func (handler httpHandler) AccountUpdateAddress(w http.ResponseWriter, r *http.Request) {
+	cid, ok := handler.requireLogin(w, r)
+	if !ok {
+		return
+	}
+	id := mux.Vars(r)["id"]
+	_ = r.ParseForm()
+	err := handler.shipSrv.Edit(r.Context(), cid, id,
+		r.FormValue("name"), r.FormValue("street1"), r.FormValue("street2"),
+		r.FormValue("city"), r.FormValue("zip"), r.FormValue("country"))
+	if err != nil {
+		handler.flash(w, r, err.Error(), "error")
+		http.Redirect(w, r, "/account/addresses/"+id+"/edit", http.StatusSeeOther)
+		return
+	}
+	handler.flash(w, r, "Address updated", "info")
+	http.Redirect(w, r, "/account/addresses", http.StatusSeeOther)
+}
+
+func (handler httpHandler) AccountDeleteAddress(w http.ResponseWriter, r *http.Request) {
+	cid, ok := handler.requireLogin(w, r)
+	if !ok {
+		return
+	}
+	id := mux.Vars(r)["id"]
+	if err := handler.shipSrv.Remove(r.Context(), cid, id); err != nil {
+		handler.flash(w, r, err.Error(), "error")
+	} else {
+		handler.flash(w, r, "Address removed", "info")
+	}
+	http.Redirect(w, r, "/account/addresses", http.StatusSeeOther)
+}
+
+func (handler httpHandler) AccountSetDefaultAddress(w http.ResponseWriter, r *http.Request) {
+	cid, ok := handler.requireLogin(w, r)
+	if !ok {
+		return
+	}
+	id := mux.Vars(r)["id"]
+	if err := handler.shipSrv.SetDefault(r.Context(), cid, id); err != nil {
+		handler.flash(w, r, err.Error(), "error")
+	}
+	http.Redirect(w, r, "/account/addresses", http.StatusSeeOther)
+}
+
+func (handler httpHandler) AccountDetails(w http.ResponseWriter, r *http.Request) {
+	cid, ok := handler.requireLogin(w, r)
+	if !ok {
+		return
+	}
+	handler.renderTemplate(w, r, "account/details", map[string]any{
+		"Active": "details",
+		"Email":  cid,
+	})
+}
+
+func (handler httpHandler) AccountChangePassword(w http.ResponseWriter, r *http.Request) {
+	cid, ok := handler.requireLogin(w, r)
+	if !ok {
+		return
+	}
+	_ = r.ParseForm()
+	err := handler.authSrv.ChangePassword(r.Context(), cid, r.FormValue("current_password"), r.FormValue("new_password"))
+	if err != nil {
+		handler.flash(w, r, err.Error(), "error")
+	} else {
+		handler.flash(w, r, "Password updated", "info")
+	}
+	http.Redirect(w, r, "/account/details", http.StatusSeeOther)
+}

--- a/backend/layout/static/main.css
+++ b/backend/layout/static/main.css
@@ -416,6 +416,59 @@ main {
   line-height: 1.7;
 }
 
+/* ---------- account area ---------- */
+.account {
+  display: grid;
+  grid-template-columns: 12rem 1fr;
+  gap: var(--space-5);
+  align-items: start;
+}
+@media (max-width: 48rem) {
+  .account { grid-template-columns: 1fr; gap: var(--space-3); }
+}
+.account-nav {
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+}
+.account-nav__link {
+  border: 0;
+  padding: var(--space-1) 0;
+  color: var(--fg-muted);
+  text-transform: lowercase;
+  letter-spacing: .02em;
+  transition: color .15s ease;
+}
+.account-nav__link:hover { color: var(--fg); border: 0; }
+.account-nav__link.is-active { color: var(--fg); border-left: 2px solid var(--fg); padding-left: var(--space-2); margin-left: calc(-1 * var(--space-2) - 2px); }
+.account-nav__link--muted { color: var(--fg-muted); }
+.account-nav__rule { display: block; border-top: 1px solid var(--rule); margin: var(--space-2) 0; }
+
+.account__hello { font-size: var(--step-1); margin-bottom: var(--space-4); }
+.account__cards { display: grid; grid-template-columns: repeat(auto-fit, minmax(14rem, 1fr)); gap: var(--space-3); }
+.account-card { border-top: 1px solid var(--rule); padding-top: var(--space-2); display: flex; flex-direction: column; gap: var(--space-1); }
+.account-card__title {
+  font-family: var(--serif);
+  font-size: var(--step-1);
+  text-transform: lowercase;
+  letter-spacing: -.01em;
+  margin-bottom: var(--space-2);
+}
+
+/* address book */
+.addr-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(15rem, 1fr)); gap: var(--space-3); margin-bottom: var(--space-4); }
+.addr-card { position: relative; border: 1px solid var(--rule); padding: var(--space-3); display: flex; flex-direction: column; gap: var(--space-2); }
+.addr-card--default { border-color: var(--fg); }
+.addr-card__badge { position: absolute; top: var(--space-2); right: var(--space-2); font-size: 0.7rem; text-transform: uppercase; letter-spacing: .08em; color: var(--fg-muted); }
+.addr-card__actions { display: flex; gap: var(--space-3); margin-top: auto; font-size: 0.85rem; align-items: center; }
+.addr-card__actions a { border: 0; }
+.addr-card__actions a:hover { border-bottom: 1px solid var(--fg); }
+.addr-add { margin-top: var(--space-4); border-top: 1px solid var(--rule); padding-top: var(--space-3); }
+
+.linkbtn { background: 0; border: 0; padding: 0; cursor: pointer; font-size: 0.85rem; color: var(--fg-muted); text-transform: lowercase; }
+.linkbtn:hover { color: var(--fg); }
+.linkbtn--danger:hover { color: var(--danger); }
+
 /* ---------- forms ---------- */
 .form {
   max-width: 28rem;

--- a/backend/layout/tmpl/account/address_edit.gohtml
+++ b/backend/layout/tmpl/account/address_edit.gohtml
@@ -1,0 +1,21 @@
+{{define "main"}}
+  <h1 class="page-title">account</h1>
+  <div class="account">
+    <aside class="account__side">{{template "account-nav" .}}</aside>
+    <div class="account__content">
+      <p class="crumbs"><a href="/account/addresses">addresses</a> / edit</p>
+      <h2 class="account-card__title">edit address</h2>
+
+      <form class="form" method="post" action="/account/addresses/{{.Address.ID}}">
+        <div class="field"><label for="a-name">full name</label><input id="a-name" name="name" value="{{.Address.Name}}" required></div>
+        <div class="field"><label for="a-street1">street</label><input id="a-street1" name="street1" value="{{.Address.Street1}}" required></div>
+        <div class="field"><label for="a-street2">street (line 2)</label><input id="a-street2" name="street2" value="{{.Address.Street2}}"></div>
+        <div class="field"><label for="a-city">city</label><input id="a-city" name="city" value="{{.Address.City}}" required></div>
+        <div class="field"><label for="a-zip">zip code</label><input id="a-zip" name="zip" value="{{.Address.Zip}}" required></div>
+        <div class="field"><label for="a-country">country</label><input id="a-country" name="country" value="{{.Address.Country}}" required></div>
+        <button type="submit" class="btn">save changes</button>
+        <p class="form__aside"><a href="/account/addresses">&larr; back to addresses</a></p>
+      </form>
+    </div>
+  </div>
+{{end}}

--- a/backend/layout/tmpl/account/addresses.gohtml
+++ b/backend/layout/tmpl/account/addresses.gohtml
@@ -1,0 +1,48 @@
+{{define "main"}}
+  <h1 class="page-title">account</h1>
+  <div class="account">
+    <aside class="account__side">{{template "account-nav" .}}</aside>
+    <div class="account__content">
+      <h2 class="account-card__title">addresses</h2>
+
+      {{if .Addresses}}
+        <div class="addr-grid">
+          {{range $a := .Addresses}}
+            <article class="addr-card {{if $a.IsDefault}}addr-card--default{{end}}">
+              {{if $a.IsDefault}}<span class="addr-card__badge">default</span>{{end}}
+              <address class="order__address">
+                {{$a.Name}}<br>
+                {{$a.Street1}}<br>
+                {{with $a.Street2}}{{.}}<br>{{end}}
+                {{$a.City}}, {{$a.Zip}}<br>
+                {{$a.Country}}
+              </address>
+              <div class="addr-card__actions">
+                <a href="/account/addresses/{{$a.ID}}/edit">edit</a>
+                {{if not $a.IsDefault}}
+                  <form method="post" action="/account/addresses/{{$a.ID}}/default"><button type="submit" class="linkbtn">make default</button></form>
+                {{end}}
+                <form method="post" action="/account/addresses/{{$a.ID}}/delete"><button type="submit" class="linkbtn linkbtn--danger">delete</button></form>
+              </div>
+            </article>
+          {{end}}
+        </div>
+      {{else}}
+        <p class="muted">no saved addresses yet.</p>
+      {{end}}
+
+      <section class="addr-add">
+        <h3 class="account-card__title">add an address</h3>
+        <form class="form" method="post" action="/account/addresses">
+          <div class="field"><label for="a-name">full name</label><input id="a-name" name="name" required></div>
+          <div class="field"><label for="a-street1">street</label><input id="a-street1" name="street1" required></div>
+          <div class="field"><label for="a-street2">street (line 2)</label><input id="a-street2" name="street2"></div>
+          <div class="field"><label for="a-city">city</label><input id="a-city" name="city" required></div>
+          <div class="field"><label for="a-zip">zip code</label><input id="a-zip" name="zip" required></div>
+          <div class="field"><label for="a-country">country</label><input id="a-country" name="country" required></div>
+          <button type="submit" class="btn">save address</button>
+        </form>
+      </section>
+    </div>
+  </div>
+{{end}}

--- a/backend/layout/tmpl/account/details.gohtml
+++ b/backend/layout/tmpl/account/details.gohtml
@@ -1,0 +1,29 @@
+{{define "main"}}
+  <h1 class="page-title">account</h1>
+  <div class="account">
+    <aside class="account__side">{{template "account-nav" .}}</aside>
+    <div class="account__content">
+      <h2 class="account-card__title">account details</h2>
+
+      <div class="field">
+        <label>email</label>
+        <p>{{.Email}}</p>
+      </div>
+
+      <section class="addr-add">
+        <h3 class="account-card__title">change password</h3>
+        <form class="form" method="post" action="/account/details/password">
+          <div class="field">
+            <label for="cur">current password</label>
+            <input id="cur" type="password" name="current_password" autocomplete="current-password" required>
+          </div>
+          <div class="field">
+            <label for="new">new password</label>
+            <input id="new" type="password" name="new_password" autocomplete="new-password" required>
+          </div>
+          <button type="submit" class="btn">update password</button>
+        </form>
+      </section>
+    </div>
+  </div>
+{{end}}

--- a/backend/layout/tmpl/account/orders.gohtml
+++ b/backend/layout/tmpl/account/orders.gohtml
@@ -1,0 +1,36 @@
+{{define "main"}}
+  <h1 class="page-title">account</h1>
+  <div class="account">
+    <aside class="account__side">{{template "account-nav" .}}</aside>
+    <div class="account__content">
+      <h2 class="account-card__title">orders</h2>
+      {{if .Orders}}
+        <table class="cart-table orders-list">
+          <thead>
+            <tr>
+              <th>order</th>
+              <th>placed</th>
+              <th>status</th>
+              <th class="col-total">total</th>
+            </tr>
+          </thead>
+          <tbody>
+            {{range $order := .Orders}}
+              <tr>
+                <td>
+                  <a href="/order/{{$order.ID}}" class="order-row__id">{{$order.ID}}</a>
+                  <span class="muted order-row__count"> &middot; {{len $order.Items}} item{{if ne (len $order.Items) 1}}s{{end}}</span>
+                </td>
+                <td class="muted">{{$order.PlacedAt.Format "Jan 2, 2006"}}</td>
+                <td><span class="order-status order-status--{{$order.Status}}">{{$order.Status}}</span></td>
+                <td class="col-total">{{$order.TotalDisplay}} {{$order.TotalCurrency}}</td>
+              </tr>
+            {{end}}
+          </tbody>
+        </table>
+      {{else}}
+        <p class="cart-empty">no orders yet. <a href="/">browse products</a></p>
+      {{end}}
+    </div>
+  </div>
+{{end}}

--- a/backend/layout/tmpl/account/overview.gohtml
+++ b/backend/layout/tmpl/account/overview.gohtml
@@ -1,0 +1,38 @@
+{{define "main"}}
+  <h1 class="page-title">account</h1>
+  <div class="account">
+    <aside class="account__side">{{template "account-nav" .}}</aside>
+    <div class="account__content">
+      <p class="account__hello">Hello, <strong>{{.Email}}</strong>.</p>
+
+      <div class="account__cards">
+        <section class="account-card">
+          <h2 class="account-card__title">latest order</h2>
+          {{if .LatestOrder.ID}}
+            <p><a href="/order/{{.LatestOrder.ID}}" class="order-row__id">{{.LatestOrder.ID}}</a></p>
+            <p class="muted">{{.LatestOrder.PlacedAt.Format "Jan 2, 2006"}} &middot; {{.LatestOrder.TotalDisplay}} {{.LatestOrder.TotalCurrency}} &middot; {{.LatestOrder.Status}}</p>
+            <p><a href="/account/orders">all orders &rarr;</a></p>
+          {{else}}
+            <p class="muted">no orders yet. <a href="/">browse products</a></p>
+          {{end}}
+        </section>
+
+        <section class="account-card">
+          <h2 class="account-card__title">default address</h2>
+          {{if not .DefaultAddress.IsZero}}
+            <address class="order__address">
+              {{.DefaultAddress.Name}}<br>
+              {{.DefaultAddress.Street1}}<br>
+              {{with .DefaultAddress.Street2}}{{.}}<br>{{end}}
+              {{.DefaultAddress.City}}, {{.DefaultAddress.Zip}}<br>
+              {{.DefaultAddress.Country}}
+            </address>
+            <p><a href="/account/addresses">manage addresses &rarr;</a></p>
+          {{else}}
+            <p class="muted">none saved. <a href="/account/addresses">add one</a></p>
+          {{end}}
+        </section>
+      </div>
+    </div>
+  </div>
+{{end}}

--- a/backend/layout/tmpl/layout.gohtml
+++ b/backend/layout/tmpl/layout.gohtml
@@ -31,7 +31,7 @@
               </a>
             </li>
             {{if .LoggedIn}}
-              <li><a href="/orders">orders</a></li>
+              <li><a href="/account">account</a></li>
             {{end}}
             {{ html .AuthMenuItem }}
           </ul>

--- a/backend/layout/tmpl/partials/account-nav.gohtml
+++ b/backend/layout/tmpl/partials/account-nav.gohtml
@@ -1,0 +1,10 @@
+{{define "account-nav"}}
+<nav class="account-nav">
+  <a href="/account" class="account-nav__link {{if eq .Active "overview"}}is-active{{end}}">overview</a>
+  <a href="/account/orders" class="account-nav__link {{if eq .Active "orders"}}is-active{{end}}">orders</a>
+  <a href="/account/addresses" class="account-nav__link {{if eq .Active "addresses"}}is-active{{end}}">addresses</a>
+  <a href="/account/details" class="account-nav__link {{if eq .Active "details"}}is-active{{end}}">account details</a>
+  <span class="account-nav__rule"></span>
+  <a href="/auth/logout" class="account-nav__link account-nav__link--muted">sign out</a>
+</nav>
+{{end}}

--- a/backend/shippinginfo/adapter/postgres.go
+++ b/backend/shippinginfo/adapter/postgres.go
@@ -1,0 +1,112 @@
+package adapter
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/bkielbasa/go-ecommerce/backend/shippinginfo/domain"
+)
+
+type Postgres struct {
+	db *sql.DB
+}
+
+func NewPostgres(db *sql.DB) Postgres {
+	return Postgres{db: db}
+}
+
+// List returns a customer's addresses, default first then oldest first.
+func (p Postgres) List(ctx context.Context, customerID string) ([]domain.Address, error) {
+	rows, err := p.db.QueryContext(ctx, `
+		SELECT id, customer_id, name, street1, street2, city, zip, country, is_default, created_at
+		FROM shippinginfo_address WHERE customer_id = $1
+		ORDER BY is_default DESC, created_at ASC
+	`, customerID)
+	if err != nil {
+		return nil, fmt.Errorf("list addresses: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []domain.Address
+	for rows.Next() {
+		a, err := scanAddress(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, a)
+	}
+	return out, rows.Err()
+}
+
+func (p Postgres) Get(ctx context.Context, customerID, id string) (domain.Address, error) {
+	row := p.db.QueryRowContext(ctx, `
+		SELECT id, customer_id, name, street1, street2, city, zip, country, is_default, created_at
+		FROM shippinginfo_address WHERE customer_id = $1 AND id = $2
+	`, customerID, id)
+	a, err := scanAddress(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return domain.Address{}, domain.ErrAddressNotFound
+	}
+	return a, err
+}
+
+func (p Postgres) Save(ctx context.Context, a domain.Address) error {
+	_, err := p.db.ExecContext(ctx, `
+		INSERT INTO shippinginfo_address
+			(id, customer_id, name, street1, street2, city, zip, country, is_default, created_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+		ON CONFLICT (id) DO UPDATE SET
+			name = EXCLUDED.name,
+			street1 = EXCLUDED.street1,
+			street2 = EXCLUDED.street2,
+			city = EXCLUDED.city,
+			zip = EXCLUDED.zip,
+			country = EXCLUDED.country,
+			is_default = EXCLUDED.is_default
+	`,
+		a.ID(), a.CustomerID(), a.Name(), a.Street1(), a.Street2(),
+		a.City(), a.Zip(), a.Country(), a.IsDefault(), a.CreatedAt(),
+	)
+	if err != nil {
+		return fmt.Errorf("save address: %w", err)
+	}
+	return nil
+}
+
+func (p Postgres) Delete(ctx context.Context, customerID, id string) error {
+	_, err := p.db.ExecContext(ctx, `DELETE FROM shippinginfo_address WHERE customer_id = $1 AND id = $2`, customerID, id)
+	return err
+}
+
+func (p Postgres) ClearDefault(ctx context.Context, customerID string) error {
+	_, err := p.db.ExecContext(ctx, `UPDATE shippinginfo_address SET is_default = false WHERE customer_id = $1`, customerID)
+	return err
+}
+
+func (p Postgres) MarkDefault(ctx context.Context, customerID, id string) error {
+	_, err := p.db.ExecContext(ctx, `UPDATE shippinginfo_address SET is_default = true WHERE customer_id = $1 AND id = $2`, customerID, id)
+	return err
+}
+
+func (p Postgres) Count(ctx context.Context, customerID string) (int, error) {
+	var n int
+	err := p.db.QueryRowContext(ctx, `SELECT count(*) FROM shippinginfo_address WHERE customer_id = $1`, customerID).Scan(&n)
+	return n, err
+}
+
+type scanner interface {
+	Scan(dest ...any) error
+}
+
+func scanAddress(s scanner) (domain.Address, error) {
+	var id, customerID, name, street1, street2, city, zip, country string
+	var isDefault bool
+	var createdAt time.Time
+	if err := s.Scan(&id, &customerID, &name, &street1, &street2, &city, &zip, &country, &isDefault, &createdAt); err != nil {
+		return domain.Address{}, err
+	}
+	return domain.Rebuild(id, customerID, name, street1, street2, city, zip, country, isDefault, createdAt), nil
+}

--- a/backend/shippinginfo/app/service.go
+++ b/backend/shippinginfo/app/service.go
@@ -1,0 +1,122 @@
+package app
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/bkielbasa/go-ecommerce/backend/shippinginfo/domain"
+)
+
+type Storage interface {
+	List(ctx context.Context, customerID string) ([]domain.Address, error)
+	Get(ctx context.Context, customerID, id string) (domain.Address, error)
+	Save(ctx context.Context, addr domain.Address) error
+	Delete(ctx context.Context, customerID, id string) error
+	ClearDefault(ctx context.Context, customerID string) error
+	MarkDefault(ctx context.Context, customerID, id string) error
+	Count(ctx context.Context, customerID string) (int, error)
+}
+
+// IDGenerator returns a fresh address id.
+type IDGenerator func() string
+
+type Service struct {
+	storage Storage
+	newID   IDGenerator
+	now     func() time.Time
+}
+
+func NewService(storage Storage, newID IDGenerator) Service {
+	return Service{storage: storage, newID: newID, now: func() time.Time { return time.Now().UTC() }}
+}
+
+// Add saves a new address. The customer's first address automatically becomes
+// the default.
+func (s Service) Add(ctx context.Context, customerID, name, street1, street2, city, zip, country string) error {
+	count, err := s.storage.Count(ctx, customerID)
+	if err != nil {
+		return fmt.Errorf("count addresses: %w", err)
+	}
+
+	addr, err := domain.NewAddress(s.newID(), customerID, name, street1, street2, city, zip, country, count == 0, s.now())
+	if err != nil {
+		return err
+	}
+	return s.storage.Save(ctx, addr)
+}
+
+// Edit updates the editable fields of an existing address, preserving its
+// default flag and creation time.
+func (s Service) Edit(ctx context.Context, customerID, id, name, street1, street2, city, zip, country string) error {
+	existing, err := s.storage.Get(ctx, customerID, id)
+	if err != nil {
+		return err
+	}
+	updated, err := domain.NewAddress(existing.ID(), customerID, name, street1, street2, city, zip, country, existing.IsDefault(), existing.CreatedAt())
+	if err != nil {
+		return err
+	}
+	return s.storage.Save(ctx, updated)
+}
+
+// Remove deletes an address. If the deleted address was the default and other
+// addresses remain, the oldest remaining one is promoted to default.
+func (s Service) Remove(ctx context.Context, customerID, id string) error {
+	target, err := s.storage.Get(ctx, customerID, id)
+	if err != nil {
+		return err
+	}
+	if err := s.storage.Delete(ctx, customerID, id); err != nil {
+		return fmt.Errorf("delete address: %w", err)
+	}
+
+	if !target.IsDefault() {
+		return nil
+	}
+
+	remaining, err := s.storage.List(ctx, customerID)
+	if err != nil {
+		return fmt.Errorf("list after delete: %w", err)
+	}
+	if len(remaining) == 0 {
+		return nil
+	}
+	// List is ordered default-first then oldest-first; after deleting the
+	// default, the first entry is the oldest remaining address.
+	return s.SetDefault(ctx, customerID, remaining[0].ID())
+}
+
+// SetDefault makes one address the customer's default, clearing the flag on
+// the others.
+func (s Service) SetDefault(ctx context.Context, customerID, id string) error {
+	if _, err := s.storage.Get(ctx, customerID, id); err != nil {
+		return err
+	}
+	if err := s.storage.ClearDefault(ctx, customerID); err != nil {
+		return fmt.Errorf("clear default: %w", err)
+	}
+	return s.storage.MarkDefault(ctx, customerID, id)
+}
+
+func (s Service) List(ctx context.Context, customerID string) ([]domain.Address, error) {
+	return s.storage.List(ctx, customerID)
+}
+
+func (s Service) Get(ctx context.Context, customerID, id string) (domain.Address, error) {
+	return s.storage.Get(ctx, customerID, id)
+}
+
+// Default returns the customer's default address, if any.
+func (s Service) Default(ctx context.Context, customerID string) (domain.Address, bool, error) {
+	addrs, err := s.storage.List(ctx, customerID)
+	if err != nil {
+		return domain.Address{}, false, err
+	}
+	for _, a := range addrs {
+		if a.IsDefault() {
+			return a, true, nil
+		}
+	}
+	return domain.Address{}, false, nil
+}

--- a/backend/shippinginfo/bounded_context.go
+++ b/backend/shippinginfo/bounded_context.go
@@ -1,0 +1,23 @@
+package shippinginfo
+
+import (
+	"crypto/rand"
+	"database/sql"
+	"encoding/hex"
+
+	"github.com/bkielbasa/go-ecommerce/backend/shippinginfo/adapter"
+	"github.com/bkielbasa/go-ecommerce/backend/shippinginfo/app"
+)
+
+// New wires the shipping-info (address book) service. It has no HTTP surface
+// of its own — the account pages in the layout context consume the service.
+func New(db *sql.DB) app.Service {
+	storage := adapter.NewPostgres(db)
+	return app.NewService(storage, newAddressID)
+}
+
+func newAddressID() string {
+	b := make([]byte, 8)
+	_, _ = rand.Read(b)
+	return "addr-" + hex.EncodeToString(b)
+}

--- a/backend/shippinginfo/domain/address.go
+++ b/backend/shippinginfo/domain/address.go
@@ -1,0 +1,77 @@
+package domain
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+var (
+	ErrAddressNotFound = errors.New("address not found")
+	ErrInvalidAddress  = errors.New("invalid address")
+)
+
+// Address is a saved shipping address in a customer's address book. Unlike
+// the checkout context's per-order Address snapshot, this is an entity with
+// identity and a mutable default flag.
+type Address struct {
+	id         string
+	customerID string
+	name       string
+	street1    string
+	street2    string
+	city       string
+	zip        string
+	country    string
+	isDefault  bool
+	createdAt  time.Time
+}
+
+// NewAddress validates and builds a new saved address. street2 is optional.
+func NewAddress(id, customerID, name, street1, street2, city, zip, country string, isDefault bool, createdAt time.Time) (Address, error) {
+	for _, f := range []struct{ label, val string }{
+		{"name", name},
+		{"street", street1},
+		{"city", city},
+		{"zip code", zip},
+		{"country", country},
+	} {
+		if strings.TrimSpace(f.val) == "" {
+			return Address{}, fmt.Errorf("%w: %s is required", ErrInvalidAddress, f.label)
+		}
+	}
+	return Address{
+		id:         id,
+		customerID: customerID,
+		name:       strings.TrimSpace(name),
+		street1:    strings.TrimSpace(street1),
+		street2:    strings.TrimSpace(street2),
+		city:       strings.TrimSpace(city),
+		zip:        strings.TrimSpace(zip),
+		country:    strings.TrimSpace(country),
+		isDefault:  isDefault,
+		createdAt:  createdAt,
+	}, nil
+}
+
+// Rebuild reconstructs an address from storage without re-validating.
+func Rebuild(id, customerID, name, street1, street2, city, zip, country string, isDefault bool, createdAt time.Time) Address {
+	return Address{
+		id: id, customerID: customerID, name: name, street1: street1,
+		street2: street2, city: city, zip: zip, country: country,
+		isDefault: isDefault, createdAt: createdAt,
+	}
+}
+
+func (a Address) ID() string            { return a.id }
+func (a Address) CustomerID() string    { return a.customerID }
+func (a Address) Name() string          { return a.name }
+func (a Address) Street1() string       { return a.street1 }
+func (a Address) Street2() string       { return a.street2 }
+func (a Address) City() string          { return a.city }
+func (a Address) Zip() string           { return a.zip }
+func (a Address) Country() string       { return a.country }
+func (a Address) IsDefault() bool       { return a.isDefault }
+func (a Address) CreatedAt() time.Time  { return a.createdAt }
+func (a Address) IsZero() bool          { return a.id == "" }

--- a/migrations/000010_shippinginfo_address.up.sql
+++ b/migrations/000010_shippinginfo_address.up.sql
@@ -1,0 +1,22 @@
+BEGIN;
+
+-- Saved shipping addresses (address book) owned by a customer. The first
+-- address a customer adds becomes their default; exactly one default per
+-- customer is expected (enforced in the application layer).
+CREATE TABLE public.shippinginfo_address (
+    id          varchar     NOT NULL,
+    customer_id varchar     NOT NULL,
+    name        varchar     NOT NULL,
+    street1     varchar     NOT NULL,
+    street2     varchar     NOT NULL DEFAULT '',
+    city        varchar     NOT NULL,
+    zip         varchar     NOT NULL,
+    country     varchar     NOT NULL,
+    is_default  boolean     NOT NULL DEFAULT false,
+    created_at  timestamptz NOT NULL DEFAULT now(),
+    CONSTRAINT shippinginfo_address_pk PRIMARY KEY (id)
+);
+
+CREATE INDEX shippinginfo_address_customer_idx ON public.shippinginfo_address(customer_id);
+
+COMMIT;


### PR DESCRIPTION
Adds a standard e-commerce account section (auth-gated, editorial theme) with a left sidebar and sub-pages, plus the saved-address book module.

## Pages (`/account*`, all gated → redirect to /auth/login if anonymous)
- **overview** — greeting, latest order, default address
- **orders** — order history in the account shell
- **addresses** — #59 address book: list / add / edit / delete / set default
- **details** — email + change password

## New module: shippinginfo (#59)
`domain.Address` entity + `app.Service` (Add = first becomes default, Edit, Remove = promotes oldest remaining if default deleted, SetDefault, List, Default) + postgres adapter + migration `000010`.

## Auth
`ChangePassword` (verify current, apply policy, store new hash) on app + both storage adapters.

## Layout
Shared sidebar via new `tmpl/partials/` glob in `renderTemplate`; header nav → `/account` when logged in.

## Closes
#30 (customer profile page), #59 (shipping information module).

## Test plan
- [x] anon → login redirect
- [x] address add (first=default) / set-default / delete-with-promotion
- [x] change password accepted + rejected (verified login with new pw works, old fails)
- [x] build / vet / tests / lint green
- [ ] browser eyeball of the layout