### PR TITLE
test(domain): cover value objects, stock & shipping invariants

### DIFF
--- a/backend/checkout/domain/address_test.go
+++ b/backend/checkout/domain/address_test.go
@@ -1,0 +1,45 @@
+package domain_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/bkielbasa/go-ecommerce/backend/checkout/domain"
+)
+
+func TestNewAddress_RequiresMandatoryFields(t *testing.T) {
+	// street2 is intentionally omitted from the required set.
+	base := []string{"Jane", "1 Main St", "apt 2", "PDX", "97201", "USA"}
+	required := map[int]string{0: "name", 1: "street1", 3: "city", 4: "zip", 5: "country"}
+
+	for idx := range required {
+		args := append([]string(nil), base...)
+		args[idx] = "   " // whitespace-only must be rejected
+		_, err := domain.NewAddress(args[0], args[1], args[2], args[3], args[4], args[5])
+		if !errors.Is(err, domain.ErrInvalidAddress) {
+			t.Errorf("blank field %d: err = %v, want ErrInvalidAddress", idx, err)
+		}
+	}
+}
+
+func TestNewAddress_Street2Optional_AndTrims(t *testing.T) {
+	a, err := domain.NewAddress(" Jane ", " 1 Main St ", "", " PDX ", " 97201 ", " USA ")
+	if err != nil {
+		t.Fatalf("NewAddress: %v", err)
+	}
+	if a.Name() != "Jane" || a.Street1() != "1 Main St" || a.City() != "PDX" {
+		t.Errorf("fields not trimmed: %+v", a)
+	}
+	if a.Street2() != "" {
+		t.Errorf("Street2 = %q, want empty", a.Street2())
+	}
+	if a.IsZero() {
+		t.Error("a populated address should not be IsZero")
+	}
+}
+
+func TestAddress_ZeroValueIsZero(t *testing.T) {
+	if !(domain.Address{}).IsZero() {
+		t.Error("zero Address should be IsZero")
+	}
+}

--- a/backend/checkout/domain/payment_method_test.go
+++ b/backend/checkout/domain/payment_method_test.go
@@ -1,0 +1,55 @@
+package domain_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/bkielbasa/go-ecommerce/backend/checkout/domain"
+)
+
+func TestPaymentMethodByCode(t *testing.T) {
+	cases := []struct {
+		code         string
+		requiresCard bool
+	}{
+		{"card", true},
+		{"paypal", false},
+		{"cod", false},
+	}
+	for _, c := range cases {
+		m, err := domain.PaymentMethodByCode(c.code)
+		if err != nil {
+			t.Fatalf("PaymentMethodByCode(%q): %v", c.code, err)
+		}
+		if m.RequiresCard() != c.requiresCard {
+			t.Errorf("%q RequiresCard = %v, want %v", c.code, m.RequiresCard(), c.requiresCard)
+		}
+	}
+}
+
+func TestPaymentMethodByCode_Invalid(t *testing.T) {
+	_, err := domain.PaymentMethodByCode("barter")
+	if !errors.Is(err, domain.ErrInvalidPaymentMethod) {
+		t.Errorf("err = %v, want ErrInvalidPaymentMethod", err)
+	}
+}
+
+func TestRebuildPaymentMethod_RequiresCardFromCode(t *testing.T) {
+	if !domain.RebuildPaymentMethod("card", "Credit / debit card").RequiresCard() {
+		t.Error("rebuilt card method should require a card")
+	}
+	if domain.RebuildPaymentMethod("cod", "Cash on delivery").RequiresCard() {
+		t.Error("rebuilt cod method should not require a card")
+	}
+}
+
+func TestPaymentMethods_ReturnsDefensiveCopy(t *testing.T) {
+	got := domain.PaymentMethods()
+	if len(got) == 0 {
+		t.Fatal("expected at least one payment method")
+	}
+	got[0] = domain.PaymentMethod{}
+	if domain.PaymentMethods()[0].IsZero() {
+		t.Error("mutating the returned slice leaked into the catalogue")
+	}
+}

