### PR TITLE
feat(catalog): per-variant images that swap on selection

### DIFF
--- a/backend/cmd/cli/seeds.go
+++ b/backend/cmd/cli/seeds.go
@@ -99,6 +99,13 @@ type variantSeed struct {
 	variants    []productcatalog.VariantInput
 }
 
+// Per-colour apron images, shared across that colour's size variants so
+// changing size keeps the image and changing colour swaps it.
+const (
+	natApron  = "https://loremflickr.com/800/800/apron,linen?lock=22"
+	navyApron = "https://loremflickr.com/800/800/apron,navy?lock=222"
+)
+
 // variantSeeds are products with selectable options where each variant has
 // its own price — the mug in two colours and the apron as a Colour×Size
 // matrix.
@@ -113,8 +120,8 @@ var variantSeeds = []variantSeed{
 			{Name: "Color", Values: []string{"Cream", "Charcoal"}},
 		},
 		variants: []productcatalog.VariantInput{
-			{ID: "ceramic-mug-cream", SKU: "MUG-CRM", Options: map[string]string{"Color": "Cream"}, Price: 2400},
-			{ID: "ceramic-mug-charcoal", SKU: "MUG-CHR", Options: map[string]string{"Color": "Charcoal"}, Price: 2600},
+			{ID: "ceramic-mug-cream", SKU: "MUG-CRM", Options: map[string]string{"Color": "Cream"}, Price: 2400, Image: "https://loremflickr.com/800/800/ceramic,mug,cream?lock=11"},
+			{ID: "ceramic-mug-charcoal", SKU: "MUG-CHR", Options: map[string]string{"Color": "Charcoal"}, Price: 2600, Image: "https://loremflickr.com/800/800/ceramic,mug,black?lock=211"},
 		},
 	},
 	{
@@ -128,12 +135,12 @@ var variantSeeds = []variantSeed{
 			{Name: "Size", Values: []string{"S", "M", "L"}},
 		},
 		variants: []productcatalog.VariantInput{
-			{ID: "linen-apron-nat-s", SKU: "APR-NAT-S", Options: map[string]string{"Color": "Natural", "Size": "S"}, Price: 5400},
-			{ID: "linen-apron-nat-m", SKU: "APR-NAT-M", Options: map[string]string{"Color": "Natural", "Size": "M"}, Price: 5800},
-			{ID: "linen-apron-nat-l", SKU: "APR-NAT-L", Options: map[string]string{"Color": "Natural", "Size": "L"}, Price: 6200},
-			{ID: "linen-apron-navy-s", SKU: "APR-NVY-S", Options: map[string]string{"Color": "Navy", "Size": "S"}, Price: 5600},
-			{ID: "linen-apron-navy-m", SKU: "APR-NVY-M", Options: map[string]string{"Color": "Navy", "Size": "M"}, Price: 6000},
-			{ID: "linen-apron-navy-l", SKU: "APR-NVY-L", Options: map[string]string{"Color": "Navy", "Size": "L"}, Price: 6400},
+			{ID: "linen-apron-nat-s", SKU: "APR-NAT-S", Options: map[string]string{"Color": "Natural", "Size": "S"}, Price: 5400, Image: natApron},
+			{ID: "linen-apron-nat-m", SKU: "APR-NAT-M", Options: map[string]string{"Color": "Natural", "Size": "M"}, Price: 5800, Image: natApron},
+			{ID: "linen-apron-nat-l", SKU: "APR-NAT-L", Options: map[string]string{"Color": "Natural", "Size": "L"}, Price: 6200, Image: natApron},
+			{ID: "linen-apron-navy-s", SKU: "APR-NVY-S", Options: map[string]string{"Color": "Navy", "Size": "S"}, Price: 5600, Image: navyApron},
+			{ID: "linen-apron-navy-m", SKU: "APR-NVY-M", Options: map[string]string{"Color": "Navy", "Size": "M"}, Price: 6000, Image: navyApron},
+			{ID: "linen-apron-navy-l", SKU: "APR-NVY-L", Options: map[string]string{"Color": "Navy", "Size": "L"}, Price: 6400, Image: navyApron},
 		},
 	},
 }

