### PR TITLE
feat(checkout): integrate contexts via an OrderPaid event

### DIFF
--- a/backend/checkout/app/checkout.go
+++ b/backend/checkout/app/checkout.go
@@ -8,6 +8,8 @@ import (
 
 	cartDomain "github.com/bkielbasa/go-ecommerce/backend/cart/domain"
 	"github.com/bkielbasa/go-ecommerce/backend/checkout/domain"
+	"github.com/bkielbasa/go-ecommerce/backend/checkout/integration"
+	"github.com/bkielbasa/go-ecommerce/backend/internal/eventbus"
 )
 
 // CartReader returns the current cart for a session. It deliberately mirrors
@@ -17,9 +19,11 @@ type CartReader interface {
 	Get(ctx context.Context, sessID string) (*cartDomain.Cart, error)
 }
 
-// CartClearer empties the cart for a session after a successful order.
-type CartClearer interface {
-	Clear(ctx context.Context, sessID string) error
+// EventPublisher publishes integration events for other bounded contexts.
+// Checkout uses it instead of calling other contexts directly — e.g. it
+// announces that an order was paid rather than reaching into the cart.
+type EventPublisher interface {
+	Publish(ctx context.Context, e eventbus.Event)
 }
 
 type OrderStorage interface {
@@ -52,28 +56,28 @@ type IDGenerator func() string
 
 type CheckoutService struct {
 	cart    CartReader
-	cartClr CartClearer
 	storage OrderStorage
 	payment PaymentProcessor
 	stock   StockReserver
+	events  EventPublisher
 	newID   IDGenerator
 	now     func() time.Time
 }
 
 func NewCheckoutService(
 	cart CartReader,
-	cartClr CartClearer,
 	storage OrderStorage,
 	payment PaymentProcessor,
 	stock StockReserver,
+	events EventPublisher,
 	newID IDGenerator,
 ) CheckoutService {
 	return CheckoutService{
 		cart:    cart,
-		cartClr: cartClr,
 		storage: storage,
 		payment: payment,
 		stock:   stock,
+		events:  events,
 		newID:   newID,
 		now:     func() time.Time { return time.Now().UTC() },
 	}
@@ -143,9 +147,14 @@ func (s CheckoutService) Place(ctx context.Context, sessID, customerID, cardNumb
 		return domain.Order{}, fmt.Errorf("save order: %w", err)
 	}
 
-	// Cart clear failure is non-fatal — the order is already placed and the
-	// customer should see the confirmation page.
-	_ = s.cartClr.Clear(ctx, sessID)
+	// Announce the paid order. Subscribers (e.g. the cart context emptying the
+	// basket) react best-effort; their failures never block the confirmation.
+	s.events.Publish(ctx, integration.OrderPaid{
+		OrderID:    order.ID(),
+		SessionID:  sessID,
+		CustomerID: customerID,
+		At:         s.now(),
+	})
 
 	return *order, nil
 }

--- a/backend/checkout/bounded_context.go
+++ b/backend/checkout/bounded_context.go
@@ -11,6 +11,7 @@ import (
 	"github.com/bkielbasa/go-ecommerce/backend/checkout/app"
 	"github.com/bkielbasa/go-ecommerce/backend/checkout/query"
 	"github.com/bkielbasa/go-ecommerce/backend/internal/application"
+	"github.com/bkielbasa/go-ecommerce/backend/internal/eventbus"
 )
 
 // CartReader and CartClearer let New accept the cart service from the cart
@@ -18,10 +19,6 @@ import (
 // cycles and keeps the contract explicit).
 type CartReader interface {
 	Get(ctx context.Context, sessID string) (*cartDomain.Cart, error)
-}
-
-type CartClearer interface {
-	Clear(ctx context.Context, sessID string) error
 }
 
 // StockReserver is implemented by the product catalogue; checkout reserves
@@ -33,11 +30,13 @@ type StockReserver interface {
 
 // New wires the checkout context and returns its command service (write side,
 // event-sourced) and query service (read side, projection-backed) separately,
-// keeping the CQRS split explicit at the composition root.
-func New(db *sql.DB, cart CartReader, cartClr CartClearer, stock StockReserver) (application.BoundedContext, app.CheckoutService, query.Service) {
+// keeping the CQRS split explicit at the composition root. Cross-context side
+// effects (e.g. clearing the cart) are driven by integration events published
+// on bus, not by direct calls.
+func New(db *sql.DB, cart CartReader, bus *eventbus.Bus, stock StockReserver) (application.BoundedContext, app.CheckoutService, query.Service) {
 	storage := adapter.NewPostgres(db)
 	payment := adapter.NewFakePayment()
-	cmd := app.NewCheckoutService(cart, cartClr, storage, payment, stock, newOrderID)
+	cmd := app.NewCheckoutService(cart, storage, payment, stock, bus, newOrderID)
 	queries := query.NewService(storage)
 	return &boundedContext{}, cmd, queries
 }

--- a/backend/checkout/integration/events.go
+++ b/backend/checkout/integration/events.go
@@ -1,0 +1,19 @@
+// Package integration holds the checkout context's published language: the
+// integration events other bounded contexts may subscribe to. These are
+// distinct from the internal, event-sourced domain events in
+// checkout/domain — they are the stable contract checkout exposes outward.
+package integration
+
+import "time"
+
+// OrderPaid is published when an order's payment succeeds. Subscribers react
+// to it without checkout knowing about them — e.g. the cart context empties
+// the basket the order was placed from.
+type OrderPaid struct {
+	OrderID    string
+	SessionID  string // the cart/session id the order was placed from
+	CustomerID string
+	At         time.Time
+}
+
+func (OrderPaid) EventName() string { return "checkout.OrderPaid" }

--- a/backend/cmd/web/main.go
+++ b/backend/cmd/web/main.go
@@ -12,10 +12,12 @@ import (
 	"github.com/bkielbasa/go-ecommerce/backend/auth"
 	"github.com/bkielbasa/go-ecommerce/backend/cart"
 	"github.com/bkielbasa/go-ecommerce/backend/checkout"
+	checkoutintegration "github.com/bkielbasa/go-ecommerce/backend/checkout/integration"
 	"github.com/bkielbasa/go-ecommerce/backend/shippinginfo"
 	"github.com/bkielbasa/go-ecommerce/backend/internal"
 	"github.com/bkielbasa/go-ecommerce/backend/internal/application"
 	"github.com/bkielbasa/go-ecommerce/backend/internal/dependency"
+	"github.com/bkielbasa/go-ecommerce/backend/internal/eventbus"
 	"github.com/bkielbasa/go-ecommerce/backend/internal/observability"
 	"github.com/bkielbasa/go-ecommerce/backend/layout"
 	"github.com/bkielbasa/go-ecommerce/backend/productcatalog"
@@ -76,11 +78,19 @@ func main() {
 	}
 
 	app.AddDependency(dependency.NewSQL(db))
+	bus := eventbus.New(logger)
 	pcBD, catalogService := productcatalog.New(db)
 	cartBD, cartSrv := cart.New(db, logger, catalogService)
 	authBD, authService := auth.New(db)
-	checkoutBD, checkoutSrv, checkoutQry := checkout.New(db, cartSrv, cartSrv, catalogService)
+	checkoutBD, checkoutSrv, checkoutQry := checkout.New(db, cartSrv, bus, catalogService)
 	shipSrv := shippinginfo.New(db)
+
+	// Cross-context integration: when checkout reports an order paid, the cart
+	// context empties the basket it was placed from.
+	bus.Subscribe(checkoutintegration.OrderPaid{}.EventName(), func(ctx context.Context, e eventbus.Event) error {
+		return cartSrv.Clear(ctx, e.(checkoutintegration.OrderPaid).SessionID)
+	})
+
 	app.AddBoundedContext(cartBD)
 
 	app.AddBoundedContext(layout.New(logger, cartSrv, catalogService, authService, checkoutSrv, checkoutQry, shipSrv))

--- a/backend/internal/eventbus/eventbus.go
+++ b/backend/internal/eventbus/eventbus.go
@@ -1,0 +1,56 @@
+// Package eventbus provides a tiny synchronous, in-process publish/subscribe
+// dispatcher used for integration between bounded contexts. A context
+// publishes an integration event; other contexts subscribe and react. The
+// publisher stays unaware of who (if anyone) is listening.
+package eventbus
+
+import (
+	"context"
+	"sync"
+
+	"github.com/sirupsen/logrus"
+)
+
+// Event is an integration event published by one bounded context for others
+// to react to. Implementations belong to the publishing context's published
+// language.
+type Event interface {
+	EventName() string
+}
+
+// Handler reacts to a published event. A handler error is logged but does not
+// abort publishing or stop the remaining handlers: subscribers are
+// best-effort side effects, decoupled from the publisher's own transaction.
+type Handler func(ctx context.Context, e Event) error
+
+// Bus is a synchronous, in-process publish/subscribe dispatcher.
+type Bus struct {
+	mu       sync.RWMutex
+	handlers map[string][]Handler
+	logger   logrus.FieldLogger
+}
+
+func New(logger logrus.FieldLogger) *Bus {
+	return &Bus{handlers: map[string][]Handler{}, logger: logger}
+}
+
+// Subscribe registers a handler for an event name. Handlers fire in
+// registration order.
+func (b *Bus) Subscribe(eventName string, h Handler) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.handlers[eventName] = append(b.handlers[eventName], h)
+}
+
+// Publish dispatches an event to all subscribed handlers synchronously.
+func (b *Bus) Publish(ctx context.Context, e Event) {
+	b.mu.RLock()
+	hs := b.handlers[e.EventName()]
+	b.mu.RUnlock()
+
+	for _, h := range hs {
+		if err := h(ctx, e); err != nil && b.logger != nil {
+			b.logger.WithError(err).WithField("event", e.EventName()).Error("event handler failed")
+		}
+	}
+}

--- a/backend/internal/eventbus/eventbus_test.go
+++ b/backend/internal/eventbus/eventbus_test.go
@@ -1,0 +1,78 @@
+package eventbus_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/bkielbasa/go-ecommerce/backend/internal/eventbus"
+)
+
+type testEvent struct{ name string }
+
+func (e testEvent) EventName() string {
+	if e.name == "" {
+		return "test.Event"
+	}
+	return e.name
+}
+
+func TestPublish_DeliversToSubscriber(t *testing.T) {
+	bus := eventbus.New(nil)
+	var got int
+	bus.Subscribe("test.Event", func(context.Context, eventbus.Event) error {
+		got++
+		return nil
+	})
+
+	bus.Publish(context.Background(), testEvent{})
+
+	if got != 1 {
+		t.Errorf("handler called %d times, want 1", got)
+	}
+}
+
+func TestPublish_HandlersFireInRegistrationOrder(t *testing.T) {
+	bus := eventbus.New(nil)
+	var order []int
+	bus.Subscribe("test.Event", func(context.Context, eventbus.Event) error { order = append(order, 1); return nil })
+	bus.Subscribe("test.Event", func(context.Context, eventbus.Event) error { order = append(order, 2); return nil })
+
+	bus.Publish(context.Background(), testEvent{})
+
+	if len(order) != 2 || order[0] != 1 || order[1] != 2 {
+		t.Errorf("handler order = %v, want [1 2]", order)
+	}
+}
+
+func TestPublish_HandlerErrorDoesNotStopOthers(t *testing.T) {
+	bus := eventbus.New(nil) // nil logger: errors are swallowed, not logged
+	var second bool
+	bus.Subscribe("test.Event", func(context.Context, eventbus.Event) error { return errors.New("boom") })
+	bus.Subscribe("test.Event", func(context.Context, eventbus.Event) error { second = true; return nil })
+
+	bus.Publish(context.Background(), testEvent{})
+
+	if !second {
+		t.Error("second handler should still run after the first returns an error")
+	}
+}
+
+func TestPublish_NoSubscribersIsNoop(t *testing.T) {
+	bus := eventbus.New(nil)
+	// must not panic
+	bus.Publish(context.Background(), testEvent{name: "test.Unheard"})
+}
+
+func TestSubscribe_ScopedByEventName(t *testing.T) {
+	bus := eventbus.New(nil)
+	var a, b int
+	bus.Subscribe("test.A", func(context.Context, eventbus.Event) error { a++; return nil })
+	bus.Subscribe("test.B", func(context.Context, eventbus.Event) error { b++; return nil })
+
+	bus.Publish(context.Background(), testEvent{name: "test.A"})
+
+	if a != 1 || b != 0 {
+		t.Errorf("a=%d b=%d, want a=1 b=0 (handlers are scoped by event name)", a, b)
+	}
+}


### PR DESCRIPTION
Checkout previously emptied the cart by calling the cart context directly. This replaces that direct call with event-driven integration (review finding #4).

- **`internal/eventbus`**: a small synchronous in-process publish/subscribe bus; handler errors are logged, not propagated (best-effort subscribers). Unit-tested for delivery, ordering, error isolation, and event-name scoping.
- **`checkout/integration.OrderPaid`**: checkout's published-language integration event, distinct from its internal event-sourced domain events.
- **checkout** publishes `OrderPaid` after a successful payment and no longer depends on a `CartClearer`.
- **composition root** wires the cart-clear as a subscriber to `OrderPaid`.

## Test plan
- [x] `go test ./internal/eventbus/... ./checkout/...` pass
- [x] vet / lint green
- [x] docker: item in cart before order, "cart is empty" after the paid order (clear driven entirely by the event)