--- a/backend/checkout/domain/place_test.go
+++ b/backend/checkout/domain/place_test.go
@@ -1,0 +1,72 @@
+package domain_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/bkielbasa/go-ecommerce/backend/checkout/domain"
+)
+
+func TestPlaceOrder_EmptyCartRejected(t *testing.T) {
+	_, err := domain.PlaceOrder("ord-1", "cart-1", "", domain.Address{},
+		domain.RebuildShippingMethod("pickup", "Personal pickup", 0),
+		domain.RebuildPaymentMethod("cod", "Cash on delivery"),
+		nil, time.Now())
+	if !errors.Is(err, domain.ErrCartEmpty) {
+		t.Errorf("err = %v, want ErrCartEmpty", err)
+	}
+}
+
+func TestPlaceOrder_EmitsPendingOrderPlaced(t *testing.T) {
+	at := time.Date(2026, 5, 27, 9, 0, 0, 0, time.UTC)
+	lines := []domain.Line{
+		domain.NewLine("v1", "Mug", 2, 1500, "USD"),
+		domain.NewLine("v2", "Plate", 1, 2000, "USD"),
+	}
+	o, err := domain.PlaceOrder("ord-1", "cart-1", "jane@example.com", domain.Address{},
+		domain.RebuildShippingMethod("courier", "Courier", 1500),
+		domain.RebuildPaymentMethod("card", "Credit / debit card"),
+		lines, at)
+	if err != nil {
+		t.Fatalf("PlaceOrder: %v", err)
+	}
+
+	if o.Status() != domain.StatusPending {
+		t.Errorf("status = %q, want pending", o.Status())
+	}
+	// A freshly placed order has exactly one uncommitted event at sequence 1.
+	pending := o.PendingEvents()
+	if len(pending) != 1 {
+		t.Fatalf("pending = %d, want 1", len(pending))
+	}
+	if _, ok := pending[0].(domain.OrderPlaced); !ok {
+		t.Errorf("pending[0] = %T, want OrderPlaced", pending[0])
+	}
+	if o.ExpectedVersion() != 0 {
+		t.Errorf("ExpectedVersion = %d, want 0 (first event appends at seq 1)", o.ExpectedVersion())
+	}
+	// subtotal 2*1500 + 1*2000 = 5000, + 1500 shipping = 6500.
+	if o.Subtotal() != 5000 {
+		t.Errorf("subtotal = %d, want 5000", o.Subtotal())
+	}
+	if o.TotalAmount() != 6500 {
+		t.Errorf("total = %d, want 6500", o.TotalAmount())
+	}
+	if o.TotalCurrency() != "USD" {
+		t.Errorf("currency = %q, want USD", o.TotalCurrency())
+	}
+}
+
+func TestLine_Totals(t *testing.T) {
+	l := domain.NewLine("v1", "Mug", 3, 1234, "USD")
+	if l.LineTotal() != 3702 {
+		t.Errorf("LineTotal = %d, want 3702", l.LineTotal())
+	}
+	if l.LineTotalDisplay() != "37.02" {
+		t.Errorf("LineTotalDisplay = %q, want 37.02", l.LineTotalDisplay())
+	}
+	if l.PriceDisplay() != "12.34" {
+		t.Errorf("PriceDisplay = %q, want 12.34", l.PriceDisplay())
+	}
+}