--- a/backend/layout/http_product.go
+++ b/backend/layout/http_product.go
@@ -101,8 +101,11 @@ func (handler httpHandler) ProductVariant(w http.ResponseWriter, r *http.Request
 	}
 	variant, _ := product.ResolveVariant(selected)
 
-	ts := template.Must(template.New("").ParseFiles("./layout/tmpl/partials/variant-box.gohtml"))
-	if err := ts.ExecuteTemplate(w, "variant-box", map[string]any{"Variant": variant}); err != nil {
+	ts := template.Must(template.New("").ParseGlob("./layout/tmpl/partials/*.gohtml"))
+	if err := ts.ExecuteTemplate(w, "variant-response", map[string]any{
+		"Variant":     variant,
+		"ProductName": product.Name(),
+	}); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}
 }

--- a/backend/layout/tmpl/partials/variant-response.gohtml
+++ b/backend/layout/tmpl/partials/variant-response.gohtml
@@ -1,0 +1,6 @@
+{{define "variant-response"}}
+{{template "variant-box" .}}
+{{if .Variant.Image}}
+<img id="product-image" hx-swap-oob="true" class="product__image" src="{{.Variant.Image}}" alt="{{.ProductName}}" width="800" height="800">
+{{end}}
+{{end}}

--- a/backend/layout/tmpl/productCatalog/show.gohtml
+++ b/backend/layout/tmpl/productCatalog/show.gohtml
@@ -2,9 +2,10 @@
   <p class="crumbs"><a href="/">products</a> / {{.Product.Name}}</p>
 
   <article class="product">
-    {{if .Product.Thumbnail}}
-      <img class="product__image"
-           src="{{.Product.Thumbnail}}"
+    {{$img := .Product.Thumbnail}}{{if .Variant.Image}}{{$img = .Variant.Image}}{{end}}
+    {{if $img}}
+      <img id="product-image" class="product__image"
+           src="{{$img}}"
            alt="{{.Product.Name}}"
            width="800" height="800">
     {{end}}

--- a/backend/productcatalog/adapter_postgres.go
+++ b/backend/productcatalog/adapter_postgres.go
@@ -54,9 +54,9 @@ func (db postgres) AddVariant(ctx context.Context, productID string, position in
 		return fmt.Errorf("marshal variant options: %w", err)
 	}
 	_, err = db.db.ExecContext(ctx, `
-		INSERT INTO productcatalog_variant (id, product_id, sku, price_amount, price_currency, position, options)
-		VALUES ($1, $2, $3, $4, $5, $6, $7)
-	`, v.ID(), productID, v.SKU(), v.Price().Amount(), string(v.Price().Currency()), position, options)
+		INSERT INTO productcatalog_variant (id, product_id, sku, image_url, price_amount, price_currency, position, options)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+	`, v.ID(), productID, v.SKU(), v.Image(), v.Price().Amount(), string(v.Price().Currency()), position, options)
 	if err != nil {
 		return fmt.Errorf("add variant: %w", err)
 	}
@@ -91,7 +91,7 @@ func (db postgres) optionTypes(ctx context.Context, productID string) ([]OptionT
 
 func (db postgres) variants(ctx context.Context, productID string) ([]Variant, error) {
 	rows, err := db.db.QueryContext(ctx, `
