### PR TITLE
refactor(checkout): dedicated CQRS read models

### DIFF
--- a/backend/checkout/adapter/postgres.go
+++ b/backend/checkout/adapter/postgres.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/bkielbasa/go-ecommerce/backend/checkout/domain"
+	"github.com/bkielbasa/go-ecommerce/backend/checkout/query"
 )
 
 type Postgres struct {
@@ -54,7 +55,9 @@ func (p Postgres) Save(ctx context.Context, order *domain.Order) error {
 	return nil
 }
 
-func (p Postgres) Find(ctx context.Context, id string) (domain.Order, error) {
+// Find reads the projection tables and returns the detail read model. It never
+// touches the event log or the write aggregate.
+func (p Postgres) Find(ctx context.Context, id string) (query.OrderView, error) {
 	var userID, status, currency string
 	var customerID sql.NullString
 	var shipName, shipStreet1, shipStreet2, shipCity, shipZip, shipCountry sql.NullString
@@ -75,10 +78,10 @@ func (p Postgres) Find(ctx context.Context, id string) (domain.Order, error) {
 		&shipMethodCode, &shipMethodLabel, &shipCost,
 		&payMethodCode, &payMethodLabel)
 	if errors.Is(err, sql.ErrNoRows) {
-		return domain.Order{}, domain.ErrOrderNotFound
+		return query.OrderView{}, domain.ErrOrderNotFound
 	}
 	if err != nil {
-		return domain.Order{}, fmt.Errorf("query order: %w", err)
+		return query.OrderView{}, fmt.Errorf("query order: %w", err)
 	}
 
 	rows, err := p.db.QueryContext(ctx, `
@@ -87,7 +90,7 @@ func (p Postgres) Find(ctx context.Context, id string) (domain.Order, error) {
 		ORDER BY id
 	`, id)
 	if err != nil {
-		return domain.Order{}, fmt.Errorf("query items: %w", err)
+		return query.OrderView{}, fmt.Errorf("query items: %w", err)
 	}
 	defer func() { _ = rows.Close() }()
 
@@ -97,12 +100,12 @@ func (p Postgres) Find(ctx context.Context, id string) (domain.Order, error) {
 		var qty int
 		var amt int64
 		if err := rows.Scan(&productID, &productName, &qty, &amt, &ccy); err != nil {
-			return domain.Order{}, fmt.Errorf("scan item: %w", err)
+			return query.OrderView{}, fmt.Errorf("scan item: %w", err)
 		}
 		lines = append(lines, domain.NewLine(productID, productName, qty, amt, ccy))
 	}
 	if err := rows.Err(); err != nil {
-		return domain.Order{}, fmt.Errorf("rows: %w", err)
+		return query.OrderView{}, fmt.Errorf("rows: %w", err)
 	}
 
 	shipTo := domain.RebuildAddress(
@@ -112,42 +115,47 @@ func (p Postgres) Find(ctx context.Context, id string) (domain.Order, error) {
 	shipMethod := domain.RebuildShippingMethod(shipMethodCode.String, shipMethodLabel.String, shipCost)
 	payMethod := domain.RebuildPaymentMethod(payMethodCode.String, payMethodLabel.String)
 
-	return domain.NewOrder(id, userID, customerID.String, shipTo, shipMethod, payMethod, lines, domain.Status(status), placedAt), nil
+	return query.NewOrderView(
+		id, customerID.String, domain.Status(status), placedAt,
+		lines, shipTo, shipMethod, payMethod,
+		totalAmt-shipCost, totalAmt, currency,
+	), nil
 }
 
 // ListByCustomer returns the customer's orders newest-first. Anonymous
 // orders (NULL customer_id) are never returned. Items are hydrated by
 // calling Find for each row (N+1) — fine for the expected order volume of
 // this demo.
-func (p Postgres) ListByCustomer(ctx context.Context, customerID string) ([]domain.Order, error) {
+// ListByCustomer returns the customer's orders newest-first as list summaries,
+// reading straight from the projection tables in a single grouped query.
+func (p Postgres) ListByCustomer(ctx context.Context, customerID string) ([]query.OrderSummary, error) {
 	rows, err := p.db.QueryContext(ctx, `
-		SELECT id FROM checkout_order WHERE customer_id = $1
-		ORDER BY placed_at DESC
+		SELECT o.id, o.status, o.placed_at, o.total_amount, o.total_currency,
+		       COUNT(i.id) AS item_count
+		FROM checkout_order o
+		LEFT JOIN checkout_order_item i ON i.order_id = o.id
+		WHERE o.customer_id = $1
+		GROUP BY o.id, o.status, o.placed_at, o.total_amount, o.total_currency
+		ORDER BY o.placed_at DESC
 	`, customerID)
 	if err != nil {
 		return nil, fmt.Errorf("query orders: %w", err)
 	}
 	defer func() { _ = rows.Close() }()
 
-	var ids []string
+	var summaries []query.OrderSummary
 	for rows.Next() {
-		var id string
-		if err := rows.Scan(&id); err != nil {
-			return nil, fmt.Errorf("scan order id: %w", err)
+		var id, status, currency string
+		var placedAt time.Time
+		var total int64
+		var itemCount int
+		if err := rows.Scan(&id, &status, &placedAt, &total, &currency, &itemCount); err != nil {
+			return nil, fmt.Errorf("scan order: %w", err)
 		}
-		ids = append(ids, id)
+		summaries = append(summaries, query.NewOrderSummary(id, domain.Status(status), placedAt, itemCount, total, currency))
 	}
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("rows: %w", err)
 	}
-
-	orders := make([]domain.Order, 0, len(ids))
-	for _, id := range ids {
-		order, err := p.Find(ctx, id)
-		if err != nil {
-			return nil, fmt.Errorf("hydrate order %s: %w", id, err)
-		}
-		orders = append(orders, order)
-	}
-	return orders, nil
+	return summaries, nil
 }

--- a/backend/checkout/app/checkout.go
+++ b/backend/checkout/app/checkout.go
@@ -28,8 +28,6 @@ type OrderStorage interface {
 	Save(ctx context.Context, order *domain.Order) error
 	// Load rebuilds the order aggregate from its event history (write side).
 	Load(ctx context.Context, id string) (*domain.Order, error)
-	Find(ctx context.Context, id string) (domain.Order, error)
-	ListByCustomer(ctx context.Context, customerID string) ([]domain.Order, error)
 }
 
 // PaymentProcessor charges a card. The fake implementation always succeeds;
@@ -182,19 +180,4 @@ func (s CheckoutService) Cancel(ctx context.Context, orderID, customerID string)
 	_ = s.stock.Release(ctx, quantities)
 
 	return nil
-}
-
-func (s CheckoutService) Find(ctx context.Context, id string) (domain.Order, error) {
-	return s.storage.Find(ctx, id)
-}
-
-// ListByCustomer returns the authenticated customer's orders newest-first.
-// Anonymous orders (placed with an empty customerID) are never returned
-// here regardless of the value passed; this is enforced by Postgres treating
-// NULL = '' as false.
-func (s CheckoutService) ListByCustomer(ctx context.Context, customerID string) ([]domain.Order, error) {
-	if customerID == "" {
-		return nil, nil
-	}
-	return s.storage.ListByCustomer(ctx, customerID)
 }

--- a/backend/checkout/bounded_context.go
+++ b/backend/checkout/bounded_context.go
@@ -9,6 +9,7 @@ import (
 	cartDomain "github.com/bkielbasa/go-ecommerce/backend/cart/domain"
 	"github.com/bkielbasa/go-ecommerce/backend/checkout/adapter"
 	"github.com/bkielbasa/go-ecommerce/backend/checkout/app"
+	"github.com/bkielbasa/go-ecommerce/backend/checkout/query"
 	"github.com/bkielbasa/go-ecommerce/backend/internal/application"
 )
 
@@ -30,11 +31,15 @@ type StockReserver interface {
 	Release(ctx context.Context, quantities map[string]int) error
 }
 
-func New(db *sql.DB, cart CartReader, cartClr CartClearer, stock StockReserver) (application.BoundedContext, app.CheckoutService) {
+// New wires the checkout context and returns its command service (write side,
+// event-sourced) and query service (read side, projection-backed) separately,
+// keeping the CQRS split explicit at the composition root.
+func New(db *sql.DB, cart CartReader, cartClr CartClearer, stock StockReserver) (application.BoundedContext, app.CheckoutService, query.Service) {
 	storage := adapter.NewPostgres(db)
 	payment := adapter.NewFakePayment()
-	srv := app.NewCheckoutService(cart, cartClr, storage, payment, stock, newOrderID)
-	return &boundedContext{}, srv
+	cmd := app.NewCheckoutService(cart, cartClr, storage, payment, stock, newOrderID)
+	queries := query.NewService(storage)
+	return &boundedContext{}, cmd, queries
 }
 
 type boundedContext struct{}

--- a/backend/checkout/query/service.go
+++ b/backend/checkout/query/service.go
@@ -1,0 +1,34 @@
+package query
+
+import "context"
+
+// Repository is the read side's data source — it reads the projection tables
+// and returns read models, never the write aggregate.
+type Repository interface {
+	Find(ctx context.Context, id string) (OrderView, error)
+	ListByCustomer(ctx context.Context, customerID string) ([]OrderSummary, error)
+}
+
+// Service is the checkout query side. It is intentionally separate from the
+// command-side CheckoutService.
+type Service struct {
+	repo Repository
+}
+
+func NewService(repo Repository) Service {
+	return Service{repo: repo}
+}
+
+// Find returns the detail read model for an order.
+func (s Service) Find(ctx context.Context, id string) (OrderView, error) {
+	return s.repo.Find(ctx, id)
+}
+
+// ListByCustomer returns the customer's orders newest-first as summaries.
+// Anonymous (empty) customers have no order history.
+func (s Service) ListByCustomer(ctx context.Context, customerID string) ([]OrderSummary, error) {
+	if customerID == "" {
+		return nil, nil
+	}
+	return s.repo.ListByCustomer(ctx, customerID)
+}

--- a/backend/checkout/query/views.go
+++ b/backend/checkout/query/views.go
@@ -1,0 +1,83 @@
+// Package query holds the read side of the checkout context (CQRS): flat read
+// models projected from the order tables, deliberately separate from the
+// event-sourced write aggregate (checkout/domain.Order). They reuse the
+// context's value objects but are never used to issue commands.
+package query
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/bkielbasa/go-ecommerce/backend/checkout/domain"
+)
+
+func money(amount int64) string {
+	return fmt.Sprintf("%d.%02d", amount/100, amount%100)
+}
+
+// OrderSummary is the read model for order lists (account orders, overview).
+type OrderSummary struct {
+	id        string
+	status    domain.Status
+	placedAt  time.Time
+	itemCount int
+	total     int64
+	currency  string
+}
+
+func NewOrderSummary(id string, status domain.Status, placedAt time.Time, itemCount int, total int64, currency string) OrderSummary {
+	return OrderSummary{id: id, status: status, placedAt: placedAt, itemCount: itemCount, total: total, currency: currency}
+}
+
+func (s OrderSummary) ID() string            { return s.id }
+func (s OrderSummary) Status() domain.Status { return s.status }
+func (s OrderSummary) PlacedAt() time.Time   { return s.placedAt }
+func (s OrderSummary) ItemCount() int        { return s.itemCount }
+func (s OrderSummary) TotalDisplay() string  { return money(s.total) }
+func (s OrderSummary) TotalCurrency() string { return s.currency }
+
+// OrderView is the read model for the order detail page.
+type OrderView struct {
+	id         string
+	customerID string
+	status     domain.Status
+	placedAt   time.Time
+	items      []domain.Line
+	shipTo     domain.Address
+	shipMethod domain.ShippingMethod
+	payMethod  domain.PaymentMethod
+	subtotal   int64
+	total      int64
+	currency   string
+}
+
+func NewOrderView(
+	id, customerID string,
+	status domain.Status,
+	placedAt time.Time,
+	items []domain.Line,
+	shipTo domain.Address,
+	shipMethod domain.ShippingMethod,
+	payMethod domain.PaymentMethod,
+	subtotal, total int64,
+	currency string,
+) OrderView {
+	return OrderView{
+		id: id, customerID: customerID, status: status, placedAt: placedAt,
+		items: items, shipTo: shipTo, shipMethod: shipMethod, payMethod: payMethod,
+		subtotal: subtotal, total: total, currency: currency,
+	}
+}
+
+func (v OrderView) ID() string                            { return v.id }
+func (v OrderView) CustomerID() string                    { return v.customerID }
+func (v OrderView) Status() domain.Status                 { return v.status }
+func (v OrderView) PlacedAt() time.Time                   { return v.placedAt }
+func (v OrderView) Items() []domain.Line                  { return v.items }
+func (v OrderView) ShipTo() domain.Address                { return v.shipTo }
+func (v OrderView) ShippingMethod() domain.ShippingMethod { return v.shipMethod }
+func (v OrderView) PaymentMethod() domain.PaymentMethod   { return v.payMethod }
+func (v OrderView) SubtotalDisplay() string               { return money(v.subtotal) }
+func (v OrderView) ShippingCostDisplay() string           { return money(v.shipMethod.Cost()) }
+func (v OrderView) TotalDisplay() string                  { return money(v.total) }
+func (v OrderView) TotalCurrency() string                 { return v.currency }

--- a/backend/cmd/web/main.go
+++ b/backend/cmd/web/main.go
@@ -79,11 +79,11 @@ func main() {
 	pcBD, catalogService := productcatalog.New(db)
 	cartBD, cartSrv := cart.New(db, logger, catalogService)
 	authBD, authService := auth.New(db)
-	checkoutBD, checkoutSrv := checkout.New(db, cartSrv, cartSrv, catalogService)
+	checkoutBD, checkoutSrv, checkoutQry := checkout.New(db, cartSrv, cartSrv, catalogService)
 	shipSrv := shippinginfo.New(db)
 	app.AddBoundedContext(cartBD)
 
-	app.AddBoundedContext(layout.New(logger, cartSrv, catalogService, authService, checkoutSrv, shipSrv))
+	app.AddBoundedContext(layout.New(logger, cartSrv, catalogService, authService, checkoutSrv, checkoutQry, shipSrv))
 	app.AddBoundedContext(pcBD)
 	app.AddBoundedContext(authBD)
 	app.AddBoundedContext(checkoutBD)

--- a/backend/layout/bounded_context.go
+++ b/backend/layout/bounded_context.go
@@ -7,6 +7,7 @@ import (
 	authDomain "github.com/bkielbasa/go-ecommerce/backend/auth/domain"
 	"github.com/bkielbasa/go-ecommerce/backend/cart/domain"
 	checkoutDomain "github.com/bkielbasa/go-ecommerce/backend/checkout/domain"
+	checkoutQuery "github.com/bkielbasa/go-ecommerce/backend/checkout/query"
 	"github.com/bkielbasa/go-ecommerce/backend/internal/application"
 	"github.com/bkielbasa/go-ecommerce/backend/productcatalog"
 	shipDomain "github.com/bkielbasa/go-ecommerce/backend/shippinginfo/domain"
@@ -41,20 +42,27 @@ type shippingService interface {
 	Default(ctx context.Context, customerID string) (shipDomain.Address, bool, error)
 }
 
-type checkoutService interface {
+// checkoutCommands is the write side of the checkout context (CQRS).
+type checkoutCommands interface {
 	Place(ctx context.Context, sessID, customerID, cardNumber string, shipTo checkoutDomain.Address, shipMethod checkoutDomain.ShippingMethod, payMethod checkoutDomain.PaymentMethod) (checkoutDomain.Order, error)
-	Find(ctx context.Context, id string) (checkoutDomain.Order, error)
-	ListByCustomer(ctx context.Context, customerID string) ([]checkoutDomain.Order, error)
 	Cancel(ctx context.Context, orderID, customerID string) error
 }
 
-func New(logger logrus.FieldLogger, cartSrv cartService, catalogSrv catalogService, authSrv authService, checkoutSrv checkoutService, shipSrv shippingService) application.BoundedContext {
+// checkoutQueries is the read side of the checkout context (CQRS); it returns
+// dedicated read models, not the write aggregate.
+type checkoutQueries interface {
+	Find(ctx context.Context, id string) (checkoutQuery.OrderView, error)
+	ListByCustomer(ctx context.Context, customerID string) ([]checkoutQuery.OrderSummary, error)
+}
+
+func New(logger logrus.FieldLogger, cartSrv cartService, catalogSrv catalogService, authSrv authService, checkoutSrv checkoutCommands, checkoutQry checkoutQueries, shipSrv shippingService) application.BoundedContext {
 	return &boundedContext{
 		handler: httpHandler{
 			cartSrv:     cartSrv,
 			catalogSrv:  catalogSrv,
 			authSrv:     authSrv,
 			checkoutSrv: checkoutSrv,
+			checkoutQry: checkoutQry,
 			shipSrv:     shipSrv,
 		},
 		logger: logger,

--- a/backend/layout/http.go
+++ b/backend/layout/http.go
@@ -39,7 +39,8 @@ type httpHandler struct {
 	cartSrv     cartService
 	catalogSrv  catalogService
 	authSrv     authService
-	checkoutSrv checkoutService
+	checkoutSrv checkoutCommands
+	checkoutQry checkoutQueries
 	shipSrv     shippingService
 }
 

--- a/backend/layout/http_account.go
+++ b/backend/layout/http_account.go
@@ -3,7 +3,7 @@ package layout
 import (
 	"net/http"
 
-	checkoutDomain "github.com/bkielbasa/go-ecommerce/backend/checkout/domain"
+	checkoutQuery "github.com/bkielbasa/go-ecommerce/backend/checkout/query"
 	"github.com/bkielbasa/go-ecommerce/backend/internal/https"
 	"github.com/gorilla/mux"
 )
@@ -34,8 +34,8 @@ func (handler httpHandler) AccountOverview(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	var latest checkoutDomain.Order
-	if orders, err := handler.checkoutSrv.ListByCustomer(r.Context(), cid); err == nil && len(orders) > 0 {
+	var latest checkoutQuery.OrderSummary
+	if orders, err := handler.checkoutQry.ListByCustomer(r.Context(), cid); err == nil && len(orders) > 0 {
 		latest = orders[0]
 	}
 	def, _, _ := handler.shipSrv.Default(r.Context(), cid)
@@ -53,7 +53,7 @@ func (handler httpHandler) AccountOrders(w http.ResponseWriter, r *http.Request)
 	if !ok {
 		return
 	}
-	orders, err := handler.checkoutSrv.ListByCustomer(r.Context(), cid)
+	orders, err := handler.checkoutQry.ListByCustomer(r.Context(), cid)
 	if err != nil {
 		https.InternalError(w, "internal-error", err.Error())
 		return

--- a/backend/layout/http_checkout.go
+++ b/backend/layout/http_checkout.go
@@ -148,7 +148,7 @@ func (handler httpHandler) Orders(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	orders, err := handler.checkoutSrv.ListByCustomer(r.Context(), customerID)
+	orders, err := handler.checkoutQry.ListByCustomer(r.Context(), customerID)
 	if err != nil {
 		https.InternalError(w, "internal-error", err.Error())
 		return
@@ -162,7 +162,7 @@ func (handler httpHandler) Orders(w http.ResponseWriter, r *http.Request) {
 func (handler httpHandler) Order(w http.ResponseWriter, r *http.Request) {
 	orderID := mux.Vars(r)["orderID"]
 
-	order, err := handler.checkoutSrv.Find(r.Context(), orderID)
+	order, err := handler.checkoutQry.Find(r.Context(), orderID)
 	if errors.Is(err, checkoutDomain.ErrOrderNotFound) {
 		http.NotFound(w, r)
 		return

--- a/backend/layout/tmpl/account/orders.gohtml
+++ b/backend/layout/tmpl/account/orders.gohtml
@@ -19,7 +19,7 @@
               <tr>
                 <td>
                   <a href="/order/{{$order.ID}}" class="order-row__id">{{$order.ID}}</a>
-                  <span class="muted order-row__count"> &middot; {{len $order.Items}} item{{if ne (len $order.Items) 1}}s{{end}}</span>
+                  <span class="muted order-row__count"> &middot; {{$order.ItemCount}} item{{if ne $order.ItemCount 1}}s{{end}}</span>
                 </td>
                 <td class="muted">{{$order.PlacedAt.Format "Jan 2, 2006"}}</td>
                 <td><span class="order-status order-status--{{$order.Status}}">{{$order.Status}}</span></td>

--- a/backend/layout/tmpl/order/index.gohtml
+++ b/backend/layout/tmpl/order/index.gohtml
@@ -16,7 +16,7 @@
           <tr>
             <td>
               <a href="/order/{{$order.ID}}" class="order-row__id">{{$order.ID}}</a>
-              <span class="muted order-row__count"> &middot; {{len $order.Items}} item{{if ne (len $order.Items) 1}}s{{end}}</span>
+              <span class="muted order-row__count"> &middot; {{$order.ItemCount}} item{{if ne $order.ItemCount 1}}s{{end}}</span>
             </td>
             <td class="muted">{{$order.PlacedAt.Format "Jan 2, 2006"}}</td>
             <td><span class="order-status order-status--{{$order.Status}}">{{$order.Status}}</span></td>


### PR DESCRIPTION
The query side reused the event-sourced write aggregate (`domain.Order`), blurring the command/query boundary (review finding #3). This introduces a real read side.

- **new `checkout/query` package**: flat read models — `OrderView` (detail) and `OrderSummary` (lists) — projected straight from the read tables, plus a `query.Service` kept separate from the command-side `CheckoutService`.
- **adapter**: `Find`→`OrderView`, `ListByCustomer`→`[]OrderSummary` (single grouped `COUNT` query); reads never rehydrate the aggregate or touch the event log.
- **composition root**: `checkout.New` returns the command and query services separately; layout splits `checkoutService` into `checkoutCommands` + `checkoutQueries`.
- **templates**: list views use the read model's `ItemCount`.

## Test plan
- [x] build / vet / lint green
- [x] docker: order detail (paid + owner cancel button), account orders list ("2 items"), `/account` latest summary, cancel → cancelled