### PR TITLE
feat(checkout): atomic stock reservation to prevent overselling

### DIFF
--- a/backend/checkout/app/checkout.go
+++ b/backend/checkout/app/checkout.go
@@ -37,10 +37,13 @@ type PaymentProcessor interface {
 	Charge(ctx context.Context, amount int64, currency, cardNumber string) error
 }
 
-// StockReducer decrements catalogue stock for an ordered variant. Implemented
-// by the product catalogue; checkout calls it once an order is paid.
-type StockReducer interface {
-	ReduceStock(ctx context.Context, variantID string, qty int) error
+// StockReserver atomically reserves (decrements) catalogue stock for the
+// ordered variants, all-or-nothing, returning a non-nil error if any variant
+// is short. Release returns reserved stock if the order can't complete.
+// Implemented by the product catalogue.
+type StockReserver interface {
+	Reserve(ctx context.Context, quantities map[string]int) error
+	Release(ctx context.Context, quantities map[string]int) error
 }
 
 // IDGenerator returns a fresh order ID. Injected so tests can substitute a
@@ -52,7 +55,7 @@ type CheckoutService struct {
 	cartClr CartClearer
 	storage OrderStorage
 	payment PaymentProcessor
-	stock   StockReducer
+	stock   StockReserver
 	newID   IDGenerator
 	now     func() time.Time
 }
@@ -62,7 +65,7 @@ func NewCheckoutService(
 	cartClr CartClearer,
 	storage OrderStorage,
 	payment PaymentProcessor,
-	stock StockReducer,
+	stock StockReserver,
 	newID IDGenerator,
 ) CheckoutService {
 	return CheckoutService{
@@ -97,6 +100,7 @@ func (s CheckoutService) Place(ctx context.Context, sessID, customerID, cardNumb
 	}
 
 	lines := make([]domain.Line, 0, len(cart.Items()))
+	quantities := map[string]int{}
 	for _, item := range cart.Items() {
 		lines = append(lines, domain.NewLine(
 			item.Product().ID(),
@@ -105,14 +109,26 @@ func (s CheckoutService) Place(ctx context.Context, sessID, customerID, cardNumb
 			item.Product().Price().Amount(),
 			string(item.Product().Price().Currency()),
 		))
+		quantities[item.Product().ID()] += item.Quantity()
+	}
+
+	// Reserve stock up front, atomically. If anything is short the order is
+	// not placed at all — this is the guard against overselling under
+	// concurrent checkouts.
+	if err := s.stock.Reserve(ctx, quantities); err != nil {
+		return domain.Order{}, fmt.Errorf("reserve stock: %w", err)
 	}
 
 	order, err := domain.PlaceOrder(s.newID(), sessID, customerID, shipTo, shipMethod, payMethod, lines, s.now())
 	if err != nil {
+		_ = s.stock.Release(ctx, quantities)
 		return domain.Order{}, err
 	}
 
 	if chargeErr := s.payment.Charge(ctx, order.TotalAmount(), order.TotalCurrency(), cardNumber); chargeErr != nil {
+		// Payment failed after reserving — give the stock back, record the
+		// failed attempt, and report the decline.
+		_ = s.stock.Release(ctx, quantities)
 		order.MarkFailed(chargeErr.Error(), s.now())
 		if err := s.storage.Save(ctx, order); err != nil {
 			return domain.Order{}, fmt.Errorf("save order: %w", err)
@@ -122,14 +138,9 @@ func (s CheckoutService) Place(ctx context.Context, sessID, customerID, cardNumb
 
 	order.MarkPaid(s.now())
 	if err := s.storage.Save(ctx, order); err != nil {
+		// Order couldn't be persisted; return the reservation.
+		_ = s.stock.Release(ctx, quantities)
 		return domain.Order{}, fmt.Errorf("save order: %w", err)
-	}
-
-	// Decrement catalogue stock for each purchased variant (the cart line id
-	// is the variant id). Best-effort: the order is already placed, so a
-	// stock-update failure shouldn't fail the checkout.
-	for _, item := range cart.Items() {
-		_ = s.stock.ReduceStock(ctx, item.Product().ID(), item.Quantity())
 	}
 
 	// Cart clear failure is non-fatal — the order is already placed and the

--- a/backend/checkout/bounded_context.go
+++ b/backend/checkout/bounded_context.go
@@ -23,13 +23,14 @@ type CartClearer interface {
 	Clear(ctx context.Context, sessID string) error
 }
 
-// StockReducer is implemented by the product catalogue; checkout calls it to
-// decrement variant stock once an order is paid.
-type StockReducer interface {
-	ReduceStock(ctx context.Context, variantID string, qty int) error
+// StockReserver is implemented by the product catalogue; checkout reserves
+// stock atomically before placing an order.
+type StockReserver interface {
+	Reserve(ctx context.Context, quantities map[string]int) error
+	Release(ctx context.Context, quantities map[string]int) error
 }
 
-func New(db *sql.DB, cart CartReader, cartClr CartClearer, stock StockReducer) (application.BoundedContext, app.CheckoutService) {
+func New(db *sql.DB, cart CartReader, cartClr CartClearer, stock StockReserver) (application.BoundedContext, app.CheckoutService) {
 	storage := adapter.NewPostgres(db)
 	payment := adapter.NewFakePayment()
 	srv := app.NewCheckoutService(cart, cartClr, storage, payment, stock, newOrderID)

--- a/backend/layout/http_checkout.go
+++ b/backend/layout/http_checkout.go
@@ -8,6 +8,7 @@ import (
 	cartDomain "github.com/bkielbasa/go-ecommerce/backend/cart/domain"
 	checkoutDomain "github.com/bkielbasa/go-ecommerce/backend/checkout/domain"
 	"github.com/bkielbasa/go-ecommerce/backend/internal/https"
+	"github.com/bkielbasa/go-ecommerce/backend/productcatalog"
 	"github.com/gorilla/mux"
 )
 
@@ -120,6 +121,11 @@ func (handler httpHandler) PlaceOrder(w http.ResponseWriter, r *http.Request) {
 
 	order, err := handler.checkoutSrv.Place(r.Context(), sessID, customerID, cardNumber, shipTo, method, payMethod)
 	if errors.Is(err, checkoutDomain.ErrCartEmpty) {
+		http.Redirect(w, r, "/cart", http.StatusSeeOther)
+		return
+	}
+	if errors.Is(err, productcatalog.ErrInsufficientStock) {
+		handler.flash(w, r, "Sorry — an item in your cart just went out of stock. Please review your cart.", "error")
 		http.Redirect(w, r, "/cart", http.StatusSeeOther)
 		return
 	}

--- a/backend/productcatalog/adapter_inmemory.go
+++ b/backend/productcatalog/adapter_inmemory.go
@@ -53,20 +53,42 @@ func (im *inMemory) Find(ctx context.Context, id string) (Product, error) {
 	return Product{}, ErrProductNotFound
 }
 
-func (im *inMemory) ReduceStock(ctx context.Context, variantID string, qty int) error {
+func (im *inMemory) find(variantID string) (string, int, bool) {
 	for pid, vs := range im.variants {
 		for i, v := range vs {
 			if v.ID() == variantID {
-				newStock := v.Stock() - qty
-				if newStock < 0 {
-					newStock = 0
-				}
-				im.variants[pid][i] = NewVariant(v.ID(), v.SKU(), v.Image(), v.Options(), v.Price(), newStock)
-				return nil
+				return pid, i, true
 			}
 		}
 	}
-	return ErrProductNotFound
+	return "", 0, false
+}
+
+// Reserve checks availability for all variants first, then decrements — so an
+// insufficient item leaves everything untouched.
+func (im *inMemory) Reserve(ctx context.Context, quantities map[string]int) error {
+	for id, qty := range quantities {
+		pid, i, ok := im.find(id)
+		if !ok || im.variants[pid][i].Stock() < qty {
+			return ErrInsufficientStock
+		}
+	}
+	for id, qty := range quantities {
+		pid, i, _ := im.find(id)
+		v := im.variants[pid][i]
+		im.variants[pid][i] = NewVariant(v.ID(), v.SKU(), v.Image(), v.Options(), v.Price(), v.Stock()-qty)
+	}
+	return nil
+}
+
+func (im *inMemory) Release(ctx context.Context, quantities map[string]int) error {
+	for id, qty := range quantities {
+		if pid, i, ok := im.find(id); ok {
+			v := im.variants[pid][i]
+			im.variants[pid][i] = NewVariant(v.ID(), v.SKU(), v.Image(), v.Options(), v.Price(), v.Stock()+qty)
+		}
+	}
+	return nil
 }
 
 func (im *inMemory) FindVariant(ctx context.Context, variantID string) (Product, Variant, error) {

--- a/backend/productcatalog/adapter_postgres.go
+++ b/backend/productcatalog/adapter_postgres.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sort"
 
 	_ "github.com/lib/pq"
 )
@@ -237,13 +238,67 @@ func scanVariant(s rowScanner) (Variant, error) {
 	return NewVariant(id, sku, image, options, price, stock), nil
 }
 
-// ReduceStock decrements a variant's stock by qty, clamped at zero.
-func (db postgres) ReduceStock(ctx context.Context, variantID string, qty int) error {
-	_, err := db.db.ExecContext(ctx, `
-		UPDATE productcatalog_variant SET stock = GREATEST(0, stock - $2) WHERE id = $1
-	`, variantID, qty)
+// Reserve atomically decrements stock for every variant in quantities. It is
+// all-or-nothing: if any variant lacks sufficient stock the whole change is
+// rolled back and ErrInsufficientStock is returned. Variants are locked in a
+// stable (sorted) order to avoid deadlocks between concurrent reservations.
+func (db postgres) Reserve(ctx context.Context, quantities map[string]int) error {
+	if len(quantities) == 0 {
+		return nil
+	}
+
+	ids := make([]string, 0, len(quantities))
+	for id := range quantities {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+
+	tx, err := db.db.BeginTx(ctx, nil)
 	if err != nil {
-		return fmt.Errorf("reduce stock: %w", err)
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer func() {
+		if err != nil {
+			_ = tx.Rollback()
+		}
+	}()
+
+	for _, id := range ids {
+		qty := quantities[id]
+		if qty <= 0 {
+			continue
+		}
+		var res sql.Result
+		res, err = tx.ExecContext(ctx, `
+			UPDATE productcatalog_variant SET stock = stock - $2
+			WHERE id = $1 AND stock >= $2
+		`, id, qty)
+		if err != nil {
+			return fmt.Errorf("reserve %s: %w", id, err)
+		}
+		n, _ := res.RowsAffected()
+		if n != 1 {
+			err = ErrInsufficientStock
+			return err
+		}
+	}
+
+	if err = tx.Commit(); err != nil {
+		return fmt.Errorf("commit reservation: %w", err)
+	}
+	return nil
+}
+
+// Release returns previously-reserved stock (best-effort, e.g. when a payment
+// fails after the reservation succeeded).
+func (db postgres) Release(ctx context.Context, quantities map[string]int) error {
+	for id, qty := range quantities {
+		if qty <= 0 {
+			continue
+		}
+		if _, err := db.db.ExecContext(ctx, `UPDATE productcatalog_variant SET stock = stock + $2 WHERE id = $1`, id, qty); err != nil {
+			return fmt.Errorf("release %s: %w", id, err)
+		}
 	}
 	return nil
 }

--- a/backend/productcatalog/app_product.go
+++ b/backend/productcatalog/app_product.go
@@ -16,7 +16,8 @@ type ProductStorage interface {
 	FindVariant(ctx context.Context, variantID string) (Product, Variant, error)
 	AddOptionType(ctx context.Context, productID string, position int, ot OptionType) error
 	AddVariant(ctx context.Context, productID string, position int, v Variant) error
-	ReduceStock(ctx context.Context, variantID string, qty int) error
+	Reserve(ctx context.Context, quantities map[string]int) error
+	Release(ctx context.Context, quantities map[string]int) error
 }
 
 func NewProductService(s ProductStorage) ProductService {
@@ -36,9 +37,16 @@ func (ps ProductService) FindVariant(ctx context.Context, variantID string) (Pro
 	return ps.storage.FindVariant(ctx, variantID)
 }
 
-// ReduceStock decrements a variant's stock (called when an order is placed).
-func (ps ProductService) ReduceStock(ctx context.Context, variantID string, qty int) error {
-	return ps.storage.ReduceStock(ctx, variantID, qty)
+// Reserve atomically decrements stock for the given variants (variant id ->
+// quantity). All-or-nothing: returns ErrInsufficientStock if any variant is
+// short, leaving stock untouched.
+func (ps ProductService) Reserve(ctx context.Context, quantities map[string]int) error {
+	return ps.storage.Reserve(ctx, quantities)
+}
+
+// Release returns previously-reserved stock (e.g. after a failed payment).
+func (ps ProductService) Release(ctx context.Context, quantities map[string]int) error {
+	return ps.storage.Release(ctx, quantities)
 }
 
 // defaultStock is given to a simple product's auto-created default variant.

--- a/backend/productcatalog/domain_variant.go
+++ b/backend/productcatalog/domain_variant.go
@@ -1,6 +1,13 @@
 package productcatalog
 
-import "strings"
+import (
+	"errors"
+	"strings"
+)
+
+// ErrInsufficientStock is returned by Reserve when one or more variants don't
+// have enough stock to satisfy the request.
+var ErrInsufficientStock = errors.New("insufficient stock")
 
 // OptionType is a product attribute the customer chooses, e.g. "Color" with
 // values ["Red", "Blue"]. The order of values is the display order.

--- a/backend/productcatalog/productcatalog_test.go
+++ b/backend/productcatalog/productcatalog_test.go
@@ -17,7 +17,8 @@ type productStorage interface {
 	FindVariant(ctx context.Context, variantID string) (productcatalog.Product, productcatalog.Variant, error)
 	AddOptionType(ctx context.Context, productID string, position int, ot productcatalog.OptionType) error
 	AddVariant(ctx context.Context, productID string, position int, v productcatalog.Variant) error
-	ReduceStock(ctx context.Context, variantID string, qty int) error
+	Reserve(ctx context.Context, quantities map[string]int) error
+	Release(ctx context.Context, quantities map[string]int) error
 }
 
 var storage productStorage


### PR DESCRIPTION
Replaces the best-effort, post-placement stock decrement with an atomic reservation taken **before** the order is placed, closing the oversell window under concurrent checkouts.

## Changes
- **catalog**: `ReduceStock` → `Reserve`/`Release` (variant→qty map). `Reserve` runs one tx, decrementing each variant with `UPDATE ... WHERE stock >= qty` and checking rows-affected; any shortfall rolls back the whole tx → `ErrInsufficientStock`. Variants locked in sorted id order (deadlock-safe). `Release` re-adds on failure paths.
- **checkout**: `Place` reserves up front (no reservation → no order); releases on payment decline / save failure. `StockReducer` → `StockReserver`.
- **handler**: `ErrInsufficientStock` → flash + redirect `/cart`.

## Test plan (docker, stock=1)
- [x] sequential: first places (stock→0), second rejected (409 + `/cart`); exactly 1 order
- [x] concurrent: two simultaneous checkouts for the last unit → exactly one wins, other → `/cart`; stock 0, never negative; one order item
- [x] build / vet / tests / lint green