--- a/backend/checkout/domain/shipping_test.go
+++ b/backend/checkout/domain/shipping_test.go
@@ -1,0 +1,78 @@
+package domain_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/bkielbasa/go-ecommerce/backend/checkout/domain"
+)
+
+func TestShippingMethodByCode(t *testing.T) {
+	cases := []struct {
+		code            string
+		wantCost        int64
+		requiresAddress bool
+	}{
+		{"flat", 500, true},
+		{"pickup", 0, false},
+		{"courier", 1500, true},
+	}
+	for _, c := range cases {
+		m, err := domain.ShippingMethodByCode(c.code)
+		if err != nil {
+			t.Fatalf("ShippingMethodByCode(%q): %v", c.code, err)
+		}
+		if m.Cost() != c.wantCost {
+			t.Errorf("%q cost = %d, want %d", c.code, m.Cost(), c.wantCost)
+		}
+		if m.RequiresAddress() != c.requiresAddress {
+			t.Errorf("%q RequiresAddress = %v, want %v", c.code, m.RequiresAddress(), c.requiresAddress)
+		}
+		if m.IsZero() {
+			t.Errorf("%q should not be zero", c.code)
+		}
+	}
+}
+
+func TestShippingMethodByCode_Invalid(t *testing.T) {
+	_, err := domain.ShippingMethodByCode("teleport")
+	if !errors.Is(err, domain.ErrInvalidShippingMethod) {
+		t.Errorf("err = %v, want ErrInvalidShippingMethod", err)
+	}
+}
+
+func TestShippingMethods_ReturnsDefensiveCopy(t *testing.T) {
+	got := domain.ShippingMethods()
+	if len(got) == 0 {
+		t.Fatal("expected at least one shipping method")
+	}
+	got[0] = domain.ShippingMethod{} // mutate the returned slice
+	again := domain.ShippingMethods()
+	if again[0].IsZero() {
+		t.Error("mutating the returned slice leaked into the catalogue")
+	}
+}
+
+func TestRebuildShippingMethod_RequiresAddressFromCode(t *testing.T) {
+	pickup := domain.RebuildShippingMethod("pickup", "Personal pickup", 0)
+	if pickup.RequiresAddress() {
+		t.Error("rebuilt pickup should not require an address")
+	}
+	courier := domain.RebuildShippingMethod("courier", "Courier", 1500)
+	if !courier.RequiresAddress() {
+		t.Error("rebuilt courier should require an address")
+	}
+}
+
+func TestShippingMethod_CostDisplay(t *testing.T) {
+	m := domain.RebuildShippingMethod("courier", "Courier", 1500)
+	if got := m.CostDisplay(); got != "15.00" {
+		t.Errorf("CostDisplay = %q, want %q", got, "15.00")
+	}
+}
+
+func TestShippingMethod_ZeroValueIsZero(t *testing.T) {
+	if !(domain.ShippingMethod{}).IsZero() {
+		t.Error("zero ShippingMethod should be IsZero")
+	}
+}

--- a/backend/productcatalog/variant_test.go
+++ b/backend/productcatalog/variant_test.go
@@ -1,0 +1,97 @@
+package productcatalog_test
+
+import (
+	"testing"
+
+	"github.com/bkielbasa/go-ecommerce/backend/productcatalog"
+)
+
+func TestVariant_StockPredicates(t *testing.T) {
+	price := productcatalog.MustNewPrice(1000, productcatalog.MustNewCurrency("USD"))
+	cases := []struct {
+		stock       int
+		wantInStock bool
+		wantLow     bool
+	}{
+		{0, false, false},  // out of stock is never "low"
+		{1, true, true},    // just above empty
+		{5, true, true},    // at the threshold
+		{6, true, false},   // above the threshold
+		{100, true, false}, // plenty
+	}
+	for _, c := range cases {
+		v := productcatalog.NewVariant("v1", "SKU", "", nil, price, c.stock)
+		if v.InStock() != c.wantInStock {
+			t.Errorf("stock %d: InStock = %v, want %v", c.stock, v.InStock(), c.wantInStock)
+		}
+		if v.LowStock() != c.wantLow {
+			t.Errorf("stock %d: LowStock = %v, want %v", c.stock, v.LowStock(), c.wantLow)
+		}
+	}
+}
+
+func TestVariant_NilOptionsBecomeEmptyMap(t *testing.T) {
+	price := productcatalog.MustNewPrice(1000, productcatalog.MustNewCurrency("USD"))
+	v := productcatalog.NewVariant("v1", "SKU", "", nil, price, 1)
+	if v.Options() == nil {
+		t.Error("Options should be a non-nil empty map, not nil")
+	}
+	if len(v.Options()) != 0 {
+		t.Errorf("Options len = %d, want 0", len(v.Options()))
+	}
+}
+
+func TestVariant_LabelFollowsOptionTypeOrder(t *testing.T) {
+	price := productcatalog.MustNewPrice(1000, productcatalog.MustNewCurrency("USD"))
+	v := productcatalog.NewVariant("v1", "SKU", "", map[string]string{
+		"Size":  "L",
+		"Color": "Red",
+	}, price, 1)
+
+	// Option types define display order: Color first, then Size.
+	optionTypes := []productcatalog.OptionType{
+		productcatalog.NewOptionType("Color", []string{"Red", "Blue"}),
+		productcatalog.NewOptionType("Size", []string{"S", "L"}),
+	}
+	if got := v.Label(optionTypes); got != "Red / L" {
+		t.Errorf("Label = %q, want %q", got, "Red / L")
+	}
+
+	// A default variant (no options) has an empty label.
+	def := productcatalog.NewVariant("v0", "SKU0", "", nil, price, 1)
+	if got := def.Label(optionTypes); got != "" {
+		t.Errorf("default variant Label = %q, want empty", got)
+	}
+}
+
+func TestVariant_ZeroValueIsZero(t *testing.T) {
+	if !(productcatalog.Variant{}).IsZero() {
+		t.Error("zero Variant should be IsZero")
+	}
+}
+
+func TestNewPrice_Validation(t *testing.T) {
+	usd := productcatalog.MustNewCurrency("USD")
+	if _, err := productcatalog.NewPrice(-1, usd); err == nil {
+		t.Error("negative amount should be rejected")
+	}
+	if _, err := productcatalog.NewPrice(100, ""); err == nil {
+		t.Error("empty currency should be rejected")
+	}
+	p := productcatalog.MustNewPrice(1234, usd)
+	if p.Display() != "12.34" {
+		t.Errorf("Display = %q, want 12.34", p.Display())
+	}
+}
+
+func TestNewCurrency_Validation(t *testing.T) {
+	if _, err := productcatalog.NewCurrency("usd"); err == nil {
+		t.Error("lowercase currency should be rejected")
+	}
+	if _, err := productcatalog.NewCurrency("US"); err == nil {
+		t.Error("two-letter currency should be rejected")
+	}
+	if _, err := productcatalog.NewCurrency("USD"); err != nil {
+		t.Errorf("USD should be valid: %v", err)
+	}
+}

