### PR TITLE
feat(catalog): product variants with per-variant pricing

### DIFF
--- a/backend/cart/bounded_context.go
+++ b/backend/cart/bounded_context.go
@@ -15,7 +15,7 @@ import (
 )
 
 type productStorage interface {
-	Find(ctx context.Context, id string) (productcatalog.Product, error)
+	FindVariant(ctx context.Context, variantID string) (productcatalog.Product, productcatalog.Variant, error)
 }
 
 func New(db *sql.DB, logger logrus.FieldLogger, pc productStorage) (application.BoundedContext, app.CartService) {
@@ -34,8 +34,12 @@ type transformProductCatalog struct {
 	pc productStorage
 }
 
-func (tpc transformProductCatalog) Find(ctx context.Context, productID string) (domain.Product, error) {
-	p, err := tpc.pc.Find(ctx, productID)
+// Find resolves a variant id into the cart's notion of a product. A variant
+// is the purchasable unit: the cart line's id is the variant id, its name is
+// the product name plus the variant label (e.g. "Ceramic Mug — Red / L"), and
+// its price is the variant's price.
+func (tpc transformProductCatalog) Find(ctx context.Context, variantID string) (domain.Product, error) {
+	p, v, err := tpc.pc.FindVariant(ctx, variantID)
 
 	if errors.Is(err, productcatalog.ErrProductNotFound) {
 		return domain.Product{}, domain.ErrProductNotFound
@@ -45,12 +49,17 @@ func (tpc transformProductCatalog) Find(ctx context.Context, productID string) (
 		return domain.Product{}, err
 	}
 
-	cur, err := domain.NewCurrency(string(p.Price().Currency()))
+	cur, err := domain.NewCurrency(string(v.Price().Currency()))
 	if err != nil {
 		return domain.Product{}, fmt.Errorf("cart: invalid currency from product catalog: %w", err)
 	}
 
-	return domain.NewProduct(string(p.ID()), p.Name(), p.Price().Amount(), cur), nil
+	name := p.Name()
+	if label := v.Label(p.OptionTypes()); label != "" {
+		name = name + " — " + label
+	}
+
+	return domain.NewProduct(v.ID(), name, v.Price().Amount(), cur), nil
 }
 
 type boundedContext struct {

--- a/backend/cmd/cli/productcatalog.go
+++ b/backend/cmd/cli/productcatalog.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"log"
 
+	"github.com/bkielbasa/go-ecommerce/backend/productcatalog"
 	"github.com/spf13/cobra"
 )
 
 type productCatalog interface {
 	Add(ctx context.Context, id, name, desc string, priceMinorUnits int64, currency, thumbnail string) error
+	AddVariantProduct(ctx context.Context, id, name, desc, currency, thumbnail string, optionTypes []productcatalog.OptionTypeInput, variants []productcatalog.VariantInput) error
 }
 
 func newProductCatalogCmd(pc productCatalog) *cobra.Command {

--- a/backend/cmd/cli/seeds.go
+++ b/backend/cmd/cli/seeds.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"fmt"
 
+	"github.com/bkielbasa/go-ecommerce/backend/productcatalog"
 	"github.com/spf13/cobra"
 )
 
@@ -22,22 +23,6 @@ type seedProduct struct {
 // photo matching the keywords. If a specific photo doesn't look right, bump
 // the lock number for that product.
 var seedProducts = []seedProduct{
-	{
-		id:              "ceramic-mug-cream",
-		name:            "Ceramic Mug",
-		description:     "A small-batch mug thrown by a single potter in Tokyo. Cream glaze over speckled stoneware. Holds 350ml. Sold individually.",
-		priceMinorUnits: 2400,
-		currency:        "USD",
-		thumbnail:       "https://loremflickr.com/800/800/ceramic,mug?lock=11",
-	},
-	{
-		id:              "linen-apron-navy",
-		name:            "Linen Apron",
-		description:     "Heavyweight Belgian linen apron in deep navy. Long cotton ties, double-stitched seams. Washes softer with every use.",
-		priceMinorUnits: 5800,
-		currency:        "USD",
-		thumbnail:       "https://loremflickr.com/800/800/apron,linen?lock=22",
-	},
 	{
 		id:              "brass-paperclips",
 		name:            "Brass Paperclips",
@@ -104,9 +89,58 @@ var seedProducts = []seedProduct{
 	},
 }
 
+type variantSeed struct {
+	id          string
+	name        string
+	description string
+	currency    string
+	thumbnail   string
+	optionTypes []productcatalog.OptionTypeInput
+	variants    []productcatalog.VariantInput
+}
+
+// variantSeeds are products with selectable options where each variant has
+// its own price — the mug in two colours and the apron as a Colour×Size
+// matrix.
+var variantSeeds = []variantSeed{
+	{
+		id:          "ceramic-mug",
+		name:        "Ceramic Mug",
+		description: "A small-batch mug thrown by a single potter in Tokyo. Speckled stoneware, holds 350ml.",
+		currency:    "USD",
+		thumbnail:   "https://loremflickr.com/800/800/ceramic,mug?lock=11",
+		optionTypes: []productcatalog.OptionTypeInput{
+			{Name: "Color", Values: []string{"Cream", "Charcoal"}},
+		},
+		variants: []productcatalog.VariantInput{
+			{ID: "ceramic-mug-cream", SKU: "MUG-CRM", Options: map[string]string{"Color": "Cream"}, Price: 2400},
+			{ID: "ceramic-mug-charcoal", SKU: "MUG-CHR", Options: map[string]string{"Color": "Charcoal"}, Price: 2600},
+		},
+	},
+	{
+		id:          "linen-apron",
+		name:        "Linen Apron",
+		description: "Heavyweight Belgian linen apron. Long cotton ties, double-stitched seams. Washes softer with every use.",
+		currency:    "USD",
+		thumbnail:   "https://loremflickr.com/800/800/apron,linen?lock=22",
+		optionTypes: []productcatalog.OptionTypeInput{
+			{Name: "Color", Values: []string{"Natural", "Navy"}},
+			{Name: "Size", Values: []string{"S", "M", "L"}},
+		},
+		variants: []productcatalog.VariantInput{
+			{ID: "linen-apron-nat-s", SKU: "APR-NAT-S", Options: map[string]string{"Color": "Natural", "Size": "S"}, Price: 5400},
+			{ID: "linen-apron-nat-m", SKU: "APR-NAT-M", Options: map[string]string{"Color": "Natural", "Size": "M"}, Price: 5800},
+			{ID: "linen-apron-nat-l", SKU: "APR-NAT-L", Options: map[string]string{"Color": "Natural", "Size": "L"}, Price: 6200},
+			{ID: "linen-apron-navy-s", SKU: "APR-NVY-S", Options: map[string]string{"Color": "Navy", "Size": "S"}, Price: 5600},
+			{ID: "linen-apron-navy-m", SKU: "APR-NVY-M", Options: map[string]string{"Color": "Navy", "Size": "M"}, Price: 6000},
+			{ID: "linen-apron-navy-l", SKU: "APR-NVY-L", Options: map[string]string{"Color": "Navy", "Size": "L"}, Price: 6400},
+		},
+	},
+}
+
 // wipeTables clears all product and cart data so seed re-runs are
-// idempotent. CASCADE keeps the cart tables consistent with the wiped
-// products.
+// idempotent. CASCADE clears the variant/option-type and cart tables that
+// reference the wiped products.
 const wipeTables = `TRUNCATE TABLE
 	productcatalog_product,
 	cart_cart_item,
@@ -130,7 +164,13 @@ func newSeedsCmd(pc productCatalog, db *sql.DB) *cobra.Command {
 				}
 			}
 
-			fmt.Printf("seeded %d products\n", len(seedProducts))
+			for _, p := range variantSeeds {
+				if err := pc.AddVariantProduct(ctx, p.id, p.name, p.description, p.currency, p.thumbnail, p.optionTypes, p.variants); err != nil {
+					return fmt.Errorf("seed variant product %s: %w", p.id, err)
+				}
+			}
+
+			fmt.Printf("seeded %d simple + %d variant products\n", len(seedProducts), len(variantSeeds))
 			return nil
 		},
 	}

--- a/backend/layout/http.go
+++ b/backend/layout/http.go
@@ -56,7 +56,8 @@ func (m boundedContext) MuxRegister(r *mux.Router) {
 	r.HandleFunc("/cart/budge", observability.HTTPWrap(m.handler.Budge, m.logger)).Methods("GET", "OPTIONS")
 
 	r.HandleFunc("/api/v1/products", observability.HTTPWrap(m.handler.AllProducts, m.logger))
-	r.HandleFunc("/product/{productID}", observability.HTTPWrap(m.handler.Product, m.logger))
+	r.HandleFunc("/product/{productID}", observability.HTTPWrap(m.handler.Product, m.logger)).Methods("GET")
+	r.HandleFunc("/product/{productID}/variant", observability.HTTPWrap(m.handler.ProductVariant, m.logger)).Methods("GET")
 
 	r.HandleFunc("/auth/login", observability.HTTPWrap(m.handler.Login, m.logger)).Methods("GET")
 	r.HandleFunc("/auth/login", observability.HTTPWrap(m.handler.HandleLogin, m.logger)).Methods("POST")

--- a/backend/layout/http_product.go
+++ b/backend/layout/http_product.go
@@ -63,8 +63,46 @@ func (handler httpHandler) Product(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	resp := map[string]any{
-		"Product": product,
+	// Resolve the initially-selected variant: the combination formed by the
+	// first value of each option type (which is what the selects default to).
+	selected := map[string]string{}
+	for _, ot := range product.OptionTypes() {
+		if len(ot.Values()) > 0 {
+			selected[ot.Name()] = ot.Values()[0]
+		}
 	}
-	handler.renderTemplate(w, r, "productCatalog/show", resp)
+	variant := product.DefaultVariant()
+	if product.HasOptions() {
+		if v, ok := product.ResolveVariant(selected); ok {
+			variant = v
+		}
+	}
+
+	handler.renderTemplate(w, r, "productCatalog/show", map[string]any{
+		"Product": product,
+		"Variant": variant,
+	})
+}
+
+// ProductVariant resolves the option selection (query params) to a variant
+// and returns the variant box partial (price + add-to-cart). Driven by the
+// option selects via HTMX.
+func (handler httpHandler) ProductVariant(w http.ResponseWriter, r *http.Request) {
+	id := mux.Vars(r)["productID"]
+	product, err := handler.catalogSrv.Find(r.Context(), id)
+	if err != nil {
+		http.NotFound(w, r)
+		return
+	}
+
+	selected := map[string]string{}
+	for _, ot := range product.OptionTypes() {
+		selected[ot.Name()] = r.URL.Query().Get(ot.Name())
+	}
+	variant, _ := product.ResolveVariant(selected)
+
+	ts := template.Must(template.New("").ParseFiles("./layout/tmpl/partials/variant-box.gohtml"))
+	if err := ts.ExecuteTemplate(w, "variant-box", map[string]any{"Variant": variant}); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
 }

--- a/backend/layout/static/main.css
+++ b/backend/layout/static/main.css
@@ -240,6 +240,25 @@ main {
   color: var(--fg-muted);
 }
 
+/* ---------- variant selector ---------- */
+.variant-form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  max-width: 18rem;
+}
+.variant-form select {
+  background: transparent;
+  border: 0;
+  border-bottom: 1px solid var(--rule);
+  padding: var(--space-1) 0;
+  font-size: var(--step-1);
+  color: var(--fg);
+  outline: none;
+}
+.variant-form select:focus { border-bottom-color: var(--fg); }
+.variant-box { display: flex; flex-direction: column; gap: var(--space-2); }
+
 /* ---------- buttons ---------- */
 .btn {
   display: inline-flex;

--- a/backend/layout/tmpl/partials/variant-box.gohtml
+++ b/backend/layout/tmpl/partials/variant-box.gohtml
@@ -1,0 +1,15 @@
+{{define "variant-box"}}
+<div id="variant-box" class="variant-box">
+  {{if .Variant.IsZero}}
+    <p class="product__price muted">that combination isn't available</p>
+  {{else}}
+    <p class="product__price">{{.Variant.Price.Display}} {{.Variant.Price.Currency}}</p>
+    <button class="btn"
+            hx-post="/cart/{{.Variant.ID}}"
+            hx-swap="none">
+      add to cart
+      <span class="loading htmx-indicator" aria-hidden="true"></span>
+    </button>
+  {{end}}
+</div>
+{{end}}

--- a/backend/layout/tmpl/productCatalog/allProducts.gohtml
+++ b/backend/layout/tmpl/productCatalog/allProducts.gohtml
@@ -10,7 +10,7 @@
                width="800" height="800">
         {{end}}
         <h2 class="product-card__name">{{.Name}}</h2>
-        <p class="product-card__price">{{.Price.Display}} {{.Price.Currency}}</p>
+        <p class="product-card__price">{{if .HasPriceRange}}from {{end}}{{.PriceFrom.Display}} {{.PriceFrom.Currency}}</p>
       </a>
     {{end}}
   </div>

--- a/backend/layout/tmpl/productCatalog/show.gohtml
+++ b/backend/layout/tmpl/productCatalog/show.gohtml
@@ -12,14 +12,26 @@
     <div class="product__body">
       <h1 class="product__name">{{.Product.Name}}</h1>
       <p class="product__description">{{.Product.Description}}</p>
-      <p class="product__price">{{.Product.Price.Display}} {{.Product.Price.Currency}}</p>
 
-      <button class="btn"
-              hx-post="/cart/{{.Product.ID}}"
-              hx-swap="none">
-        add to cart
-        <span class="loading htmx-indicator" aria-hidden="true"></span>
-      </button>
+      {{if .Product.HasOptions}}
+        <form class="variant-form">
+          {{range .Product.OptionTypes}}
+            <div class="field">
+              <label for="opt-{{.Name}}">{{.Name}}</label>
+              <select id="opt-{{.Name}}" name="{{.Name}}"
+                      hx-get="/product/{{$.Product.ID}}/variant"
+                      hx-trigger="change"
+                      hx-include="closest form"
+                      hx-target="#variant-box"
+                      hx-swap="outerHTML">
+                {{range .Values}}<option value="{{.}}">{{.}}</option>{{end}}
+              </select>
+            </div>
+          {{end}}
+        </form>
+      {{end}}
+
+      {{template "variant-box" .}}
 
       <p class="product__hint muted">added to your cart without a page reload.</p>
     </div>

--- a/backend/productcatalog/adapter_inmemory.go
+++ b/backend/productcatalog/adapter_inmemory.go
@@ -5,32 +5,60 @@ import (
 )
 
 type inMemory struct {
-	products []Product
+	products    []Product
+	optionTypes map[string][]OptionType
+	variants    map[string][]Variant
 }
 
 func NewInMemory() *inMemory {
-	return &inMemory{}
+	return &inMemory{
+		optionTypes: map[string][]OptionType{},
+		variants:    map[string][]Variant{},
+	}
 }
 
 func (im *inMemory) Add(ctx context.Context, p Product) error {
 	im.products = append(im.products, p)
-
 	return nil
 }
 
+func (im *inMemory) AddOptionType(ctx context.Context, productID string, position int, ot OptionType) error {
+	im.optionTypes[productID] = append(im.optionTypes[productID], ot)
+	return nil
+}
+
+func (im *inMemory) AddVariant(ctx context.Context, productID string, position int, v Variant) error {
+	im.variants[productID] = append(im.variants[productID], v)
+	return nil
+}
+
+func (im *inMemory) hydrate(p Product) Product {
+	return p.WithCatalog(im.optionTypes[string(p.ID())], im.variants[string(p.ID())])
+}
+
 func (im *inMemory) All(ctx context.Context) ([]Product, error) {
-	return im.products, nil
+	out := make([]Product, 0, len(im.products))
+	for _, p := range im.products {
+		out = append(out, im.hydrate(p))
+	}
+	return out, nil
 }
 
 func (im *inMemory) Find(ctx context.Context, id string) (Product, error) {
 	for _, p := range im.products {
 		if string(p.ID()) == id {
-			return p, nil
+			return im.hydrate(p), nil
 		}
 	}
 	return Product{}, ErrProductNotFound
 }
 
-func (im *inMemory) Reserve(ctx context.Context, name string) error {
-	return nil
+func (im *inMemory) FindVariant(ctx context.Context, variantID string) (Product, Variant, error) {
+	for _, p := range im.products {
+		full := im.hydrate(p)
+		if v, ok := full.Variant(variantID); ok {
+			return full, v, nil
+		}
+	}
+	return Product{}, Variant{}, ErrProductNotFound
 }

--- a/backend/productcatalog/adapter_postgres.go
+++ b/backend/productcatalog/adapter_postgres.go
@@ -3,6 +3,7 @@ package productcatalog
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"fmt"
 
@@ -20,7 +21,7 @@ func NewPostgres(db *sql.DB) postgres {
 }
 
 func (db postgres) Add(ctx context.Context, p Product) error {
-	q := `INSERT INTO productcatalog_product (id, name, description, thumbnail, price_amount, price_currency) 
+	q := `INSERT INTO productcatalog_product (id, name, description, thumbnail, price_amount, price_currency)
 		VALUES ($1, $2, $3, $4, $5, $6)`
 
 	_, err := db.db.ExecContext(ctx, q, p.ID(), p.Name(), p.Description(), p.Thumbnail(), p.Price().Amount(), p.Price().Currency())
@@ -31,86 +32,206 @@ func (db postgres) Add(ctx context.Context, p Product) error {
 	return nil
 }
 
+func (db postgres) AddOptionType(ctx context.Context, productID string, position int, ot OptionType) error {
+	values, err := json.Marshal(ot.Values())
+	if err != nil {
+		return fmt.Errorf("marshal option values: %w", err)
+	}
+	id := fmt.Sprintf("opt-%s-%d", productID, position)
+	_, err = db.db.ExecContext(ctx, `
+		INSERT INTO productcatalog_option_type (id, product_id, name, position, values)
+		VALUES ($1, $2, $3, $4, $5)
+	`, id, productID, ot.Name(), position, values)
+	if err != nil {
+		return fmt.Errorf("add option type: %w", err)
+	}
+	return nil
+}
+
+func (db postgres) AddVariant(ctx context.Context, productID string, position int, v Variant) error {
+	options, err := json.Marshal(v.Options())
+	if err != nil {
+		return fmt.Errorf("marshal variant options: %w", err)
+	}
+	_, err = db.db.ExecContext(ctx, `
+		INSERT INTO productcatalog_variant (id, product_id, sku, price_amount, price_currency, position, options)
+		VALUES ($1, $2, $3, $4, $5, $6, $7)
+	`, v.ID(), productID, v.SKU(), v.Price().Amount(), string(v.Price().Currency()), position, options)
+	if err != nil {
+		return fmt.Errorf("add variant: %w", err)
+	}
+	return nil
+}
+
+func (db postgres) optionTypes(ctx context.Context, productID string) ([]OptionType, error) {
+	rows, err := db.db.QueryContext(ctx, `
+		SELECT name, values FROM productcatalog_option_type
+		WHERE product_id = $1 ORDER BY position
+	`, productID)
+	if err != nil {
+		return nil, fmt.Errorf("query option types: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []OptionType
+	for rows.Next() {
+		var name string
+		var valuesRaw []byte
+		if err := rows.Scan(&name, &valuesRaw); err != nil {
+			return nil, fmt.Errorf("scan option type: %w", err)
+		}
+		var values []string
+		if err := json.Unmarshal(valuesRaw, &values); err != nil {
+			return nil, fmt.Errorf("unmarshal option values: %w", err)
+		}
+		out = append(out, NewOptionType(name, values))
+	}
+	return out, rows.Err()
+}
+
+func (db postgres) variants(ctx context.Context, productID string) ([]Variant, error) {
+	rows, err := db.db.QueryContext(ctx, `
+		SELECT id, sku, price_amount, price_currency, options FROM productcatalog_variant
+		WHERE product_id = $1 ORDER BY position
+	`, productID)
+	if err != nil {
+		return nil, fmt.Errorf("query variants: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []Variant
+	for rows.Next() {
+		v, err := scanVariant(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, v)
+	}
+	return out, rows.Err()
+}
+
+func (db postgres) withCatalog(ctx context.Context, p Product) (Product, error) {
+	ots, err := db.optionTypes(ctx, string(p.ID()))
+	if err != nil {
+		return Product{}, err
+	}
+	vs, err := db.variants(ctx, string(p.ID()))
+	if err != nil {
+		return Product{}, err
+	}
+	return p.WithCatalog(ots, vs), nil
+}
+
 func (db postgres) All(ctx context.Context) ([]Product, error) {
-	q := `SELECT id, name, description, thumbnail, price_amount, price_currency FROM productcatalog_product`
+	q := `SELECT id, name, description, thumbnail, price_amount, price_currency FROM productcatalog_product ORDER BY id`
 
 	rows, err := db.db.QueryContext(ctx, q)
 	if err != nil {
 		return nil, fmt.Errorf("cannot query products: %w", err)
 	}
 
-	products := []Product{}
-
-	for rows.Next() {
-		var id, name, description, thumbnail string
-		var amount int64
-		var currency string
-
-		err = rows.Scan(&id, &name, &description, &thumbnail, &amount, &currency)
-		if err != nil {
-			return nil, fmt.Errorf("cannot scan product: %w", err)
+	var base []Product
+	func() {
+		defer func() { _ = rows.Close() }()
+		for rows.Next() {
+			p, err := scanProduct(rows)
+			if err != nil {
+				return
+			}
+			base = append(base, p)
 		}
-
-		pid, err := NewProductId(id)
-		if err != nil {
-			return nil, fmt.Errorf("cannot rebuild the product ID: %w", err)
-		}
-
-		cur, err := NewCurrency(currency)
-		if err != nil {
-			return nil, fmt.Errorf("cannot rebuild the product currency: %w", err)
-		}
-
-		priceVO, err := NewPrice(amount, cur)
-		if err != nil {
-			return nil, fmt.Errorf("cannot rebuild the product price: %w", err)
-		}
-
-		prod, err := NewProduct(pid, name, description, priceVO, thumbnail)
-		if err != nil {
-			return nil, fmt.Errorf("cannot create product from data in the DB: %w", err)
-		}
-		products = append(products, prod)
-	}
-
+	}()
 	if err = rows.Err(); err != nil {
 		return nil, fmt.Errorf("cannot fetch products: %w", err)
 	}
 
+	products := make([]Product, 0, len(base))
+	for _, p := range base {
+		full, err := db.withCatalog(ctx, p)
+		if err != nil {
+			return nil, err
+		}
+		products = append(products, full)
+	}
 	return products, nil
 }
 
 func (db postgres) Find(ctx context.Context, id string) (Product, error) {
-	q := `SELECT name, description, thumbnail, price_amount, price_currency FROM productcatalog_product WHERE id = $1`
-
-	row := db.db.QueryRowContext(ctx, q, id)
-	var name, description, thumbnail string
-	var amount int64
-	var currency string
-
-	err := row.Scan(&name, &description, &thumbnail, &amount, &currency)
+	q := `SELECT id, name, description, thumbnail, price_amount, price_currency FROM productcatalog_product WHERE id = $1`
+	p, err := scanProduct(db.db.QueryRowContext(ctx, q, id))
 	if errors.Is(err, sql.ErrNoRows) {
 		return Product{}, ErrProductNotFound
 	}
-
 	if err != nil {
 		return Product{}, fmt.Errorf("cannot scan product: %w", err)
 	}
+	return db.withCatalog(ctx, p)
+}
 
-	pId, err := NewProductId(id)
-	if err != nil {
-		return Product{}, fmt.Errorf("cannot build product: %w", err)
+// FindVariant resolves a variant id to its variant and owning product.
+func (db postgres) FindVariant(ctx context.Context, variantID string) (Product, Variant, error) {
+	var productID string
+	err := db.db.QueryRowContext(ctx, `SELECT product_id FROM productcatalog_variant WHERE id = $1`, variantID).Scan(&productID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return Product{}, Variant{}, ErrProductNotFound
 	}
+	if err != nil {
+		return Product{}, Variant{}, fmt.Errorf("find variant: %w", err)
+	}
+	p, err := db.Find(ctx, productID)
+	if err != nil {
+		return Product{}, Variant{}, err
+	}
+	v, ok := p.Variant(variantID)
+	if !ok {
+		return Product{}, Variant{}, ErrProductNotFound
+	}
+	return p, v, nil
+}
 
+type rowScanner interface {
+	Scan(dest ...any) error
+}
+
+func scanProduct(s rowScanner) (Product, error) {
+	var id, name, description, thumbnail, currency string
+	var amount int64
+	if err := s.Scan(&id, &name, &description, &thumbnail, &amount, &currency); err != nil {
+		return Product{}, err
+	}
+	pid, err := NewProductId(id)
+	if err != nil {
+		return Product{}, fmt.Errorf("rebuild product id: %w", err)
+	}
 	cur, err := NewCurrency(currency)
 	if err != nil {
-		return Product{}, fmt.Errorf("cannot rebuild product currency: %w", err)
+		return Product{}, fmt.Errorf("rebuild currency: %w", err)
 	}
-
-	priceVO, err := NewPrice(amount, cur)
+	price, err := NewPrice(amount, cur)
 	if err != nil {
-		return Product{}, fmt.Errorf("cannot rebuild product price: %w", err)
+		return Product{}, fmt.Errorf("rebuild price: %w", err)
 	}
+	return NewProduct(pid, name, description, price, thumbnail)
+}
 
-	return NewProduct(pId, name, description, priceVO, thumbnail)
+func scanVariant(s rowScanner) (Variant, error) {
+	var id, sku, currency string
+	var amount int64
+	var optionsRaw []byte
+	if err := s.Scan(&id, &sku, &amount, &currency, &optionsRaw); err != nil {
+		return Variant{}, err
+	}
+	cur, err := NewCurrency(currency)
+	if err != nil {
+		return Variant{}, fmt.Errorf("rebuild variant currency: %w", err)
+	}
+	price, err := NewPrice(amount, cur)
+	if err != nil {
+		return Variant{}, fmt.Errorf("rebuild variant price: %w", err)
+	}
+	var options map[string]string
+	if err := json.Unmarshal(optionsRaw, &options); err != nil {
+		return Variant{}, fmt.Errorf("unmarshal variant options: %w", err)
+	}
+	return NewVariant(id, sku, options, price), nil
 }

--- a/backend/productcatalog/app_product.go
+++ b/backend/productcatalog/app_product.go
@@ -13,6 +13,9 @@ type ProductStorage interface {
 	All(ctx context.Context) ([]Product, error)
 	Add(ctx context.Context, p Product) error
 	Find(ctx context.Context, id string) (Product, error)
+	FindVariant(ctx context.Context, variantID string) (Product, Variant, error)
+	AddOptionType(ctx context.Context, productID string, position int, ot OptionType) error
+	AddVariant(ctx context.Context, productID string, position int, v Variant) error
 }
 
 func NewProductService(s ProductStorage) ProductService {
@@ -25,6 +28,11 @@ func (ps ProductService) AllProducts(ctx context.Context) ([]Product, error) {
 
 func (ps ProductService) Find(ctx context.Context, id string) (Product, error) {
 	return ps.storage.Find(ctx, id)
+}
+
+// FindVariant resolves a variant id to its variant and owning product.
+func (ps ProductService) FindVariant(ctx context.Context, variantID string) (Product, Variant, error) {
+	return ps.storage.FindVariant(ctx, variantID)
 }
 
 func (ps ProductService) Add(ctx context.Context, id, name, desc string, priceMinorUnits int64, currency, thumbnail string) error {
@@ -48,10 +56,78 @@ func (ps ProductService) Add(ctx context.Context, id, name, desc string, priceMi
 		return err
 	}
 
-	err = ps.storage.Add(ctx, p)
-	if err != nil {
+	if err = ps.storage.Add(ctx, p); err != nil {
 		return err
 	}
 
+	// A simple product is purchasable through a single default variant
+	// carrying its price (no options).
+	defaultVariant := NewVariant("var-"+id, id, nil, priceVO)
+	return ps.storage.AddVariant(ctx, id, 0, defaultVariant)
+}
+
+// OptionTypeInput / VariantInput describe a product's options and variants for
+// AddVariantProduct (used by seeding).
+type OptionTypeInput struct {
+	Name   string
+	Values []string
+}
+
+type VariantInput struct {
+	ID      string
+	SKU     string
+	Options map[string]string
+	Price   int64
+}
+
+// AddVariantProduct creates a product with explicit option types and variants
+// (each independently priced). The product's base price is the lowest variant
+// price, used for "from $X" display.
+func (ps ProductService) AddVariantProduct(ctx context.Context, id, name, desc, currency, thumbnail string, optionTypes []OptionTypeInput, variants []VariantInput) error {
+	if len(variants) == 0 {
+		return fmt.Errorf("a variant product needs at least one variant")
+	}
+	pID, err := NewProductId(id)
+	if err != nil {
+		return err
+	}
+	cur, err := NewCurrency(currency)
+	if err != nil {
+		return fmt.Errorf("invalid currency: %w", err)
+	}
+
+	base := variants[0].Price
+	for _, v := range variants[1:] {
+		if v.Price < base {
+			base = v.Price
+		}
+	}
+	basePrice, err := NewPrice(base, cur)
+	if err != nil {
+		return fmt.Errorf("invalid base price: %w", err)
+	}
+
+	product, err := NewProduct(pID, name, desc, basePrice, thumbnail)
+	if err != nil {
+		return err
+	}
+	if err = ps.storage.Add(ctx, product); err != nil {
+		return err
+	}
+
+	for i, ot := range optionTypes {
+		if err = ps.storage.AddOptionType(ctx, id, i, NewOptionType(ot.Name, ot.Values)); err != nil {
+			return err
+		}
+	}
+	for i, v := range variants {
+		price, err := NewPrice(v.Price, cur)
+		if err != nil {
+			return fmt.Errorf("invalid variant price: %w", err)
+		}
+		if err = ps.storage.AddVariant(ctx, id, i, NewVariant(v.ID, v.SKU, v.Options, price)); err != nil {
+			return err
+		}
+	}
 	return nil
 }

--- a/backend/productcatalog/domain_product.go
+++ b/backend/productcatalog/domain_product.go
@@ -72,13 +72,17 @@ func (p Price) Display() string {
 	return fmt.Sprintf("%d.%02d", p.amount/100, p.amount%100)
 }
 
-// Product is an entity that represents a single product visable in the product catalog
+// Product is an entity that represents a single product visable in the product catalog.
+// Its purchasable units are its variants; price is the product's base/display
+// price (the price the catalogue was seeded with).
 type Product struct {
 	id          ProductID
 	name        string
 	description string
 	price       Price
 	thumbnail   string
+	optionTypes []OptionType
+	variants    []Variant
 }
 
 var emptyProduct = Product{}
@@ -131,4 +135,82 @@ func (p Product) Price() Price {
 
 func (p Product) Thumbnail() string {
 	return p.thumbnail
+}
+
+// WithCatalog returns a copy of the product with its option types and
+// variants attached (used by the storage layer after loading them).
+func (p Product) WithCatalog(optionTypes []OptionType, variants []Variant) Product {
+	p.optionTypes = optionTypes
+	p.variants = variants
+	return p
+}
+
+func (p Product) OptionTypes() []OptionType { return p.optionTypes }
+func (p Product) Variants() []Variant       { return p.variants }
+func (p Product) HasOptions() bool          { return len(p.optionTypes) > 0 }
+
+// Variant returns the variant with the given id, if it belongs to this product.
+func (p Product) Variant(id string) (Variant, bool) {
+	for _, v := range p.variants {
+		if v.id == id {
+			return v, true
+		}
+	}
+	return Variant{}, false
+}
+
+// DefaultVariant is the first variant (used when a product has no options).
+func (p Product) DefaultVariant() Variant {
+	if len(p.variants) > 0 {
+		return p.variants[0]
+	}
+	return Variant{}
+}
+
+// PriceFrom is the lowest variant price, for "from $X" display. Falls back to
+// the product base price when there are no variants.
+func (p Product) PriceFrom() Price {
+	if len(p.variants) == 0 {
+		return p.price
+	}
+	min := p.variants[0].price
+	for _, v := range p.variants[1:] {
+		if v.price.Amount() < min.Amount() {
+			min = v.price
+		}
+	}
+	return min
+}
+
+// HasPriceRange reports whether variants span more than one price (so the UI
+// can show "from $X" rather than a single price).
+func (p Product) HasPriceRange() bool {
+	if len(p.variants) < 2 {
+		return false
+	}
+	first := p.variants[0].price.Amount()
+	for _, v := range p.variants[1:] {
+		if v.price.Amount() != first {
+			return true
+		}
+	}
+	return false
+}
+
+// ResolveVariant finds the variant matching the selected option values
+// (keyed by option-type name).
+func (p Product) ResolveVariant(selected map[string]string) (Variant, bool) {
+	for _, v := range p.variants {
+		match := true
+		for _, ot := range p.optionTypes {
+			if v.options[ot.name] != selected[ot.name] {
+				match = false
+				break
+			}
+		}
+		if match {
+			return v, true
+		}
+	}
+	return Variant{}, false
 }

--- a/backend/productcatalog/domain_variant.go
+++ b/backend/productcatalog/domain_variant.go
@@ -1,0 +1,52 @@
+package productcatalog
+
+import "strings"
+
+// OptionType is a product attribute the customer chooses, e.g. "Color" with
+// values ["Red", "Blue"]. The order of values is the display order.
+type OptionType struct {
+	name   string
+	values []string
+}
+
+func NewOptionType(name string, values []string) OptionType {
+	return OptionType{name: name, values: values}
+}
+
+func (o OptionType) Name() string     { return o.name }
+func (o OptionType) Values() []string { return o.values }
+
+// Variant is a concrete, purchasable version of a product — a specific
+// combination of option values with its own price. A product with no options
+// has a single default variant whose options map is empty.
+type Variant struct {
+	id      string
+	sku     string
+	options map[string]string // e.g. {"Color":"Red","Size":"L"}
+	price   Price
+}
+
+func NewVariant(id, sku string, options map[string]string, price Price) Variant {
+	if options == nil {
+		options = map[string]string{}
+	}
+	return Variant{id: id, sku: sku, options: options, price: price}
+}
+
+func (v Variant) ID() string                 { return v.id }
+func (v Variant) SKU() string                { return v.sku }
+func (v Variant) Options() map[string]string { return v.options }
+func (v Variant) Price() Price               { return v.price }
+func (v Variant) IsZero() bool               { return v.id == "" }
+
+// Label builds a human label from the variant's option values, in the
+// product's option-type order (e.g. "Red / L"). Empty for a default variant.
+func (v Variant) Label(optionTypes []OptionType) string {
+	parts := make([]string, 0, len(optionTypes))
+	for _, ot := range optionTypes {
+		if val, ok := v.options[ot.name]; ok && val != "" {
+			parts = append(parts, val)
+		}
+	}
+	return strings.Join(parts, " / ")
+}

--- a/backend/productcatalog/productcatalog_test.go
+++ b/backend/productcatalog/productcatalog_test.go
@@ -14,6 +14,9 @@ type productStorage interface {
 	All(ctx context.Context) ([]productcatalog.Product, error)
 	Add(ctx context.Context, p productcatalog.Product) error
 	Find(ctx context.Context, id string) (productcatalog.Product, error)
+	FindVariant(ctx context.Context, variantID string) (productcatalog.Product, productcatalog.Variant, error)
+	AddOptionType(ctx context.Context, productID string, position int, ot productcatalog.OptionType) error
+	AddVariant(ctx context.Context, productID string, position int, v productcatalog.Variant) error
 }
 
 var storage productStorage

--- a/migrations/000011_productcatalog_variants.up.sql
+++ b/migrations/000011_productcatalog_variants.up.sql
@@ -1,0 +1,40 @@
+BEGIN;
+
+-- Option types a product offers (e.g. Color, Size). values is a JSON array
+-- of the allowed values in display order.
+CREATE TABLE public.productcatalog_option_type (
+    id         varchar NOT NULL,
+    product_id varchar NOT NULL,
+    name       varchar NOT NULL,
+    position   integer NOT NULL DEFAULT 0,
+    values     jsonb   NOT NULL DEFAULT '[]'::jsonb,
+    CONSTRAINT productcatalog_option_type_pk PRIMARY KEY (id),
+    CONSTRAINT productcatalog_option_type_fk FOREIGN KEY (product_id)
+        REFERENCES public.productcatalog_product(id) ON DELETE CASCADE
+);
+CREATE INDEX productcatalog_option_type_product_idx ON public.productcatalog_option_type(product_id);
+
+-- Purchasable variants. options is a JSON object mapping option-type name to
+-- the chosen value, e.g. {"Color":"Red","Size":"L"}. An empty object is a
+-- default (single) variant.
+CREATE TABLE public.productcatalog_variant (
+    id             varchar NOT NULL,
+    product_id     varchar NOT NULL,
+    sku            varchar NOT NULL DEFAULT '',
+    price_amount   bigint  NOT NULL,
+    price_currency varchar NOT NULL,
+    position       integer NOT NULL DEFAULT 0,
+    options        jsonb   NOT NULL DEFAULT '{}'::jsonb,
+    CONSTRAINT productcatalog_variant_pk PRIMARY KEY (id),
+    CONSTRAINT productcatalog_variant_fk FOREIGN KEY (product_id)
+        REFERENCES public.productcatalog_product(id) ON DELETE CASCADE
+);
+CREATE INDEX productcatalog_variant_product_idx ON public.productcatalog_variant(product_id);
+
+-- Give every existing product a default variant carrying its current price,
+-- so products stay purchasable after price moves to the variant level.
+INSERT INTO public.productcatalog_variant (id, product_id, sku, price_amount, price_currency, position, options)
+SELECT 'var-' || id, id, id, price_amount, price_currency, 0, '{}'::jsonb
+FROM public.productcatalog_product;
+
+COMMIT;


### PR DESCRIPTION
Shopify-style variants: products have option types (Color, Size) and variants that are combinations of option values, each independently priced. Full vertical — a variant is selectable on the product page and buyable through cart and checkout.

**Key idea:** a variant is the purchasable unit, so cart/order lines (already storing id/name/price) barely change — line id = variant id, name = "Product — Red / L", price = variant price.

## Changes
- **productcatalog**: `OptionType` + `Variant` domain; `Product` gains `PriceFrom`, `HasPriceRange`, `ResolveVariant`, `DefaultVariant`, `Variant(id)`. Migration `000011` (option_type + variant tables, jsonb options/values) with a data step giving every existing product a default variant. Adapter `FindVariant`. `ProductService.Add` also creates a default variant; new `AddVariantProduct`.
- **product page**: option `<select>`s → HTMX `GET /product/{id}/variant` resolves the combo and swaps the price + add-to-cart box. List shows "from $min" when prices vary.
- **cart**: add-to-cart posts a variant id; ACL uses `FindVariant`, labels the line with the variant.
- **seeds**: mug in 2 colours, apron as a 6-variant Colour×Size matrix ($54–$64); other 8 stay simple.

## Test plan
- [x] select Navy/L apron → $64 → add → checkout → order line "Linen Apron — Navy / L" @ 6400
- [x] list shows "from 54.00" / "from 24.00" for variant products
- [x] HTMX variant resolution returns correct price + variant id
- [x] existing products still purchasable (default variant)
- [x] build / vet / tests / lint green