-		SELECT id, sku, price_amount, price_currency, options FROM productcatalog_variant
+		SELECT id, sku, image_url, price_amount, price_currency, options FROM productcatalog_variant
 		WHERE product_id = $1 ORDER BY position
 	`, productID)
 	if err != nil {
@@ -215,10 +215,10 @@ func scanProduct(s rowScanner) (Product, error) {
 }
 
 func scanVariant(s rowScanner) (Variant, error) {
-	var id, sku, currency string
+	var id, sku, image, currency string
 	var amount int64
 	var optionsRaw []byte
-	if err := s.Scan(&id, &sku, &amount, &currency, &optionsRaw); err != nil {
+	if err := s.Scan(&id, &sku, &image, &amount, &currency, &optionsRaw); err != nil {
 		return Variant{}, err
 	}
 	cur, err := NewCurrency(currency)
@@ -233,5 +233,5 @@ func scanVariant(s rowScanner) (Variant, error) {
 	if err := json.Unmarshal(optionsRaw, &options); err != nil {
 		return Variant{}, fmt.Errorf("unmarshal variant options: %w", err)
 	}
-	return NewVariant(id, sku, options, price), nil
+	return NewVariant(id, sku, image, options, price), nil
 }

--- a/backend/productcatalog/app_product.go
+++ b/backend/productcatalog/app_product.go
@@ -61,8 +61,8 @@ func (ps ProductService) Add(ctx context.Context, id, name, desc string, priceMi
 	}
 
 	// A simple product is purchasable through a single default variant
-	// carrying its price (no options).
-	defaultVariant := NewVariant("var-"+id, id, nil, priceVO)
+	// carrying its price (no options) and the product image.
+	defaultVariant := NewVariant("var-"+id, id, thumbnail, nil, priceVO)
 	return ps.storage.AddVariant(ctx, id, 0, defaultVariant)
 }
 
@@ -76,6 +76,7 @@ type OptionTypeInput struct {
 type VariantInput struct {
 	ID      string
 	SKU     string
+	Image   string
 	Options map[string]string
 	Price   int64
 }
@@ -125,7 +126,7 @@ func (ps ProductService) AddVariantProduct(ctx context.Context, id, name, desc, 
 		if err != nil {
 			return fmt.Errorf("invalid variant price: %w", err)
 		}
-		if err = ps.storage.AddVariant(ctx, id, i, NewVariant(v.ID, v.SKU, v.Options, price)); err != nil {
+		if err = ps.storage.AddVariant(ctx, id, i, NewVariant(v.ID, v.SKU, v.Image, v.Options, price)); err != nil {
 			return err
 		}
 	}

--- a/backend/productcatalog/domain_variant.go
+++ b/backend/productcatalog/domain_variant.go
@@ -22,19 +22,21 @@ func (o OptionType) Values() []string { return o.values }
 type Variant struct {
 	id      string
 	sku     string
+	image   string
 	options map[string]string // e.g. {"Color":"Red","Size":"L"}
 	price   Price
 }
 
-func NewVariant(id, sku string, options map[string]string, price Price) Variant {
+func NewVariant(id, sku, image string, options map[string]string, price Price) Variant {
 	if options == nil {
 		options = map[string]string{}
 	}
-	return Variant{id: id, sku: sku, options: options, price: price}
+	return Variant{id: id, sku: sku, image: image, options: options, price: price}
 }
 
 func (v Variant) ID() string                 { return v.id }
 func (v Variant) SKU() string                { return v.sku }
+func (v Variant) Image() string              { return v.image }
 func (v Variant) Options() map[string]string { return v.options }
 func (v Variant) Price() Price               { return v.price }
 func (v Variant) IsZero() bool               { return v.id == "" }

--- a/migrations/000012_productcatalog_variant_image.up.sql
+++ b/migrations/000012_productcatalog_variant_image.up.sql
@@ -1,0 +1,13 @@
+BEGIN;
+
+ALTER TABLE public.productcatalog_variant
+    ADD COLUMN image_url varchar NOT NULL DEFAULT '';
+
+-- Existing variants (the default ones created for pre-variant products)
+-- inherit their product's thumbnail so the product page still shows an image.
+UPDATE public.productcatalog_variant v
+SET image_url = p.thumbnail
+FROM public.productcatalog_product p
+WHERE v.product_id = p.id AND v.image_url = '';
+
+COMMIT;


### PR DESCRIPTION
Each variant carries its own image. On the product page, changing an option re-resolves the variant and swaps the displayed image via an HTMX out-of-band update — picking a colour shows that colour's photo; picking a different size keeps the same colour image.

## Changes
- `Variant` gains an image; migration `000012` adds `image_url` to `productcatalog_variant`, backfilling existing default variants with the product thumbnail.
- adapter + `ProductService.Add` (default variant = product thumbnail) + `AddVariantProduct` (`VariantInput.Image`).
- product page: `<img id="product-image">`; `GET /product/{id}/variant` returns the variant box + `<img hx-swap-oob="true" id="product-image">`.
- seeds: mug Cream/Charcoal + apron Natural/Navy per-colour images.

## Test plan
- [x] initial page shows default-variant image
- [x] resolve Navy/L → OOB navy image + add-to-cart for that variant
- [x] resolve Natural/M → keeps the colour image
- [x] existing default variants backfilled with thumbnail
- [x] build / vet / tests / lint green