### PR TITLE
feat(cli): author product variants from product-add

### DIFF
--- a/backend/cmd/cli/productcatalog.go
+++ b/backend/cmd/cli/productcatalog.go
@@ -2,7 +2,10 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"log"
+	"strconv"
+	"strings"
 
 	"github.com/bkielbasa/go-ecommerce/backend/productcatalog"
 	"github.com/spf13/cobra"
@@ -30,13 +33,44 @@ func newProductCatalogCmd(pc productCatalog) *cobra.Command {
 func newProductCatalogAddCmd(pc productCatalog) *cobra.Command {
 	var price int64
 	var id, name, shortDesc, currency, thumbnail string
+	var optionFlags, variantFlags []string
 
 	cmd := &cobra.Command{
-		Use: "product-add",
-		RunE: func(cmd *cobra.Command, args []string) error {
+		Use:   "product-add",
+		Short: "Add a product. Use --option/--variant to author variants, or --price for a simple product.",
+		Long: `Add a product to the catalog.
 
-			err := pc.Add(cmd.Context(), id, name, shortDesc, price, currency, thumbnail)
-			return err
+Simple product (single price):
+  product-add --id mug --name "Mug" --price 2400 --thumbnail URL
+
+Product with variants (each variant priced independently):
+  product-add --id mug --name "Mug" \
+    --option "Color:Cream,Charcoal" \
+    --variant "Color=Cream;2400;MUG-CRM;IMG_URL" \
+    --variant "Color=Charcoal;2600;MUG-CHR;IMG_URL"
+
+--option grammar:  "<Name>:<v1>,<v2>,..."
+--variant grammar: "<opt1>=<val1>,<opt2>=<val2>;<priceMinorUnits>[;<sku>[;<imageURL>]]"
+  (leave the options part empty for a single default variant)`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+
+			if len(variantFlags) > 0 {
+				optionTypes, err := parseOptionTypes(optionFlags)
+				if err != nil {
+					return err
+				}
+				variants, err := parseVariants(variantFlags, id)
+				if err != nil {
+					return err
+				}
+				return pc.AddVariantProduct(ctx, id, name, shortDesc, currency, thumbnail, optionTypes, variants)
+			}
+
+			if !cmd.Flags().Changed("price") {
+				return fmt.Errorf("--price is required for a simple product (or pass --variant to author variants)")
+			}
+			return pc.Add(ctx, id, name, shortDesc, price, currency, thumbnail)
 		},
 	}
 
@@ -50,18 +84,75 @@ func newProductCatalogAddCmd(pc productCatalog) *cobra.Command {
 		log.Print(err)
 	}
 
-	cmd.Flags().Int64VarP(&price, "price", "", 0, "product price in minor units (e.g. cents)")
-	if err := cmd.MarkFlagRequired("price"); err != nil {
-		log.Print(err)
-	}
-
-	cmd.Flags().StringVarP(&currency, "currency", "c", "USD", "product price")
-	if err := cmd.MarkFlagRequired("currency"); err != nil {
-		log.Print(err)
-	}
-
+	cmd.Flags().Int64VarP(&price, "price", "", 0, "product price in minor units (e.g. cents) — for a simple product")
+	cmd.Flags().StringVarP(&currency, "currency", "c", "USD", "ISO 4217 currency code")
 	cmd.Flags().StringVarP(&shortDesc, "short-desc", "s", "", "product short description")
 	cmd.Flags().StringVarP(&thumbnail, "thumbnail", "t", "", "product thumbnail URL")
+	cmd.Flags().StringArrayVar(&optionFlags, "option", nil, `option type, repeatable: "Color:Cream,Charcoal"`)
+	cmd.Flags().StringArrayVar(&variantFlags, "variant", nil, `variant, repeatable: "Color=Cream;2400;SKU;IMG"`)
 
 	return cmd
+}
+
+func parseOptionTypes(flags []string) ([]productcatalog.OptionTypeInput, error) {
+	out := make([]productcatalog.OptionTypeInput, 0, len(flags))
+	for _, f := range flags {
+		name, valuesCSV, found := strings.Cut(f, ":")
+		name = strings.TrimSpace(name)
+		if !found || name == "" {
+			return nil, fmt.Errorf("--option %q must be \"Name:v1,v2,...\"", f)
+		}
+		var values []string
+		for _, v := range strings.Split(valuesCSV, ",") {
+			if v = strings.TrimSpace(v); v != "" {
+				values = append(values, v)
+			}
+		}
+		if len(values) == 0 {
+			return nil, fmt.Errorf("--option %q has no values", f)
+		}
+		out = append(out, productcatalog.OptionTypeInput{Name: name, Values: values})
+	}
+	return out, nil
+}
+
+func parseVariants(flags []string, productID string) ([]productcatalog.VariantInput, error) {
+	out := make([]productcatalog.VariantInput, 0, len(flags))
+	for i, f := range flags {
+		parts := strings.Split(f, ";")
+		if len(parts) < 2 {
+			return nil, fmt.Errorf("--variant %q must be \"opts;price[;sku[;image]]\"", f)
+		}
+
+		price, err := strconv.ParseInt(strings.TrimSpace(parts[1]), 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("--variant %q: price must be an integer (minor units): %w", f, err)
+		}
+
+		var sku, image string
+		if len(parts) >= 3 {
+			sku = strings.TrimSpace(parts[2])
+		}
+		if len(parts) >= 4 {
+			image = strings.TrimSpace(parts[3])
+		}
+
+		options := map[string]string{}
+		if optsCSV := strings.TrimSpace(parts[0]); optsCSV != "" {
+			for _, kv := range strings.Split(optsCSV, ",") {
+				k, v, found := strings.Cut(kv, "=")
+				if !found || strings.TrimSpace(k) == "" {
+					return nil, fmt.Errorf("--variant %q: option %q must be \"Name=Value\"", f, kv)
+				}
+				options[strings.TrimSpace(k)] = strings.TrimSpace(v)
+			}
+		}
+
+		vid := fmt.Sprintf("%s-%d", productID, i)
+		if sku != "" {
+			vid = productID + "-" + strings.ToLower(sku)
+		}
+		out = append(out, productcatalog.VariantInput{ID: vid, SKU: sku, Image: image, Options: options, Price: price})
+	}
+	return out, nil
 }


### PR DESCRIPTION
`product-add` can now create variant products via two repeatable flags:

    --option  "Color:Cream,Charcoal"
    --variant "Color=Cream;2400;MUG-CRM;IMG_URL"

Any `--variant` → builds a full variant product (per-variant price/sku/image). No `--variant` → simple product, and `--price` is now explicitly required (was silently defaulting to 0); `--price` is no longer a hard-required flag so variant products don't need a meaningless product-level price.

Grammar: `"<opt1>=<v1>,<opt2>=<v2>;<priceMinorUnits>[;<sku>[;<image>]]"` (empty options = single default variant). Variant ids derived from product id + sku (or index).

## Test plan
- [x] simple product → default variant
- [x] two-colour tee → option type + two priced/imaged variants; renders on product page (select White → $23 + white image + add-to-cart for that variant)
- [x] missing --price on a simple product rejected with a clear message
- [x] build / vet / lint green