### PR TITLE
feat(checkout): cancel order (exercises full ES write path)

### DIFF
--- a/backend/checkout/adapter/events_codec.go
+++ b/backend/checkout/adapter/events_codec.go
@@ -63,6 +63,12 @@ type paymentFailedDTO struct {
 	At      time.Time `json:"at"`
 }
 
+type orderCancelledDTO struct {
+	OrderID string    `json:"order_id"`
+	Reason  string    `json:"reason"`
+	At      time.Time `json:"at"`
+}
+
 // marshalEvent returns the stored type name and JSON payload for a domain event.
 func marshalEvent(e domain.Event) (string, []byte, error) {
 	var payload any
@@ -92,6 +98,8 @@ func marshalEvent(e domain.Event) (string, []byte, error) {
 		payload = paymentSucceededDTO{OrderID: ev.OrderID, At: ev.At}
 	case domain.PaymentFailed:
 		payload = paymentFailedDTO{OrderID: ev.OrderID, Reason: ev.Reason, At: ev.At}
+	case domain.OrderCancelled:
+		payload = orderCancelledDTO{OrderID: ev.OrderID, Reason: ev.Reason, At: ev.At}
 	default:
 		return "", nil, fmt.Errorf("no codec for event %s", e.EventType())
 	}
@@ -137,6 +145,12 @@ func unmarshalEvent(eventType string, payload []byte) (domain.Event, error) {
 			return nil, fmt.Errorf("unmarshal PaymentFailed: %w", err)
 		}
 		return domain.PaymentFailed{OrderID: dto.OrderID, Reason: dto.Reason, At: dto.At}, nil
+	case "OrderCancelled":
+		var dto orderCancelledDTO
+		if err := json.Unmarshal(payload, &dto); err != nil {
+			return nil, fmt.Errorf("unmarshal OrderCancelled: %w", err)
+		}
+		return domain.OrderCancelled{OrderID: dto.OrderID, Reason: dto.Reason, At: dto.At}, nil
 	default:
 		return nil, fmt.Errorf("unknown event type %q", eventType)
 	}

--- a/backend/checkout/adapter/events_postgres.go
+++ b/backend/checkout/adapter/events_postgres.go
@@ -60,6 +60,18 @@ func (p Postgres) LoadEvents(ctx context.Context, aggregateID string) ([]domain.
 	return events, rows.Err()
 }
 
