### PR TITLE
refactor(cart): name variant ids as variantID

### DIFF
--- a/backend/cart/app/cart.go
+++ b/backend/cart/app/cart.go
@@ -20,18 +20,18 @@ type CartStorage interface {
 }
 
 type ProductCatalog interface {
-	Find(ctx context.Context, productID string) (domain.Product, error)
+	Find(ctx context.Context, variantID string) (domain.Product, error)
 }
 
 func NewCartService(storage CartStorage, pc ProductCatalog) CartService {
 	return CartService{storage: storage, productCatalog: pc}
 }
 
-func (c CartService) AddToCart(ctx context.Context, sessID string, productID string, qty int) error {
+func (c CartService) AddToCart(ctx context.Context, sessID string, variantID string, qty int) error {
 	user := domain.NewUser(sessID)
-	p, err := c.productCatalog.Find(ctx, productID)
+	p, err := c.productCatalog.Find(ctx, variantID)
 	if err != nil {
-		return fmt.Errorf("could not find product (%s): %w", productID, err)
+		return fmt.Errorf("could not find product for variant (%s): %w", variantID, err)
 	}
 
 	cart, err := c.storage.Get(ctx, user)

--- a/backend/layout/http.go
+++ b/backend/layout/http.go
@@ -53,7 +53,7 @@ func (m boundedContext) MuxRegister(r *mux.Router) {
 	r.HandleFunc("/", m.handler.HomePage)
 
 	r.HandleFunc("/cart", observability.HTTPWrap(m.handler.Cart, m.logger)).Methods("GET")
-	r.HandleFunc("/cart/{cartID}", observability.HTTPWrap(m.handler.AddToCart, m.logger)).Methods("POST")
+	r.HandleFunc("/cart/{variantID}", observability.HTTPWrap(m.handler.AddToCart, m.logger)).Methods("POST")
 	r.HandleFunc("/cart/budge", observability.HTTPWrap(m.handler.Budge, m.logger)).Methods("GET", "OPTIONS")
 
 	r.HandleFunc("/api/v1/products", observability.HTTPWrap(m.handler.AllProducts, m.logger))

--- a/backend/layout/http_cart.go
+++ b/backend/layout/http_cart.go
@@ -16,9 +16,9 @@ import (
 
 func (handler httpHandler) AddToCart(w http.ResponseWriter, r *http.Request) {
 	cartID := cartIDFromCookies(w, r)
-	productID := mux.Vars(r)["cartID"]
+	variantID := mux.Vars(r)["variantID"]
 
-	err := handler.cartSrv.AddToCart(r.Context(), cartID, productID, 1)
+	err := handler.cartSrv.AddToCart(r.Context(), cartID, variantID, 1)
 
 	if errors.Is(err, domain.ErrProductNotFound) {
 		https.NotFound(w, "cart-not-found", err.Error())


### PR DESCRIPTION
The cart add-to-cart path keys on a variant id but the param/route were named productID/{cartID}. Rename to variantID and /cart/{variantID}. No behavior change (URL shape unchanged).