### PR TITLE
feat(catalog): per-variant stock / inventory

### DIFF
--- a/backend/cart/bounded_context.go
+++ b/backend/cart/bounded_context.go
@@ -49,6 +49,10 @@ func (tpc transformProductCatalog) Find(ctx context.Context, variantID string) (
 		return domain.Product{}, err
 	}
 
+	if !v.InStock() {
+		return domain.Product{}, domain.ErrOutOfStock
+	}
+
 	cur, err := domain.NewCurrency(string(v.Price().Currency()))
 	if err != nil {
 		return domain.Product{}, fmt.Errorf("cart: invalid currency from product catalog: %w", err)

--- a/backend/cart/domain/product.go
+++ b/backend/cart/domain/product.go
@@ -7,8 +7,9 @@ import (
 )
 
 var (
-	ErrProductNotFound   = errors.New("product not found")
-	ErrCurrencyMismatch  = errors.New("currency mismatch")
+	ErrProductNotFound  = errors.New("product not found")
+	ErrCurrencyMismatch = errors.New("currency mismatch")
+	ErrOutOfStock       = errors.New("variant is out of stock")
 )
 
 // Currency is an ISO 4217 three-letter currency code.

--- a/backend/checkout/app/checkout.go
+++ b/backend/checkout/app/checkout.go
@@ -37,6 +37,12 @@ type PaymentProcessor interface {
 	Charge(ctx context.Context, amount int64, currency, cardNumber string) error
 }
 
+// StockReducer decrements catalogue stock for an ordered variant. Implemented
+// by the product catalogue; checkout calls it once an order is paid.
+type StockReducer interface {
+	ReduceStock(ctx context.Context, variantID string, qty int) error
+}
+
 // IDGenerator returns a fresh order ID. Injected so tests can substitute a
 // deterministic generator.
 type IDGenerator func() string
@@ -46,6 +52,7 @@ type CheckoutService struct {
 	cartClr CartClearer
 	storage OrderStorage
 	payment PaymentProcessor
+	stock   StockReducer
 	newID   IDGenerator
 	now     func() time.Time
 }
@@ -55,6 +62,7 @@ func NewCheckoutService(
 	cartClr CartClearer,
 	storage OrderStorage,
 	payment PaymentProcessor,
+	stock StockReducer,
 	newID IDGenerator,
 ) CheckoutService {
 	return CheckoutService{
@@ -62,6 +70,7 @@ func NewCheckoutService(
 		cartClr: cartClr,
 		storage: storage,
 		payment: payment,
+		stock:   stock,
 		newID:   newID,
 		now:     func() time.Time { return time.Now().UTC() },
 	}
@@ -114,6 +123,13 @@ func (s CheckoutService) Place(ctx context.Context, sessID, customerID, cardNumb
 	order.MarkPaid(s.now())
 	if err := s.storage.Save(ctx, order); err != nil {
 		return domain.Order{}, fmt.Errorf("save order: %w", err)
+	}
+
+	// Decrement catalogue stock for each purchased variant (the cart line id
+	// is the variant id). Best-effort: the order is already placed, so a
+	// stock-update failure shouldn't fail the checkout.
+	for _, item := range cart.Items() {
+		_ = s.stock.ReduceStock(ctx, item.Product().ID(), item.Quantity())
 	}
 
 	// Cart clear failure is non-fatal — the order is already placed and the

--- a/backend/checkout/bounded_context.go
+++ b/backend/checkout/bounded_context.go
@@ -23,10 +23,16 @@ type CartClearer interface {
 	Clear(ctx context.Context, sessID string) error
 }
 
-func New(db *sql.DB, cart CartReader, cartClr CartClearer) (application.BoundedContext, app.CheckoutService) {
+// StockReducer is implemented by the product catalogue; checkout calls it to
+// decrement variant stock once an order is paid.
+type StockReducer interface {
+	ReduceStock(ctx context.Context, variantID string, qty int) error
+}
+
+func New(db *sql.DB, cart CartReader, cartClr CartClearer, stock StockReducer) (application.BoundedContext, app.CheckoutService) {
 	storage := adapter.NewPostgres(db)
 	payment := adapter.NewFakePayment()
-	srv := app.NewCheckoutService(cart, cartClr, storage, payment, newOrderID)
+	srv := app.NewCheckoutService(cart, cartClr, storage, payment, stock, newOrderID)
 	return &boundedContext{}, srv
 }
 

--- a/backend/cmd/cli/productcatalog.go
+++ b/backend/cmd/cli/productcatalog.go
@@ -50,8 +50,8 @@ Product with variants (each variant priced independently):
     --variant "Color=Charcoal;2600;MUG-CHR;IMG_URL"
 
 --option grammar:  "<Name>:<v1>,<v2>,..."
---variant grammar: "<opt1>=<val1>,<opt2>=<val2>;<priceMinorUnits>[;<sku>[;<imageURL>]]"
-  (leave the options part empty for a single default variant)`,
+--variant grammar: "<opt1>=<val1>,<opt2>=<val2>;<priceMinorUnits>[;<sku>[;<imageURL>[;<stock>]]]"
+  (leave the options part empty for a single default variant; stock defaults to 100)`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 
@@ -130,11 +130,19 @@ func parseVariants(flags []string, productID string) ([]productcatalog.VariantIn
 		}
 
 		var sku, image string
+		stock := 100
 		if len(parts) >= 3 {
 			sku = strings.TrimSpace(parts[2])
 		}
 		if len(parts) >= 4 {
 			image = strings.TrimSpace(parts[3])
+		}
+		if len(parts) >= 5 {
+			s, err := strconv.Atoi(strings.TrimSpace(parts[4]))
+			if err != nil {
+				return nil, fmt.Errorf("--variant %q: stock must be an integer: %w", f, err)
+			}
+			stock = s
 		}
 
 		options := map[string]string{}
@@ -152,7 +160,7 @@ func parseVariants(flags []string, productID string) ([]productcatalog.VariantIn
 		if sku != "" {
 			vid = productID + "-" + strings.ToLower(sku)
 		}
-		out = append(out, productcatalog.VariantInput{ID: vid, SKU: sku, Image: image, Options: options, Price: price})
+		out = append(out, productcatalog.VariantInput{ID: vid, SKU: sku, Image: image, Options: options, Price: price, Stock: stock})
 	}
 	return out, nil
 }

--- a/backend/cmd/cli/seeds.go
+++ b/backend/cmd/cli/seeds.go
@@ -120,8 +120,8 @@ var variantSeeds = []variantSeed{
 			{Name: "Color", Values: []string{"Cream", "Charcoal"}},
 		},
 		variants: []productcatalog.VariantInput{
-			{ID: "ceramic-mug-cream", SKU: "MUG-CRM", Options: map[string]string{"Color": "Cream"}, Price: 2400, Image: "https://loremflickr.com/800/800/ceramic,mug,cream?lock=11"},
-			{ID: "ceramic-mug-charcoal", SKU: "MUG-CHR", Options: map[string]string{"Color": "Charcoal"}, Price: 2600, Image: "https://loremflickr.com/800/800/ceramic,mug,black?lock=211"},
+			{ID: "ceramic-mug-cream", SKU: "MUG-CRM", Options: map[string]string{"Color": "Cream"}, Price: 2400, Image: "https://loremflickr.com/800/800/ceramic,mug,cream?lock=11", Stock: 40},
+			{ID: "ceramic-mug-charcoal", SKU: "MUG-CHR", Options: map[string]string{"Color": "Charcoal"}, Price: 2600, Image: "https://loremflickr.com/800/800/ceramic,mug,black?lock=211", Stock: 0},
 		},
 	},
 	{
@@ -135,12 +135,12 @@ var variantSeeds = []variantSeed{
 			{Name: "Size", Values: []string{"S", "M", "L"}},
 		},
 		variants: []productcatalog.VariantInput{
-			{ID: "linen-apron-nat-s", SKU: "APR-NAT-S", Options: map[string]string{"Color": "Natural", "Size": "S"}, Price: 5400, Image: natApron},
-			{ID: "linen-apron-nat-m", SKU: "APR-NAT-M", Options: map[string]string{"Color": "Natural", "Size": "M"}, Price: 5800, Image: natApron},
-			{ID: "linen-apron-nat-l", SKU: "APR-NAT-L", Options: map[string]string{"Color": "Natural", "Size": "L"}, Price: 6200, Image: natApron},
-			{ID: "linen-apron-navy-s", SKU: "APR-NVY-S", Options: map[string]string{"Color": "Navy", "Size": "S"}, Price: 5600, Image: navyApron},
-			{ID: "linen-apron-navy-m", SKU: "APR-NVY-M", Options: map[string]string{"Color": "Navy", "Size": "M"}, Price: 6000, Image: navyApron},
-			{ID: "linen-apron-navy-l", SKU: "APR-NVY-L", Options: map[string]string{"Color": "Navy", "Size": "L"}, Price: 6400, Image: navyApron},
+			{ID: "linen-apron-nat-s", SKU: "APR-NAT-S", Options: map[string]string{"Color": "Natural", "Size": "S"}, Price: 5400, Image: natApron, Stock: 12},
+			{ID: "linen-apron-nat-m", SKU: "APR-NAT-M", Options: map[string]string{"Color": "Natural", "Size": "M"}, Price: 5800, Image: natApron, Stock: 8},
+			{ID: "linen-apron-nat-l", SKU: "APR-NAT-L", Options: map[string]string{"Color": "Natural", "Size": "L"}, Price: 6200, Image: natApron, Stock: 5},
+			{ID: "linen-apron-navy-s", SKU: "APR-NVY-S", Options: map[string]string{"Color": "Navy", "Size": "S"}, Price: 5600, Image: navyApron, Stock: 10},
+			{ID: "linen-apron-navy-m", SKU: "APR-NVY-M", Options: map[string]string{"Color": "Navy", "Size": "M"}, Price: 6000, Image: navyApron, Stock: 6},
+			{ID: "linen-apron-navy-l", SKU: "APR-NVY-L", Options: map[string]string{"Color": "Navy", "Size": "L"}, Price: 6400, Image: navyApron, Stock: 3},
 		},
 	},
 }

--- a/backend/cmd/web/main.go
+++ b/backend/cmd/web/main.go
@@ -79,7 +79,7 @@ func main() {
 	pcBD, catalogService := productcatalog.New(db)
 	cartBD, cartSrv := cart.New(db, logger, catalogService)
 	authBD, authService := auth.New(db)
-	checkoutBD, checkoutSrv := checkout.New(db, cartSrv, cartSrv)
+	checkoutBD, checkoutSrv := checkout.New(db, cartSrv, cartSrv, catalogService)
 	shipSrv := shippinginfo.New(db)
 	app.AddBoundedContext(cartBD)
 

--- a/backend/layout/http_cart.go
+++ b/backend/layout/http_cart.go
@@ -25,6 +25,11 @@ func (handler httpHandler) AddToCart(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if errors.Is(err, domain.ErrOutOfStock) {
+		http.Error(w, "this item is out of stock", http.StatusConflict)
+		return
+	}
+
 	if err != nil {
 		https.InternalError(w, "internal-error", err.Error())
 		log.Print(err)

--- a/backend/layout/static/main.css
+++ b/backend/layout/static/main.css
@@ -258,6 +258,10 @@ main {
 }
 .variant-form select:focus { border-bottom-color: var(--fg); }
 .variant-box { display: flex; flex-direction: column; gap: var(--space-2); }
+.stock { font-size: 0.85rem; }
+.stock--in { color: var(--fg-muted); }
+.stock--low { color: #B8860B; }
+.stock--out { color: var(--danger); text-transform: lowercase; }
 
 /* ---------- buttons ---------- */
 .btn {

--- a/backend/layout/tmpl/partials/variant-box.gohtml
+++ b/backend/layout/tmpl/partials/variant-box.gohtml
@@ -4,12 +4,21 @@
     <p class="product__price muted">that combination isn't available</p>
   {{else}}
     <p class="product__price">{{.Variant.Price.Display}} {{.Variant.Price.Currency}}</p>
-    <button class="btn"
-            hx-post="/cart/{{.Variant.ID}}"
-            hx-swap="none">
-      add to cart
-      <span class="loading htmx-indicator" aria-hidden="true"></span>
-    </button>
+    {{if .Variant.InStock}}
+      {{if .Variant.LowStock}}
+        <p class="stock stock--low">only {{.Variant.Stock}} left</p>
+      {{else}}
+        <p class="stock stock--in">in stock</p>
+      {{end}}
+      <button class="btn"
+              hx-post="/cart/{{.Variant.ID}}"
+              hx-swap="none">
+        add to cart
+        <span class="loading htmx-indicator" aria-hidden="true"></span>
+      </button>
+    {{else}}
+      <p class="stock stock--out">out of stock</p>
+    {{end}}
   {{end}}
 </div>
 {{end}}

--- a/backend/productcatalog/adapter_inmemory.go
+++ b/backend/productcatalog/adapter_inmemory.go
@@ -53,6 +53,22 @@ func (im *inMemory) Find(ctx context.Context, id string) (Product, error) {
 	return Product{}, ErrProductNotFound
 }
 
+func (im *inMemory) ReduceStock(ctx context.Context, variantID string, qty int) error {
+	for pid, vs := range im.variants {
+		for i, v := range vs {
+			if v.ID() == variantID {
+				newStock := v.Stock() - qty
+				if newStock < 0 {
+					newStock = 0
+				}
+				im.variants[pid][i] = NewVariant(v.ID(), v.SKU(), v.Image(), v.Options(), v.Price(), newStock)
+				return nil
+			}
+		}
+	}
+	return ErrProductNotFound
+}
+
 func (im *inMemory) FindVariant(ctx context.Context, variantID string) (Product, Variant, error) {
 	for _, p := range im.products {
 		full := im.hydrate(p)

--- a/backend/productcatalog/adapter_postgres.go
+++ b/backend/productcatalog/adapter_postgres.go
@@ -54,9 +54,9 @@ func (db postgres) AddVariant(ctx context.Context, productID string, position in
 		return fmt.Errorf("marshal variant options: %w", err)
 	}
 	_, err = db.db.ExecContext(ctx, `
-		INSERT INTO productcatalog_variant (id, product_id, sku, image_url, price_amount, price_currency, position, options)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
-	`, v.ID(), productID, v.SKU(), v.Image(), v.Price().Amount(), string(v.Price().Currency()), position, options)
+		INSERT INTO productcatalog_variant (id, product_id, sku, image_url, price_amount, price_currency, position, options, stock)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+	`, v.ID(), productID, v.SKU(), v.Image(), v.Price().Amount(), string(v.Price().Currency()), position, options, v.Stock())
 	if err != nil {
 		return fmt.Errorf("add variant: %w", err)
 	}
@@ -91,7 +91,7 @@ func (db postgres) optionTypes(ctx context.Context, productID string) ([]OptionT
 
 func (db postgres) variants(ctx context.Context, productID string) ([]Variant, error) {
 	rows, err := db.db.QueryContext(ctx, `
-		SELECT id, sku, image_url, price_amount, price_currency, options FROM productcatalog_variant
+		SELECT id, sku, image_url, price_amount, price_currency, options, stock FROM productcatalog_variant
 		WHERE product_id = $1 ORDER BY position
 	`, productID)
 	if err != nil {
@@ -217,8 +217,9 @@ func scanProduct(s rowScanner) (Product, error) {
 func scanVariant(s rowScanner) (Variant, error) {
 	var id, sku, image, currency string
 	var amount int64
+	var stock int
 	var optionsRaw []byte
-	if err := s.Scan(&id, &sku, &image, &amount, &currency, &optionsRaw); err != nil {
+	if err := s.Scan(&id, &sku, &image, &amount, &currency, &optionsRaw, &stock); err != nil {
 		return Variant{}, err
 	}
 	cur, err := NewCurrency(currency)
@@ -233,5 +234,16 @@ func scanVariant(s rowScanner) (Variant, error) {
 	if err := json.Unmarshal(optionsRaw, &options); err != nil {
 		return Variant{}, fmt.Errorf("unmarshal variant options: %w", err)
 	}
-	return NewVariant(id, sku, image, options, price), nil
+	return NewVariant(id, sku, image, options, price, stock), nil
+}
+
+// ReduceStock decrements a variant's stock by qty, clamped at zero.
+func (db postgres) ReduceStock(ctx context.Context, variantID string, qty int) error {
+	_, err := db.db.ExecContext(ctx, `
+		UPDATE productcatalog_variant SET stock = GREATEST(0, stock - $2) WHERE id = $1
+	`, variantID, qty)
+	if err != nil {
+		return fmt.Errorf("reduce stock: %w", err)
+	}
+	return nil
 }

--- a/backend/productcatalog/app_product.go
+++ b/backend/productcatalog/app_product.go
@@ -16,6 +16,7 @@ type ProductStorage interface {
 	FindVariant(ctx context.Context, variantID string) (Product, Variant, error)
 	AddOptionType(ctx context.Context, productID string, position int, ot OptionType) error
 	AddVariant(ctx context.Context, productID string, position int, v Variant) error
+	ReduceStock(ctx context.Context, variantID string, qty int) error
 }
 
 func NewProductService(s ProductStorage) ProductService {
@@ -34,6 +35,14 @@ func (ps ProductService) Find(ctx context.Context, id string) (Product, error) {
 func (ps ProductService) FindVariant(ctx context.Context, variantID string) (Product, Variant, error) {
 	return ps.storage.FindVariant(ctx, variantID)
 }
+
+// ReduceStock decrements a variant's stock (called when an order is placed).
+func (ps ProductService) ReduceStock(ctx context.Context, variantID string, qty int) error {
+	return ps.storage.ReduceStock(ctx, variantID, qty)
+}
+
+// defaultStock is given to a simple product's auto-created default variant.
+const defaultStock = 100
 
 func (ps ProductService) Add(ctx context.Context, id, name, desc string, priceMinorUnits int64, currency, thumbnail string) error {
 	pId, err := NewProductId(id)
@@ -62,7 +71,7 @@ func (ps ProductService) Add(ctx context.Context, id, name, desc string, priceMi
 
 	// A simple product is purchasable through a single default variant
 	// carrying its price (no options) and the product image.
-	defaultVariant := NewVariant("var-"+id, id, thumbnail, nil, priceVO)
+	defaultVariant := NewVariant("var-"+id, id, thumbnail, nil, priceVO, defaultStock)
 	return ps.storage.AddVariant(ctx, id, 0, defaultVariant)
 }
 
@@ -79,6 +88,7 @@ type VariantInput struct {
 	Image   string
 	Options map[string]string
 	Price   int64
+	Stock   int
 }
 
 // AddVariantProduct creates a product with explicit option types and variants
@@ -126,7 +136,7 @@ func (ps ProductService) AddVariantProduct(ctx context.Context, id, name, desc, 
 		if err != nil {
 			return fmt.Errorf("invalid variant price: %w", err)
 		}
-		if err = ps.storage.AddVariant(ctx, id, i, NewVariant(v.ID, v.SKU, v.Image, v.Options, price)); err != nil {
+		if err = ps.storage.AddVariant(ctx, id, i, NewVariant(v.ID, v.SKU, v.Image, v.Options, price, v.Stock)); err != nil {
 			return err
 		}
 	}

--- a/backend/productcatalog/domain_variant.go
+++ b/backend/productcatalog/domain_variant.go
@@ -19,19 +19,24 @@ func (o OptionType) Values() []string { return o.values }
 // Variant is a concrete, purchasable version of a product — a specific
 // combination of option values with its own price. A product with no options
 // has a single default variant whose options map is empty.
+// lowStockThreshold is the level at or below which the UI nudges with
+// "only N left".
+const lowStockThreshold = 5
+
 type Variant struct {
 	id      string
 	sku     string
 	image   string
 	options map[string]string // e.g. {"Color":"Red","Size":"L"}
 	price   Price
+	stock   int
 }
 
-func NewVariant(id, sku, image string, options map[string]string, price Price) Variant {
+func NewVariant(id, sku, image string, options map[string]string, price Price, stock int) Variant {
 	if options == nil {
 		options = map[string]string{}
 	}
-	return Variant{id: id, sku: sku, image: image, options: options, price: price}
+	return Variant{id: id, sku: sku, image: image, options: options, price: price, stock: stock}
 }
 
 func (v Variant) ID() string                 { return v.id }
@@ -39,6 +44,9 @@ func (v Variant) SKU() string                { return v.sku }
 func (v Variant) Image() string              { return v.image }
 func (v Variant) Options() map[string]string { return v.options }
 func (v Variant) Price() Price               { return v.price }
+func (v Variant) Stock() int                 { return v.stock }
+func (v Variant) InStock() bool              { return v.stock > 0 }
+func (v Variant) LowStock() bool             { return v.stock > 0 && v.stock <= lowStockThreshold }
 func (v Variant) IsZero() bool               { return v.id == "" }
 
 // Label builds a human label from the variant's option values, in the

--- a/backend/productcatalog/productcatalog_test.go
+++ b/backend/productcatalog/productcatalog_test.go
@@ -17,6 +17,7 @@ type productStorage interface {
 	FindVariant(ctx context.Context, variantID string) (productcatalog.Product, productcatalog.Variant, error)
 	AddOptionType(ctx context.Context, productID string, position int, ot productcatalog.OptionType) error
 	AddVariant(ctx context.Context, productID string, position int, v productcatalog.Variant) error
+	ReduceStock(ctx context.Context, variantID string, qty int) error
 }
 
 var storage productStorage

--- a/migrations/000013_productcatalog_variant_stock.up.sql
+++ b/migrations/000013_productcatalog_variant_stock.up.sql
@@ -1,0 +1,10 @@
+BEGIN;
+
+ALTER TABLE public.productcatalog_variant
+    ADD COLUMN stock integer NOT NULL DEFAULT 0;
+
+-- Existing variants start well-stocked so nothing is unexpectedly
+-- unavailable after the column is added.
+UPDATE public.productcatalog_variant SET stock = 100;
+
+COMMIT;


### PR DESCRIPTION
Each variant tracks a stock count; the storefront reflects availability and stock is decremented when an order is placed.

## Changes
- domain `Variant` gains stock + `InStock`/`LowStock` (≤5); migration `000013` adds the column (backfill 100).
- adapter + `ProductService.ReduceStock` (`UPDATE ... GREATEST(0, stock-qty)`); `Add` default variant = 100; `AddVariantProduct`/`VariantInput` carry per-variant stock.
- product page: "in stock" / "only N left" / "out of stock"; add-to-cart only renders when in stock.
- cart: ACL rejects out-of-stock variant (`ErrOutOfStock`); add-to-cart handler → HTTP 409.
- checkout: decrements each purchased variant's stock once paid (new `StockReducer`).
- seeds: charcoal mug out of stock, navy/L apron low (3); CLI `--variant` gains optional 5th stock field (default 100).

**Known limitation:** decrement is post-placement, clamped at 0 — concurrent orders could oversell. A real system would reserve/verify transactionally at checkout.

## Test plan
- [x] OOS variant: no button + POST returns 409
- [x] low stock shows "only 3 left"
- [x] placing an order decremented stock (40 → 39)
- [x] build / vet / tests / lint green