+// Load rebuilds an order aggregate from its event history (write side).
+func (p Postgres) Load(ctx context.Context, id string) (*domain.Order, error) {
+	events, err := p.LoadEvents(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	if len(events) == 0 {
+		return nil, domain.ErrOrderNotFound
+	}
+	return domain.RehydrateOrder(events), nil
+}
+
 // projectEventTx updates the read model (checkout_order / _item) for a single
 // event, inside the same transaction the event was appended in — so the read
 // model is always consistent with the event log.
@@ -71,6 +83,8 @@ func projectEventTx(ctx context.Context, tx *sql.Tx, e domain.Event) error {
 		return setOrderStatus(ctx, tx, ev.OrderID, string(domain.StatusPaid))
 	case domain.PaymentFailed:
 		return setOrderStatus(ctx, tx, ev.OrderID, string(domain.StatusFailed))
+	case domain.OrderCancelled:
+		return setOrderStatus(ctx, tx, ev.OrderID, string(domain.StatusCancelled))
 	default:
 		return fmt.Errorf("no projection for event %s", e.EventType())
 	}

--- a/backend/checkout/app/checkout.go
+++ b/backend/checkout/app/checkout.go
@@ -26,6 +26,8 @@ type OrderStorage interface {
 	// Save persists the aggregate's pending events and projects them to the
 	// read model.
 	Save(ctx context.Context, order *domain.Order) error
+	// Load rebuilds the order aggregate from its event history (write side).
+	Load(ctx context.Context, id string) (*domain.Order, error)
 	Find(ctx context.Context, id string) (domain.Order, error)
 	ListByCustomer(ctx context.Context, customerID string) ([]domain.Order, error)
 }
@@ -148,6 +150,38 @@ func (s CheckoutService) Place(ctx context.Context, sessID, customerID, cardNumb
 	_ = s.cartClr.Clear(ctx, sessID)
 
 	return *order, nil
+}
+
+// Cancel cancels a customer's paid order: it rehydrates the aggregate from its
+// events, applies the Cancel command, persists the resulting OrderCancelled
+// event, and returns the reserved stock to the catalogue.
+//
+// Only the order's owner may cancel it; for any other customer the order is
+// reported as not found so its existence isn't leaked.
+func (s CheckoutService) Cancel(ctx context.Context, orderID, customerID string) error {
+	order, err := s.storage.Load(ctx, orderID)
+	if err != nil {
+		return err
+	}
+	if customerID == "" || order.CustomerID() != customerID {
+		return domain.ErrOrderNotFound
+	}
+
+	if err := order.Cancel("cancelled by customer", s.now()); err != nil {
+		return err
+	}
+	if err := s.storage.Save(ctx, order); err != nil {
+		return fmt.Errorf("save cancellation: %w", err)
+	}
+
+	// Return the reserved stock to the catalogue (best-effort).
+	quantities := map[string]int{}
+	for _, ln := range order.Items() {
+		quantities[ln.ProductID()] += ln.Quantity()
+	}
+	_ = s.stock.Release(ctx, quantities)
+
+	return nil
 }
 
 func (s CheckoutService) Find(ctx context.Context, id string) (domain.Order, error) {

--- a/backend/checkout/domain/events.go
+++ b/backend/checkout/domain/events.go
@@ -46,3 +46,13 @@ type PaymentFailed struct {
 
 func (e PaymentFailed) EventType() string     { return "PaymentFailed" }
 func (e PaymentFailed) OccurredAt() time.Time { return e.At }
+
+// OrderCancelled is emitted when a placed order is cancelled by the customer.
+type OrderCancelled struct {
+	OrderID string
+	Reason  string
+	At      time.Time
+}
+
+func (e OrderCancelled) EventType() string     { return "OrderCancelled" }
+func (e OrderCancelled) OccurredAt() time.Time { return e.At }

--- a/backend/checkout/domain/order.go
+++ b/backend/checkout/domain/order.go
@@ -9,14 +9,16 @@ import (
 type Status string
 
 const (
-	StatusPending Status = "pending"
-	StatusPaid    Status = "paid"
-	StatusFailed  Status = "failed"
+	StatusPending   Status = "pending"
+	StatusPaid      Status = "paid"
+	StatusFailed    Status = "failed"
+	StatusCancelled Status = "cancelled"
 )
 
 var (
-	ErrOrderNotFound = errors.New("order not found")
-	ErrCartEmpty     = errors.New("cannot place order from an empty cart")
+	ErrOrderNotFound       = errors.New("order not found")
+	ErrCartEmpty           = errors.New("cannot place order from an empty cart")
+	ErrOrderNotCancellable = errors.New("order cannot be cancelled")
 )
 
 // Order is a placed (or attempted) checkout. Once created, line items are a
@@ -186,8 +188,20 @@ func (o *Order) apply(e Event) {
 		o.status = StatusPaid
 	case PaymentFailed:
 		o.status = StatusFailed
+	case OrderCancelled:
+		o.status = StatusCancelled
 	}
 	o.version++
+}
+
+// Cancel cancels a paid order. Only paid orders can be cancelled — pending,
+// failed and already-cancelled orders are rejected with ErrOrderNotCancellable.
+func (o *Order) Cancel(reason string, at time.Time) error {
+	if o.status != StatusPaid {
+		return ErrOrderNotCancellable
+	}
+	o.raise(OrderCancelled{OrderID: o.id, Reason: reason, At: at})
+	return nil
 }
 
 // PendingEvents returns events raised but not yet persisted.

--- a/backend/checkout/domain/order_test.go
+++ b/backend/checkout/domain/order_test.go
@@ -1,0 +1,89 @@
+package domain_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/bkielbasa/go-ecommerce/backend/checkout/domain"
+)
+
+func paidOrderEvents() []domain.Event {
+	at := time.Date(2026, 5, 27, 9, 0, 0, 0, time.UTC)
+	return []domain.Event{
+		domain.OrderPlaced{
+			OrderID:    "ord-1",
+			UserID:     "cart-1",
+			CustomerID: "jane@example.com",
+			ShipTo:     domain.RebuildAddress("Jane", "1 Main St", "", "PDX", "97201", "USA"),
+			ShipMethod: domain.RebuildShippingMethod("courier", "Courier", 1500),
+			PayMethod:  domain.RebuildPaymentMethod("card", "Credit / debit card"),
+			Lines:      []domain.Line{domain.NewLine("v1", "Item", 2, 1000, "USD")},
+			At:         at,
+		},
+		domain.PaymentSucceeded{OrderID: "ord-1", At: at},
+	}
+}
+
+func TestRehydrate_FoldsToPaid(t *testing.T) {
+	o := domain.RehydrateOrder(paidOrderEvents())
+
+	if o.Status() != domain.StatusPaid {
+		t.Fatalf("status = %q, want paid", o.Status())
+	}
+	if len(o.PendingEvents()) != 0 {
+		t.Errorf("rehydrated order should have no pending events, got %d", len(o.PendingEvents()))
+	}
+	// subtotal 2*1000 + 1500 shipping
+	if o.TotalAmount() != 3500 {
+		t.Errorf("total = %d, want 3500", o.TotalAmount())
+	}
+}
+
+func TestCancel_RehydrateCommandAppend(t *testing.T) {
+	o := domain.RehydrateOrder(paidOrderEvents())
+
+	if err := o.Cancel("changed mind", time.Now()); err != nil {
+		t.Fatalf("Cancel: %v", err)
+	}
+
+	if o.Status() != domain.StatusCancelled {
+		t.Errorf("status = %q, want cancelled", o.Status())
+	}
+	pending := o.PendingEvents()
+	if len(pending) != 1 {
+		t.Fatalf("expected 1 pending event, got %d", len(pending))
+	}
+	if _, ok := pending[0].(domain.OrderCancelled); !ok {
+		t.Errorf("pending event = %T, want OrderCancelled", pending[0])
+	}
+	// Two events were folded in; the cancellation must append at sequence 3.
+	if o.ExpectedVersion() != 2 {
+		t.Errorf("ExpectedVersion = %d, want 2 (cancellation appends at seq 3)", o.ExpectedVersion())
+	}
+}
+
+func TestCancel_NotAllowedTwice(t *testing.T) {
+	o := domain.RehydrateOrder(paidOrderEvents())
+	if err := o.Cancel("first", time.Now()); err != nil {
+		t.Fatalf("first cancel: %v", err)
+	}
+	if err := o.Cancel("again", time.Now()); !errors.Is(err, domain.ErrOrderNotCancellable) {
+		t.Errorf("second cancel err = %v, want ErrOrderNotCancellable", err)
+	}
+}
+
+func TestCancel_FailedOrderNotCancellable(t *testing.T) {
+	at := time.Date(2026, 5, 27, 9, 0, 0, 0, time.UTC)
+	o := domain.RehydrateOrder([]domain.Event{
+		domain.OrderPlaced{OrderID: "ord-2", Lines: []domain.Line{domain.NewLine("v1", "Item", 1, 1000, "USD")}, ShipMethod: domain.RebuildShippingMethod("pickup", "Personal pickup", 0), At: at},
+		domain.PaymentFailed{OrderID: "ord-2", Reason: "declined", At: at},
+	})
+
+	if o.Status() != domain.StatusFailed {
+		t.Fatalf("status = %q, want failed", o.Status())
+	}
+	if err := o.Cancel("nope", time.Now()); !errors.Is(err, domain.ErrOrderNotCancellable) {
+		t.Errorf("cancel of failed order err = %v, want ErrOrderNotCancellable", err)
+	}
+}

--- a/backend/layout/bounded_context.go
+++ b/backend/layout/bounded_context.go
@@ -45,6 +45,7 @@ type checkoutService interface {
 	Place(ctx context.Context, sessID, customerID, cardNumber string, shipTo checkoutDomain.Address, shipMethod checkoutDomain.ShippingMethod, payMethod checkoutDomain.PaymentMethod) (checkoutDomain.Order, error)
 	Find(ctx context.Context, id string) (checkoutDomain.Order, error)
 	ListByCustomer(ctx context.Context, customerID string) ([]checkoutDomain.Order, error)
+	Cancel(ctx context.Context, orderID, customerID string) error
 }
 
 func New(logger logrus.FieldLogger, cartSrv cartService, catalogSrv catalogService, authSrv authService, checkoutSrv checkoutService, shipSrv shippingService) application.BoundedContext {

--- a/backend/layout/http.go
+++ b/backend/layout/http.go
@@ -70,6 +70,7 @@ func (m boundedContext) MuxRegister(r *mux.Router) {
 	r.HandleFunc("/checkout", observability.HTTPWrap(m.handler.PlaceOrder, m.logger)).Methods("POST")
 	r.HandleFunc("/orders", observability.HTTPWrap(m.handler.Orders, m.logger)).Methods("GET")
 	r.HandleFunc("/order/{orderID}", observability.HTTPWrap(m.handler.Order, m.logger)).Methods("GET")
+	r.HandleFunc("/order/{orderID}/cancel", observability.HTTPWrap(m.handler.CancelOrder, m.logger)).Methods("POST")
 
 	r.HandleFunc("/account", observability.HTTPWrap(m.handler.AccountOverview, m.logger)).Methods("GET")
 	r.HandleFunc("/account/orders", observability.HTTPWrap(m.handler.AccountOrders, m.logger)).Methods("GET")

--- a/backend/layout/http_checkout.go
+++ b/backend/layout/http_checkout.go
@@ -172,7 +172,36 @@ func (handler httpHandler) Order(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// The owner may cancel a paid order.
+	customerID := handler.currentCustomerID(r)
+	canCancel := order.Status() == checkoutDomain.StatusPaid &&
+		customerID != "" && order.CustomerID() == customerID
+
 	handler.renderTemplate(w, r, "order/show", map[string]any{
-		"Order": order,
+		"Order":     order,
+		"CanCancel": canCancel,
 	})
+}
+
+func (handler httpHandler) CancelOrder(w http.ResponseWriter, r *http.Request) {
+	customerID, ok := handler.requireLogin(w, r)
+	if !ok {
+		return
+	}
+	orderID := mux.Vars(r)["orderID"]
+
+	err := handler.checkoutSrv.Cancel(r.Context(), orderID, customerID)
+	switch {
+	case errors.Is(err, checkoutDomain.ErrOrderNotFound):
+		http.NotFound(w, r)
+		return
+	case errors.Is(err, checkoutDomain.ErrOrderNotCancellable):
+		handler.flash(w, r, "This order can no longer be cancelled.", "error")
+	case err != nil:
+		https.InternalError(w, "internal-error", err.Error())
+		return
+	default:
+		handler.flash(w, r, "Your order has been cancelled.", "info")
+	}
+	http.Redirect(w, r, "/order/"+orderID, http.StatusSeeOther)
 }

--- a/backend/layout/static/main.css
+++ b/backend/layout/static/main.css
@@ -362,9 +362,11 @@ main {
   border: 1px solid currentColor;
   color: var(--fg-muted);
 }
-.order-status--paid    { color: var(--fg); }
-.order-status--failed  { color: var(--danger); }
-.order-status--pending { color: var(--info); }
+.order-status--paid      { color: var(--fg); }
+.order-status--failed    { color: var(--danger); }
+.order-status--pending   { color: var(--info); }
+.order-status--cancelled { color: var(--danger); }
+.order__actions { display: flex; align-items: center; gap: var(--space-3); margin-top: var(--space-2); }
 
 /* ---------- order confirmation ---------- */
 .order {

--- a/backend/layout/tmpl/order/show.gohtml
+++ b/backend/layout/tmpl/order/show.gohtml
@@ -3,10 +3,14 @@
 
   <article class="order">
     <header class="order__header">
-      <h1 class="order__title">thank you.</h1>
+      {{if eq .Order.Status "cancelled"}}
+        <h1 class="order__title">order cancelled.</h1>
+      {{else}}
+        <h1 class="order__title">thank you.</h1>
+      {{end}}
       <p class="order__subtitle muted">
         order <span class="order__id">{{.Order.ID}}</span> &middot;
-        {{.Order.Status}} &middot;
+        <span class="order-status order-status--{{.Order.Status}}">{{.Order.Status}}</span> &middot;
         placed {{.Order.PlacedAt.Format "Jan 2, 2006 15:04 MST"}}
       </p>
     </header>
@@ -75,6 +79,14 @@
 
     <p class="order__hint muted">a confirmation email would normally be on its way. this is a demo, so nothing was actually charged or sent.</p>
 
-    <a href="/" class="btn btn--ghost">continue shopping</a>
+    <div class="order__actions">
+      <a href="/" class="btn btn--ghost">continue shopping</a>
+      {{if .CanCancel}}
+        <form method="post" action="/order/{{.Order.ID}}/cancel"
+              onsubmit="return confirm('Cancel this order? Reserved stock will be released.');">
+          <button type="submit" class="linkbtn linkbtn--danger">cancel order</button>
+        </form>
+      {{end}}
+    </div>
   </article>
 {{end}}


### PR DESCRIPTION
Adds order cancellation — the first flow that loads an existing aggregate, runs a command, and appends (review finding #2). `LoadEvents`/`RehydrateOrder` are now actually used.

- **domain**: `OrderCancelled` + `StatusCancelled`; `Order.Cancel` (only paid orders, else `ErrOrderNotCancellable`).
- **adapter**: codec for `OrderCancelled`; projection → cancelled; new `Load(id)` rehydrates from history.
- **app**: `Cancel(orderID, customerID)` = Load → Cancel → Save → release reserved stock; owner-only (non-owner → `ErrOrderNotFound`).
- **layout**: `POST /order/{id}/cancel` (login required); owner-only cancel button on a paid order; status badge + "order cancelled" heading.
- **tests**: domain (rehydrate, cancel appends at right version, cancel-twice/failed rejected) + codec round-trip for `OrderCancelled`.

## Test plan
- [x] domain unit tests pass
- [x] docker: place → cancel → seq 3 OrderCancelled, read model cancelled, stock returned (35→37), second cancel refused
- [x] build / vet / lint green