--- a/backend/shippinginfo/domain/address_test.go
+++ b/backend/shippinginfo/domain/address_test.go
@@ -1,0 +1,48 @@
+package domain_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/bkielbasa/go-ecommerce/backend/shippinginfo/domain"
+)
+
+func TestNewAddress_RequiresMandatoryFields(t *testing.T) {
+	now := time.Now()
+	// args after id/customerID: name, street1, street2, city, zip, country
+	base := []string{"Jane", "1 Main St", "apt 2", "PDX", "97201", "USA"}
+	required := map[int]string{0: "name", 1: "street1", 3: "city", 4: "zip", 5: "country"}
+
+	for idx := range required {
+		args := append([]string(nil), base...)
+		args[idx] = "  "
+		_, err := domain.NewAddress("a1", "jane@example.com", args[0], args[1], args[2], args[3], args[4], args[5], false, now)
+		if !errors.Is(err, domain.ErrInvalidAddress) {
+			t.Errorf("blank field %d: err = %v, want ErrInvalidAddress", idx, err)
+		}
+	}
+}
+
+func TestNewAddress_Street2Optional_AndTrims(t *testing.T) {
+	now := time.Now()
+	a, err := domain.NewAddress("a1", "jane@example.com", " Jane ", " 1 Main St ", "", " PDX ", " 97201 ", " USA ", true, now)
+	if err != nil {
+		t.Fatalf("NewAddress: %v", err)
+	}
+	if a.Name() != "Jane" || a.Street1() != "1 Main St" || a.City() != "PDX" || a.Country() != "USA" {
+		t.Errorf("fields not trimmed: %+v", a)
+	}
+	if !a.IsDefault() {
+		t.Error("IsDefault should be true")
+	}
+	if a.IsZero() {
+		t.Error("a populated address should not be IsZero")
+	}
+}
+
+func TestAddress_ZeroValueIsZero(t *testing.T) {
+	if !(domain.Address{}).IsZero() {
+		t.Error("zero Address should be IsZero")
+	}
+}


### PR DESCRIPTION
Adds table-driven unit tests for previously untested pure domain logic (review finding #5).

- **checkout** shipping/payment catalogues: lookup, invalid codes, required-address / required-card derivation, defensive-copy of the catalogue slice.
- **checkout & shippinginfo** `Address` validation: required fields, optional `street2`, whitespace trimming, `IsZero`.
- **checkout** `PlaceOrder` command: empty-cart rejection, `OrderPlaced` emission, expected version, total derivation; plus `Line` totals.
- **productcatalog** `Variant` stock predicates (low-stock threshold boundary), nil-options handling, label ordering, and `Price`/`Currency` validation.

## Test plan
- [x] `go test ./checkout/domain/... ./productcatalog/... ./shippinginfo/...` pass
- [x] vet / lint green