### PR TITLE
feat(admin): admin panel + store-style storefront navigation

### DIFF
--- a/backend/auth/adapter/auth_storage_postgres.go
+++ b/backend/auth/adapter/auth_storage_postgres.go
@@ -31,7 +31,7 @@ func (p authStoragePostgres) UpdatePassword(ctx context.Context, email, password
 func (p authStoragePostgres) Find(ctx context.Context, email string) (Customer, error) {
 	c := Customer{}
 
-	err := p.db.QueryRowContext(ctx, "SELECT username, password_hash FROM auth_customer WHERE username = $1", email).Scan(&c.Username, &c.PasswordHash)
+	err := p.db.QueryRowContext(ctx, "SELECT username, password_hash, is_admin FROM auth_customer WHERE username = $1", email).Scan(&c.Username, &c.PasswordHash, &c.IsAdmin)
 
 	if err == sql.ErrNoRows {
 		return Customer{}, domain.ErrCustomerNotFound

--- a/backend/auth/adapter/customer.go
+++ b/backend/auth/adapter/customer.go
@@ -7,4 +7,5 @@ package adapter
 type Customer struct {
 	Username     string
 	PasswordHash string
+	IsAdmin      bool
 }

--- a/backend/auth/app/auth.go
+++ b/backend/auth/app/auth.go
@@ -159,6 +159,21 @@ func (a auth) ChangePassword(ctx context.Context, email, oldPassword, newPasswor
 	return a.authStorage.UpdatePassword(ctx, email, newHash)
 }
 
+// IsAdmin reports whether the customer identified by email has the admin
+// flag set. A missing customer is treated as a non-admin (false, nil); any
+// other lookup error is returned.
+func (a auth) IsAdmin(ctx context.Context, email string) (bool, error) {
+	customer, err := a.authStorage.Find(ctx, email)
+	if err == domain.ErrCustomerNotFound {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("could not find customer: %w", err)
+	}
+
+	return customer.IsAdmin, nil
+}
+
 func hashPassword(password string) (string, error) {
 	bytes, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
 	return string(bytes), err

--- a/backend/auth/bounded_context.go
+++ b/backend/auth/bounded_context.go
@@ -19,6 +19,7 @@ type appService interface {
 	Logout(ctx context.Context, sesionID string) error
 	FindByToken(ctx context.Context, sessToken string) (*domain.Session, error)
 	ChangePassword(ctx context.Context, email, oldPassword, newPassword string) error
+	IsAdmin(ctx context.Context, email string) (bool, error)
 }
 
 func New(db *sql.DB) (application.BoundedContext, appService) {

--- a/backend/checkout/adapter/postgres.go
+++ b/backend/checkout/adapter/postgres.go
@@ -152,7 +152,43 @@ func (p Postgres) ListByCustomer(ctx context.Context, customerID string) ([]quer
 		if err := rows.Scan(&id, &status, &placedAt, &total, &currency, &itemCount); err != nil {
 			return nil, fmt.Errorf("scan order: %w", err)
 		}
-		summaries = append(summaries, query.NewOrderSummary(id, domain.Status(status), placedAt, itemCount, total, currency))
+		summaries = append(summaries, query.NewOrderSummary(customerID, id, domain.Status(status), placedAt, itemCount, total, currency))
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("rows: %w", err)
+	}
+	return summaries, nil
+}
+
+// ListAll returns every order newest-first as list summaries, regardless of
+// customer (including anonymous orders with a NULL customer_id). It powers the
+// admin order list and uses the same grouped query as ListByCustomer without
+// the customer filter.
+func (p Postgres) ListAll(ctx context.Context) ([]query.OrderSummary, error) {
+	rows, err := p.db.QueryContext(ctx, `
+		SELECT o.id, o.customer_id, o.status, o.placed_at, o.total_amount, o.total_currency,
+		       COUNT(i.id) AS item_count
+		FROM checkout_order o
+		LEFT JOIN checkout_order_item i ON i.order_id = o.id
+		GROUP BY o.id, o.customer_id, o.status, o.placed_at, o.total_amount, o.total_currency
+		ORDER BY o.placed_at DESC
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("query orders: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var summaries []query.OrderSummary
+	for rows.Next() {
+		var id, status, currency string
+		var customerID sql.NullString
+		var placedAt time.Time
+		var total int64
+		var itemCount int
+		if err := rows.Scan(&id, &customerID, &status, &placedAt, &total, &currency, &itemCount); err != nil {
+			return nil, fmt.Errorf("scan order: %w", err)
+		}
+		summaries = append(summaries, query.NewOrderSummary(customerID.String, id, domain.Status(status), placedAt, itemCount, total, currency))
 	}
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("rows: %w", err)

--- a/backend/checkout/app/checkout.go
+++ b/backend/checkout/app/checkout.go
@@ -174,7 +174,25 @@ func (s CheckoutService) Cancel(ctx context.Context, orderID, customerID string)
 		return domain.ErrOrderNotFound
 	}
 
-	if err := order.Cancel("cancelled by customer", s.now()); err != nil {
+	return s.cancel(ctx, order, "cancelled by customer")
+}
+
+// AdminCancel cancels any paid order on behalf of an administrator, without an
+// ownership check. It rehydrates the aggregate, applies Cancel (returning
+// ErrOrderNotCancellable for non-paid orders), persists the OrderCancelled
+// event, and returns the reserved stock to the catalogue.
+func (s CheckoutService) AdminCancel(ctx context.Context, orderID string) error {
+	order, err := s.storage.Load(ctx, orderID)
+	if err != nil {
+		return err
+	}
+	return s.cancel(ctx, order, "cancelled by admin")
+}
+
+// cancel applies the Cancel command, persists it, and releases reserved stock
+// (best-effort). Shared by the customer and admin cancellation flows.
+func (s CheckoutService) cancel(ctx context.Context, order *domain.Order, reason string) error {
+	if err := order.Cancel(reason, s.now()); err != nil {
 		return err
 	}
 	if err := s.storage.Save(ctx, order); err != nil {

--- a/backend/checkout/query/service.go
+++ b/backend/checkout/query/service.go
@@ -7,6 +7,7 @@ import "context"
 type Repository interface {
 	Find(ctx context.Context, id string) (OrderView, error)
 	ListByCustomer(ctx context.Context, customerID string) ([]OrderSummary, error)
+	ListAll(ctx context.Context) ([]OrderSummary, error)
 }
 
 // Service is the checkout query side. It is intentionally separate from the
@@ -31,4 +32,10 @@ func (s Service) ListByCustomer(ctx context.Context, customerID string) ([]Order
 		return nil, nil
 	}
 	return s.repo.ListByCustomer(ctx, customerID)
+}
+
+// ListAll returns every order newest-first as summaries, regardless of
+// customer. Intended for the admin order list.
+func (s Service) ListAll(ctx context.Context) ([]OrderSummary, error) {
+	return s.repo.ListAll(ctx)
 }

--- a/backend/checkout/query/views.go
+++ b/backend/checkout/query/views.go
@@ -15,20 +15,23 @@ func money(amount int64) string {
 	return fmt.Sprintf("%d.%02d", amount/100, amount%100)
 }
 
-// OrderSummary is the read model for order lists (account orders, overview).
+// OrderSummary is the read model for order lists (account orders, overview,
+// admin order list).
 type OrderSummary struct {
-	id        string
-	status    domain.Status
-	placedAt  time.Time
-	itemCount int
-	total     int64
-	currency  string
+	customerID string
+	id         string
+	status     domain.Status
+	placedAt   time.Time
+	itemCount  int
+	total      int64
+	currency   string
 }
 
-func NewOrderSummary(id string, status domain.Status, placedAt time.Time, itemCount int, total int64, currency string) OrderSummary {
-	return OrderSummary{id: id, status: status, placedAt: placedAt, itemCount: itemCount, total: total, currency: currency}
+func NewOrderSummary(customerID, id string, status domain.Status, placedAt time.Time, itemCount int, total int64, currency string) OrderSummary {
+	return OrderSummary{customerID: customerID, id: id, status: status, placedAt: placedAt, itemCount: itemCount, total: total, currency: currency}
 }
 
+func (s OrderSummary) CustomerID() string    { return s.customerID }
 func (s OrderSummary) ID() string            { return s.id }
 func (s OrderSummary) Status() domain.Status { return s.status }
 func (s OrderSummary) PlacedAt() time.Time   { return s.placedAt }

--- a/backend/cmd/cli/seeds.go
+++ b/backend/cmd/cli/seeds.go
@@ -7,7 +7,32 @@ import (
 
 	"github.com/bkielbasa/go-ecommerce/backend/productcatalog/app"
 	"github.com/spf13/cobra"
+	"golang.org/x/crypto/bcrypt"
 )
+
+// seedAdmin email/password for the demo admin account. The password is
+// hashed with the same bcrypt cost the auth service uses (bcrypt.DefaultCost)
+// so the seeded credentials work against the normal login flow.
+const (
+	seedAdminEmail    = "admin@example.com"
+	seedAdminPassword = "Admin123!"
+)
+
+const upsertAdmin = `INSERT INTO auth_customer (username, password_hash, is_admin)
+	VALUES ($1, $2, true)
+	ON CONFLICT (username) DO UPDATE SET is_admin = true`
+
+// seedAdminUser idempotently creates (or promotes) the demo admin account.
+func seedAdminUser(ctx context.Context, db *sql.DB) error {
+	hash, err := bcrypt.GenerateFromPassword([]byte(seedAdminPassword), bcrypt.DefaultCost)
+	if err != nil {
+		return fmt.Errorf("hash admin password: %w", err)
+	}
+	if _, err := db.ExecContext(ctx, upsertAdmin, seedAdminEmail, string(hash)); err != nil {
+		return fmt.Errorf("seed admin user: %w", err)
+	}
+	return nil
+}
 
 type seedProduct struct {
 	id              string
@@ -390,9 +415,13 @@ func newSeedsCmd(pc productCatalog, db *sql.DB) *cobra.Command {
 				return err
 			}
 
-			fmt.Printf("seeded %d simple + %d variant products, %d attribute types, %d categories, %d category assignments, %d attribute values\n",
+			if err := seedAdminUser(ctx, db); err != nil {
+				return err
+			}
+
+			fmt.Printf("seeded %d simple + %d variant products, %d attribute types, %d categories, %d category assignments, %d attribute values, admin user %s (password %s)\n",
 				len(seedProducts), len(variantSeeds), len(attributeTypeSeeds), len(categorySeeds),
-				countCategoryAssignments(), len(productAttributeSeeds))
+				countCategoryAssignments(), len(productAttributeSeeds), seedAdminEmail, seedAdminPassword)
 			return nil
 		},
 	}

--- a/backend/cmd/cli/seeds.go
+++ b/backend/cmd/cli/seeds.go
@@ -388,6 +388,39 @@ func seedReferenceData(ctx context.Context, db *sql.DB) error {
 	return nil
 }
 
+// seededProductIDsInOrder returns the seeded product ids in the order they are
+// inserted (simple products first, then variant products).
+func seededProductIDsInOrder() []string {
+	ids := make([]string, 0, len(seedProducts)+len(variantSeeds))
+	for _, p := range seedProducts {
+		ids = append(ids, p.id)
+	}
+	for _, p := range variantSeeds {
+		ids = append(ids, p.id)
+	}
+	return ids
+}
+
+// seedCreatedAt makes the catalogue ordering deterministic so "new arrivals"
+// is stable: each seeded product's created_at is set to now() minus a per-row
+// day offset. The first-seeded product gets the largest offset (oldest) and
+// the last-seeded product the smallest (newest), so admin-created products
+// (which default to now()) sort newest of all. Idempotent: re-running simply
+// resets the timestamps.
+func seedCreatedAt(ctx context.Context, db *sql.DB) error {
+	ids := seededProductIDsInOrder()
+	n := len(ids)
+	for i, id := range ids {
+		offset := n - i // first row => largest offset (oldest)
+		if _, err := db.ExecContext(ctx,
+			`UPDATE productcatalog_product SET created_at = now() - make_interval(days => $2) WHERE id = $1`,
+			id, offset); err != nil {
+			return fmt.Errorf("seed created_at for %s: %w", id, err)
+		}
+	}
+	return nil
+}
+
 func newSeedsCmd(pc productCatalog, db *sql.DB) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "seeds",
@@ -409,6 +442,10 @@ func newSeedsCmd(pc productCatalog, db *sql.DB) *cobra.Command {
 				if err := pc.AddVariantProduct(ctx, p.id, p.name, p.description, p.currency, p.thumbnail, p.optionTypes, p.variants); err != nil {
 					return fmt.Errorf("seed variant product %s: %w", p.id, err)
 				}
+			}
+
+			if err := seedCreatedAt(ctx, db); err != nil {
+				return err
 			}
 
 			if err := seedReferenceData(ctx, db); err != nil {

--- a/backend/layout/bounded_context.go
+++ b/backend/layout/bounded_context.go
@@ -21,6 +21,15 @@ type catalogService interface {
 	List(ctx context.Context, q pcapp.ProductQuery) ([]pcdomain.Product, error)
 	Categories(ctx context.Context) ([]pcdomain.Category, error)
 	Facets(ctx context.Context, categorySlug string) ([]pcapp.Facet, error)
+
+	CreateCategory(ctx context.Context, name, slug string) error
+	UpdateCategory(ctx context.Context, id, name, slug string, position int) error
+	DeleteCategory(ctx context.Context, id string) error
+
+	AttributeTypes(ctx context.Context) ([]pcdomain.AttributeType, error)
+	CreateAttributeType(ctx context.Context, name, unit string, kind pcdomain.AttributeKind, filterable bool) error
+	UpdateAttributeType(ctx context.Context, id, name, unit string, kind pcdomain.AttributeKind, filterable bool, position int) error
+	DeleteAttributeType(ctx context.Context, id string) error
 }
 
 type cartService interface {

--- a/backend/layout/bounded_context.go
+++ b/backend/layout/bounded_context.go
@@ -22,6 +22,13 @@ type catalogService interface {
 	Categories(ctx context.Context) ([]pcdomain.Category, error)
 	Facets(ctx context.Context, categorySlug string) ([]pcapp.Facet, error)
 
+	Add(ctx context.Context, id, name, desc string, priceMinorUnits int64, currency, thumbnail string) error
+	UpdateProduct(ctx context.Context, id, name, desc string, priceMinorUnits int64, currency, thumbnail string) error
+	DeleteProduct(ctx context.Context, id string) error
+	SetVariantStock(ctx context.Context, variantID string, stock int) error
+	SetProductCategories(ctx context.Context, productID string, categoryIDs []string) error
+	SetProductAttributes(ctx context.Context, productID string, values []pcapp.AttributeAssignment) error
+
 	CreateCategory(ctx context.Context, name, slug string) error
 	UpdateCategory(ctx context.Context, id, name, slug string, position int) error
 	DeleteCategory(ctx context.Context, id string) error

--- a/backend/layout/bounded_context.go
+++ b/backend/layout/bounded_context.go
@@ -34,6 +34,7 @@ type authService interface {
 	CreateNewCustomer(ctx context.Context, email, password string) error
 	FindByToken(ctx context.Context, sessToken string) (*authDomain.Session, error)
 	ChangePassword(ctx context.Context, email, oldPassword, newPassword string) error
+	IsAdmin(ctx context.Context, email string) (bool, error)
 }
 
 type shippingService interface {

--- a/backend/layout/bounded_context.go
+++ b/backend/layout/bounded_context.go
@@ -17,6 +17,7 @@ import (
 
 type catalogService interface {
 	AllProducts(ctx context.Context) ([]pcdomain.Product, error)
+	Newest(ctx context.Context, limit int) ([]pcdomain.Product, error)
 	Find(ctx context.Context, id string) (pcdomain.Product, error)
 	List(ctx context.Context, q pcapp.ProductQuery) ([]pcdomain.Product, error)
 	Categories(ctx context.Context) ([]pcdomain.Category, error)

--- a/backend/layout/bounded_context.go
+++ b/backend/layout/bounded_context.go
@@ -67,6 +67,7 @@ type shippingService interface {
 type checkoutCommands interface {
 	Place(ctx context.Context, sessID, customerID, cardNumber string, shipTo checkoutDomain.Address, shipMethod checkoutDomain.ShippingMethod, payMethod checkoutDomain.PaymentMethod) (checkoutDomain.Order, error)
 	Cancel(ctx context.Context, orderID, customerID string) error
+	AdminCancel(ctx context.Context, orderID string) error
 }
 
 // checkoutQueries is the read side of the checkout context (CQRS); it returns
@@ -74,6 +75,7 @@ type checkoutCommands interface {
 type checkoutQueries interface {
 	Find(ctx context.Context, id string) (checkoutQuery.OrderView, error)
 	ListByCustomer(ctx context.Context, customerID string) ([]checkoutQuery.OrderSummary, error)
+	ListAll(ctx context.Context) ([]checkoutQuery.OrderSummary, error)
 }
 
 func New(logger logrus.FieldLogger, cartSrv cartService, catalogSrv catalogService, authSrv authService, checkoutSrv checkoutCommands, checkoutQry checkoutQueries, shipSrv shippingService) application.BoundedContext {

--- a/backend/layout/http.go
+++ b/backend/layout/http.go
@@ -119,6 +119,18 @@ func (m boundedContext) MuxRegister(r *mux.Router) {
 	// Admin panel. Later phases register the /admin/products, /admin/categories,
 	// /admin/attributes and /admin/orders handlers here, all behind requireAdmin.
 	r.HandleFunc("/admin", observability.HTTPWrap(m.handler.AdminDashboard, m.logger)).Methods("GET")
+
+	r.HandleFunc("/admin/categories", observability.HTTPWrap(m.handler.AdminCategories, m.logger)).Methods("GET")
+	r.HandleFunc("/admin/categories", observability.HTTPWrap(m.handler.AdminCreateCategory, m.logger)).Methods("POST")
+	r.HandleFunc("/admin/categories/{id}/edit", observability.HTTPWrap(m.handler.AdminEditCategoryForm, m.logger)).Methods("GET")
+	r.HandleFunc("/admin/categories/{id}/delete", observability.HTTPWrap(m.handler.AdminDeleteCategory, m.logger)).Methods("POST")
+	r.HandleFunc("/admin/categories/{id}", observability.HTTPWrap(m.handler.AdminUpdateCategory, m.logger)).Methods("POST")
+
+	r.HandleFunc("/admin/attributes", observability.HTTPWrap(m.handler.AdminAttributes, m.logger)).Methods("GET")
+	r.HandleFunc("/admin/attributes", observability.HTTPWrap(m.handler.AdminCreateAttribute, m.logger)).Methods("POST")
+	r.HandleFunc("/admin/attributes/{id}/edit", observability.HTTPWrap(m.handler.AdminEditAttributeForm, m.logger)).Methods("GET")
+	r.HandleFunc("/admin/attributes/{id}/delete", observability.HTTPWrap(m.handler.AdminDeleteAttribute, m.logger)).Methods("POST")
+	r.HandleFunc("/admin/attributes/{id}", observability.HTTPWrap(m.handler.AdminUpdateAttribute, m.logger)).Methods("POST")
 }
 
 func (handler httpHandler) renderTemplate(w http.ResponseWriter, r *http.Request, templateName string, data map[string]any) {

--- a/backend/layout/http.go
+++ b/backend/layout/http.go
@@ -44,7 +44,21 @@ type httpHandler struct {
 	shipSrv     shippingService
 }
 
+// HomePage renders the storefront landing page: a "new arrivals" grid of the
+// newest products plus a link through to the full shop.
 func (handler httpHandler) HomePage(w http.ResponseWriter, r *http.Request) {
+	newest, err := handler.catalogSrv.Newest(r.Context(), 8)
+	if err != nil {
+		log.Printf("cannot get newest products: %s", err)
+		newest = nil
+	}
+	handler.renderTemplate(w, r, "home", map[string]any{
+		"Newest": newest,
+	})
+}
+
+// ShopPage renders the full filterable catalog (all categories).
+func (handler httpHandler) ShopPage(w http.ResponseWriter, r *http.Request) {
 	handler.renderProductsPage(w, r, "")
 }
 
@@ -72,7 +86,7 @@ func (handler httpHandler) renderProductsPage(w http.ResponseWriter, r *http.Req
 		facets = nil
 	}
 
-	handler.renderTemplate(w, r, "home", map[string]any{
+	handler.renderTemplate(w, r, "productCatalog/catalog", map[string]any{
 		"Categories":     categories,
 		"Facets":         facets,
 		"ActiveCategory": activeCategory,
@@ -82,6 +96,7 @@ func (handler httpHandler) renderProductsPage(w http.ResponseWriter, r *http.Req
 func (m boundedContext) MuxRegister(r *mux.Router) {
 	r.PathPrefix("/static/").Handler(StaticHandler())
 	r.HandleFunc("/", m.handler.HomePage)
+	r.HandleFunc("/products", observability.HTTPWrap(m.handler.ShopPage, m.logger)).Methods("GET")
 	r.HandleFunc("/category/{slug}", observability.HTTPWrap(m.handler.CategoryPage, m.logger)).Methods("GET")
 
 	r.HandleFunc("/cart", observability.HTTPWrap(m.handler.Cart, m.logger)).Methods("GET")
@@ -172,7 +187,14 @@ func (handler httpHandler) renderTemplate(w http.ResponseWriter, r *http.Request
 	data["AuthMenuItem"] = renderPartial(w, r, http.HandlerFunc(handler.AuthMenuItem))
 	data["LoggedIn"] = handler.currentCustomerID(r) != ""
 	data["IsAdmin"] = handler.isAdmin(r)
-	err := session.Save(r, w)
+	// NavCategories lets the storefront header list category links on every page.
+	navCategories, err := handler.catalogSrv.Categories(r.Context())
+	if err != nil {
+		log.Printf("cannot get nav categories: %s", err)
+		navCategories = nil
+	}
+	data["NavCategories"] = navCategories
+	err = session.Save(r, w)
 	if err != nil {
 		log.Print(err.Error())
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)

--- a/backend/layout/http.go
+++ b/backend/layout/http.go
@@ -140,6 +140,10 @@ func (m boundedContext) MuxRegister(r *mux.Router) {
 	r.HandleFunc("/admin/attributes/{id}/edit", observability.HTTPWrap(m.handler.AdminEditAttributeForm, m.logger)).Methods("GET")
 	r.HandleFunc("/admin/attributes/{id}/delete", observability.HTTPWrap(m.handler.AdminDeleteAttribute, m.logger)).Methods("POST")
 	r.HandleFunc("/admin/attributes/{id}", observability.HTTPWrap(m.handler.AdminUpdateAttribute, m.logger)).Methods("POST")
+
+	r.HandleFunc("/admin/orders", observability.HTTPWrap(m.handler.AdminOrders, m.logger)).Methods("GET")
+	r.HandleFunc("/admin/orders/{orderID}/cancel", observability.HTTPWrap(m.handler.AdminCancelOrder, m.logger)).Methods("POST")
+	r.HandleFunc("/admin/orders/{orderID}", observability.HTTPWrap(m.handler.AdminOrderDetail, m.logger)).Methods("GET")
 }
 
 func (handler httpHandler) renderTemplate(w http.ResponseWriter, r *http.Request, templateName string, data map[string]any) {

--- a/backend/layout/http.go
+++ b/backend/layout/http.go
@@ -185,6 +185,48 @@ func (handler httpHandler) renderTemplate(w http.ResponseWriter, r *http.Request
 	}
 }
 
+// renderAdminTemplate mirrors renderTemplate but renders inside the dedicated
+// admin shell (tmpl/admin/layout.gohtml, which defines "adminbase") instead of
+// the storefront base. It still pulls in the shared partials glob (where the
+// admin-nav partial lives) and the page template (which defines "main"), but it
+// does not need AuthMenuItem/LoggedIn/IsAdmin — the admin shell exposes the
+// signed-in admin via data["AdminEmail"].
+func (handler httpHandler) renderAdminTemplate(w http.ResponseWriter, r *http.Request, templateName string, data map[string]any) {
+	if data == nil {
+		data = make(map[string]any)
+	}
+
+	files := []string{
+		"./layout/tmpl/admin/layout.gohtml",
+		"./layout/tmpl/" + templateName + ".gohtml",
+	}
+	partials, _ := filepath.Glob("./layout/tmpl/partials/*.gohtml")
+	files = append(files, partials...)
+
+	var ts = template.Must(template.New("").Funcs(template.FuncMap{
+		"html": func(value interface{}) template.HTML {
+			return template.HTML(fmt.Sprint(value))
+		},
+		"add": func(a, b int) int { return a + b },
+	}).ParseFiles(files...))
+
+	session, _ := store.Get(r, "ecommerce")
+	data["FlashInfo"] = session.Flashes()
+	data["FlashError"] = session.Flashes("error")
+	data["AdminEmail"] = handler.currentCustomerID(r)
+	err := session.Save(r, w)
+	if err != nil {
+		log.Print(err.Error())
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+	}
+
+	err = ts.ExecuteTemplate(w, "adminbase", data)
+	if err != nil {
+		log.Print(err.Error())
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+	}
+}
+
 func renderPartial(w http.ResponseWriter, r *http.Request, h http.HandlerFunc) string {
 	buf := buffer{buf: bytes.NewBufferString("")}
 	h.ServeHTTP(http.ResponseWriter(&buf), r)

--- a/backend/layout/http.go
+++ b/backend/layout/http.go
@@ -120,6 +120,15 @@ func (m boundedContext) MuxRegister(r *mux.Router) {
 	// /admin/attributes and /admin/orders handlers here, all behind requireAdmin.
 	r.HandleFunc("/admin", observability.HTTPWrap(m.handler.AdminDashboard, m.logger)).Methods("GET")
 
+	r.HandleFunc("/admin/products", observability.HTTPWrap(m.handler.AdminProducts, m.logger)).Methods("GET")
+	r.HandleFunc("/admin/products", observability.HTTPWrap(m.handler.AdminCreateProduct, m.logger)).Methods("POST")
+	r.HandleFunc("/admin/products/{id}/edit", observability.HTTPWrap(m.handler.AdminEditProductForm, m.logger)).Methods("GET")
+	r.HandleFunc("/admin/products/{id}/stock", observability.HTTPWrap(m.handler.AdminUpdateProductStock, m.logger)).Methods("POST")
+	r.HandleFunc("/admin/products/{id}/categories", observability.HTTPWrap(m.handler.AdminUpdateProductCategories, m.logger)).Methods("POST")
+	r.HandleFunc("/admin/products/{id}/attributes", observability.HTTPWrap(m.handler.AdminUpdateProductAttributes, m.logger)).Methods("POST")
+	r.HandleFunc("/admin/products/{id}/delete", observability.HTTPWrap(m.handler.AdminDeleteProduct, m.logger)).Methods("POST")
+	r.HandleFunc("/admin/products/{id}", observability.HTTPWrap(m.handler.AdminUpdateProduct, m.logger)).Methods("POST")
+
 	r.HandleFunc("/admin/categories", observability.HTTPWrap(m.handler.AdminCategories, m.logger)).Methods("GET")
 	r.HandleFunc("/admin/categories", observability.HTTPWrap(m.handler.AdminCreateCategory, m.logger)).Methods("POST")
 	r.HandleFunc("/admin/categories/{id}/edit", observability.HTTPWrap(m.handler.AdminEditCategoryForm, m.logger)).Methods("GET")
@@ -150,6 +159,7 @@ func (handler httpHandler) renderTemplate(w http.ResponseWriter, r *http.Request
 		"html": func(value interface{}) template.HTML {
 			return template.HTML(fmt.Sprint(value))
 		},
+		"add": func(a, b int) int { return a + b },
 	}).ParseFiles(files...))
 
 	session, _ := store.Get(r, "ecommerce")

--- a/backend/layout/http.go
+++ b/backend/layout/http.go
@@ -115,6 +115,10 @@ func (m boundedContext) MuxRegister(r *mux.Router) {
 	r.HandleFunc("/account/addresses/{id}/default", observability.HTTPWrap(m.handler.AccountSetDefaultAddress, m.logger)).Methods("POST")
 	r.HandleFunc("/account/details", observability.HTTPWrap(m.handler.AccountDetails, m.logger)).Methods("GET")
 	r.HandleFunc("/account/details/password", observability.HTTPWrap(m.handler.AccountChangePassword, m.logger)).Methods("POST")
+
+	// Admin panel. Later phases register the /admin/products, /admin/categories,
+	// /admin/attributes and /admin/orders handlers here, all behind requireAdmin.
+	r.HandleFunc("/admin", observability.HTTPWrap(m.handler.AdminDashboard, m.logger)).Methods("GET")
 }
 
 func (handler httpHandler) renderTemplate(w http.ResponseWriter, r *http.Request, templateName string, data map[string]any) {
@@ -141,6 +145,7 @@ func (handler httpHandler) renderTemplate(w http.ResponseWriter, r *http.Request
 	data["FlashError"] = session.Flashes("error")
 	data["AuthMenuItem"] = renderPartial(w, r, http.HandlerFunc(handler.AuthMenuItem))
 	data["LoggedIn"] = handler.currentCustomerID(r) != ""
+	data["IsAdmin"] = handler.isAdmin(r)
 	err := session.Save(r, w)
 	if err != nil {
 		log.Print(err.Error())

--- a/backend/layout/http_admin.go
+++ b/backend/layout/http_admin.go
@@ -56,11 +56,16 @@ func (handler httpHandler) AdminDashboard(w http.ResponseWriter, r *http.Request
 	if err != nil {
 		categories = nil
 	}
+	orders, err := handler.checkoutQry.ListAll(r.Context())
+	if err != nil {
+		orders = nil
+	}
 
 	handler.renderTemplate(w, r, "admin/dashboard", map[string]any{
 		"Active":        "dashboard",
 		"Email":         email,
 		"ProductCount":  len(products),
 		"CategoryCount": len(categories),
+		"OrderCount":    len(orders),
 	})
 }

--- a/backend/layout/http_admin.go
+++ b/backend/layout/http_admin.go
@@ -1,0 +1,66 @@
+package layout
+
+import (
+	"net/http"
+)
+
+// requireAdmin is the access gate for every admin page. It resolves the
+// current customer and confirms they hold the admin flag. On failure it has
+// already written the response (a redirect to login for anonymous users, or a
+// 403 for non-admins) and returns ok=false; callers should simply return.
+//
+// Later admin phases (products, categories, orders, ...) reuse this gate as
+// their first line.
+func (handler httpHandler) requireAdmin(w http.ResponseWriter, r *http.Request) (string, bool) {
+	email := handler.currentCustomerID(r)
+	if email == "" {
+		http.Redirect(w, r, "/auth/login", http.StatusSeeOther)
+		return "", false
+	}
+
+	isAdmin, err := handler.authSrv.IsAdmin(r.Context(), email)
+	if err != nil || !isAdmin {
+		http.Error(w, "Forbidden", http.StatusForbidden)
+		return "", false
+	}
+
+	return email, true
+}
+
+// isAdmin is a defensive helper for templates: it reports whether the current
+// request belongs to a logged-in admin, swallowing any lookup error as a
+// non-admin. Used by renderTemplate to expose `.IsAdmin`.
+func (handler httpHandler) isAdmin(r *http.Request) bool {
+	email := handler.currentCustomerID(r)
+	if email == "" {
+		return false
+	}
+	isAdmin, err := handler.authSrv.IsAdmin(r.Context(), email)
+	return err == nil && isAdmin
+}
+
+// AdminDashboard renders the admin landing page with at-a-glance counts and
+// the shared admin sub-navigation. It is the shell for the CRUD sections that
+// later phases hang off /admin/*.
+func (handler httpHandler) AdminDashboard(w http.ResponseWriter, r *http.Request) {
+	email, ok := handler.requireAdmin(w, r)
+	if !ok {
+		return
+	}
+
+	products, err := handler.catalogSrv.AllProducts(r.Context())
+	if err != nil {
+		products = nil
+	}
+	categories, err := handler.catalogSrv.Categories(r.Context())
+	if err != nil {
+		categories = nil
+	}
+
+	handler.renderTemplate(w, r, "admin/dashboard", map[string]any{
+		"Active":        "dashboard",
+		"Email":         email,
+		"ProductCount":  len(products),
+		"CategoryCount": len(categories),
+	})
+}

--- a/backend/layout/http_admin.go
+++ b/backend/layout/http_admin.go
@@ -61,7 +61,7 @@ func (handler httpHandler) AdminDashboard(w http.ResponseWriter, r *http.Request
 		orders = nil
 	}
 
-	handler.renderTemplate(w, r, "admin/dashboard", map[string]any{
+	handler.renderAdminTemplate(w, r, "admin/dashboard", map[string]any{
 		"Active":        "dashboard",
 		"Email":         email,
 		"ProductCount":  len(products),

--- a/backend/layout/http_admin_catalog.go
+++ b/backend/layout/http_admin_catalog.go
@@ -1,0 +1,203 @@
+package layout
+
+import (
+	"net/http"
+	"strconv"
+
+	pcdomain "github.com/bkielbasa/go-ecommerce/backend/productcatalog/domain"
+	"github.com/gorilla/mux"
+)
+
+// AdminCategories renders the categories list page with the inline "new" form.
+func (handler httpHandler) AdminCategories(w http.ResponseWriter, r *http.Request) {
+	email, ok := handler.requireAdmin(w, r)
+	if !ok {
+		return
+	}
+	categories, err := handler.catalogSrv.Categories(r.Context())
+	if err != nil {
+		categories = nil
+	}
+	handler.renderTemplate(w, r, "admin/categories", map[string]any{
+		"Active":     "categories",
+		"Email":      email,
+		"Categories": categories,
+	})
+}
+
+// AdminCreateCategory handles the create-category form submission.
+func (handler httpHandler) AdminCreateCategory(w http.ResponseWriter, r *http.Request) {
+	if _, ok := handler.requireAdmin(w, r); !ok {
+		return
+	}
+	_ = r.ParseForm()
+	err := handler.catalogSrv.CreateCategory(r.Context(), r.FormValue("name"), r.FormValue("slug"))
+	if err != nil {
+		handler.flash(w, r, err.Error(), "error")
+	} else {
+		handler.flash(w, r, "Category created", "info")
+	}
+	http.Redirect(w, r, "/admin/categories", http.StatusSeeOther)
+}
+
+// AdminEditCategoryForm renders the edit form for a single category.
+func (handler httpHandler) AdminEditCategoryForm(w http.ResponseWriter, r *http.Request) {
+	email, ok := handler.requireAdmin(w, r)
+	if !ok {
+		return
+	}
+	id := mux.Vars(r)["id"]
+	categories, err := handler.catalogSrv.Categories(r.Context())
+	if err != nil {
+		http.Redirect(w, r, "/admin/categories", http.StatusSeeOther)
+		return
+	}
+	var found *pcdomain.Category
+	for i := range categories {
+		if categories[i].ID() == id {
+			found = &categories[i]
+			break
+		}
+	}
+	if found == nil {
+		handler.flash(w, r, "Category not found", "error")
+		http.Redirect(w, r, "/admin/categories", http.StatusSeeOther)
+		return
+	}
+	handler.renderTemplate(w, r, "admin/category_edit", map[string]any{
+		"Active":   "categories",
+		"Email":    email,
+		"Category": *found,
+	})
+}
+
+// AdminUpdateCategory handles the edit-category form submission.
+func (handler httpHandler) AdminUpdateCategory(w http.ResponseWriter, r *http.Request) {
+	if _, ok := handler.requireAdmin(w, r); !ok {
+		return
+	}
+	id := mux.Vars(r)["id"]
+	_ = r.ParseForm()
+	position, _ := strconv.Atoi(r.FormValue("position"))
+	err := handler.catalogSrv.UpdateCategory(r.Context(), id, r.FormValue("name"), r.FormValue("slug"), position)
+	if err != nil {
+		handler.flash(w, r, err.Error(), "error")
+		http.Redirect(w, r, "/admin/categories/"+id+"/edit", http.StatusSeeOther)
+		return
+	}
+	handler.flash(w, r, "Category updated", "info")
+	http.Redirect(w, r, "/admin/categories", http.StatusSeeOther)
+}
+
+// AdminDeleteCategory deletes a category (and cascades its product links).
+func (handler httpHandler) AdminDeleteCategory(w http.ResponseWriter, r *http.Request) {
+	if _, ok := handler.requireAdmin(w, r); !ok {
+		return
+	}
+	id := mux.Vars(r)["id"]
+	if err := handler.catalogSrv.DeleteCategory(r.Context(), id); err != nil {
+		handler.flash(w, r, err.Error(), "error")
+	} else {
+		handler.flash(w, r, "Category deleted", "info")
+	}
+	http.Redirect(w, r, "/admin/categories", http.StatusSeeOther)
+}
+
+// AdminAttributes renders the attribute types list page with the inline form.
+func (handler httpHandler) AdminAttributes(w http.ResponseWriter, r *http.Request) {
+	email, ok := handler.requireAdmin(w, r)
+	if !ok {
+		return
+	}
+	types, err := handler.catalogSrv.AttributeTypes(r.Context())
+	if err != nil {
+		types = nil
+	}
+	handler.renderTemplate(w, r, "admin/attributes", map[string]any{
+		"Active":     "attributes",
+		"Email":      email,
+		"Attributes": types,
+	})
+}
+
+// AdminCreateAttribute handles the create-attribute-type form submission.
+func (handler httpHandler) AdminCreateAttribute(w http.ResponseWriter, r *http.Request) {
+	if _, ok := handler.requireAdmin(w, r); !ok {
+		return
+	}
+	_ = r.ParseForm()
+	kind := pcdomain.AttributeKind(r.FormValue("kind"))
+	filterable := r.FormValue("filterable") != ""
+	err := handler.catalogSrv.CreateAttributeType(r.Context(), r.FormValue("name"), r.FormValue("unit"), kind, filterable)
+	if err != nil {
+		handler.flash(w, r, err.Error(), "error")
+	} else {
+		handler.flash(w, r, "Attribute type created", "info")
+	}
+	http.Redirect(w, r, "/admin/attributes", http.StatusSeeOther)
+}
+
+// AdminEditAttributeForm renders the edit form for a single attribute type.
+func (handler httpHandler) AdminEditAttributeForm(w http.ResponseWriter, r *http.Request) {
+	email, ok := handler.requireAdmin(w, r)
+	if !ok {
+		return
+	}
+	id := mux.Vars(r)["id"]
+	types, err := handler.catalogSrv.AttributeTypes(r.Context())
+	if err != nil {
+		http.Redirect(w, r, "/admin/attributes", http.StatusSeeOther)
+		return
+	}
+	var found *pcdomain.AttributeType
+	for i := range types {
+		if types[i].ID() == id {
+			found = &types[i]
+			break
+		}
+	}
+	if found == nil {
+		handler.flash(w, r, "Attribute type not found", "error")
+		http.Redirect(w, r, "/admin/attributes", http.StatusSeeOther)
+		return
+	}
+	handler.renderTemplate(w, r, "admin/attribute_edit", map[string]any{
+		"Active":    "attributes",
+		"Email":     email,
+		"Attribute": *found,
+	})
+}
+
+// AdminUpdateAttribute handles the edit-attribute-type form submission.
+func (handler httpHandler) AdminUpdateAttribute(w http.ResponseWriter, r *http.Request) {
+	if _, ok := handler.requireAdmin(w, r); !ok {
+		return
+	}
+	id := mux.Vars(r)["id"]
+	_ = r.ParseForm()
+	position, _ := strconv.Atoi(r.FormValue("position"))
+	kind := pcdomain.AttributeKind(r.FormValue("kind"))
+	filterable := r.FormValue("filterable") != ""
+	err := handler.catalogSrv.UpdateAttributeType(r.Context(), id, r.FormValue("name"), r.FormValue("unit"), kind, filterable, position)
+	if err != nil {
+		handler.flash(w, r, err.Error(), "error")
+		http.Redirect(w, r, "/admin/attributes/"+id+"/edit", http.StatusSeeOther)
+		return
+	}
+	handler.flash(w, r, "Attribute type updated", "info")
+	http.Redirect(w, r, "/admin/attributes", http.StatusSeeOther)
+}
+
+// AdminDeleteAttribute deletes an attribute type (and cascades product links).
+func (handler httpHandler) AdminDeleteAttribute(w http.ResponseWriter, r *http.Request) {
+	if _, ok := handler.requireAdmin(w, r); !ok {
+		return
+	}
+	id := mux.Vars(r)["id"]
+	if err := handler.catalogSrv.DeleteAttributeType(r.Context(), id); err != nil {
+		handler.flash(w, r, err.Error(), "error")
+	} else {
+		handler.flash(w, r, "Attribute type deleted", "info")
+	}
+	http.Redirect(w, r, "/admin/attributes", http.StatusSeeOther)
+}

--- a/backend/layout/http_admin_catalog.go
+++ b/backend/layout/http_admin_catalog.go
@@ -18,7 +18,7 @@ func (handler httpHandler) AdminCategories(w http.ResponseWriter, r *http.Reques
 	if err != nil {
 		categories = nil
 	}
-	handler.renderTemplate(w, r, "admin/categories", map[string]any{
+	handler.renderAdminTemplate(w, r, "admin/categories", map[string]any{
 		"Active":     "categories",
 		"Email":      email,
 		"Categories": categories,
@@ -64,7 +64,7 @@ func (handler httpHandler) AdminEditCategoryForm(w http.ResponseWriter, r *http.
 		http.Redirect(w, r, "/admin/categories", http.StatusSeeOther)
 		return
 	}
-	handler.renderTemplate(w, r, "admin/category_edit", map[string]any{
+	handler.renderAdminTemplate(w, r, "admin/category_edit", map[string]any{
 		"Active":   "categories",
 		"Email":    email,
 		"Category": *found,
@@ -113,7 +113,7 @@ func (handler httpHandler) AdminAttributes(w http.ResponseWriter, r *http.Reques
 	if err != nil {
 		types = nil
 	}
-	handler.renderTemplate(w, r, "admin/attributes", map[string]any{
+	handler.renderAdminTemplate(w, r, "admin/attributes", map[string]any{
 		"Active":     "attributes",
 		"Email":      email,
 		"Attributes": types,
@@ -161,7 +161,7 @@ func (handler httpHandler) AdminEditAttributeForm(w http.ResponseWriter, r *http
 		http.Redirect(w, r, "/admin/attributes", http.StatusSeeOther)
 		return
 	}
-	handler.renderTemplate(w, r, "admin/attribute_edit", map[string]any{
+	handler.renderAdminTemplate(w, r, "admin/attribute_edit", map[string]any{
 		"Active":    "attributes",
 		"Email":     email,
 		"Attribute": *found,

--- a/backend/layout/http_admin_orders.go
+++ b/backend/layout/http_admin_orders.go
@@ -1,0 +1,76 @@
+package layout
+
+import (
+	"errors"
+	"net/http"
+
+	checkoutDomain "github.com/bkielbasa/go-ecommerce/backend/checkout/domain"
+	"github.com/bkielbasa/go-ecommerce/backend/internal/https"
+	"github.com/gorilla/mux"
+)
+
+// AdminOrders renders the admin order list: every order newest-first.
+func (handler httpHandler) AdminOrders(w http.ResponseWriter, r *http.Request) {
+	email, ok := handler.requireAdmin(w, r)
+	if !ok {
+		return
+	}
+	orders, err := handler.checkoutQry.ListAll(r.Context())
+	if err != nil {
+		https.InternalError(w, "internal-error", err.Error())
+		return
+	}
+	handler.renderTemplate(w, r, "admin/orders", map[string]any{
+		"Active": "orders",
+		"Email":  email,
+		"Orders": orders,
+	})
+}
+
+// AdminOrderDetail renders a single order's detail with an admin cancel form
+// for paid orders.
+func (handler httpHandler) AdminOrderDetail(w http.ResponseWriter, r *http.Request) {
+	email, ok := handler.requireAdmin(w, r)
+	if !ok {
+		return
+	}
+	orderID := mux.Vars(r)["orderID"]
+	order, err := handler.checkoutQry.Find(r.Context(), orderID)
+	if errors.Is(err, checkoutDomain.ErrOrderNotFound) {
+		http.NotFound(w, r)
+		return
+	}
+	if err != nil {
+		https.InternalError(w, "internal-error", err.Error())
+		return
+	}
+	handler.renderTemplate(w, r, "admin/order_detail", map[string]any{
+		"Active":    "orders",
+		"Email":     email,
+		"Order":     order,
+		"CanCancel": order.Status() == checkoutDomain.StatusPaid,
+	})
+}
+
+// AdminCancelOrder cancels any order as admin and redirects back to its detail.
+func (handler httpHandler) AdminCancelOrder(w http.ResponseWriter, r *http.Request) {
+	if _, ok := handler.requireAdmin(w, r); !ok {
+		return
+	}
+	orderID := mux.Vars(r)["orderID"]
+	err := handler.checkoutSrv.AdminCancel(r.Context(), orderID)
+	switch {
+	case errors.Is(err, checkoutDomain.ErrOrderNotFound):
+		handler.flash(w, r, "Order not found.", "error")
+		http.Redirect(w, r, "/admin/orders", http.StatusSeeOther)
+		return
+	case errors.Is(err, checkoutDomain.ErrOrderNotCancellable):
+		handler.flash(w, r, "This order can no longer be cancelled.", "error")
+	case err != nil:
+		https.InternalError(w, "internal-error", err.Error())
+		return
+	default:
+		handler.flash(w, r, "Order cancelled.", "info")
+	}
+	http.Redirect(w, r, "/admin/orders/"+orderID, http.StatusSeeOther)
+}

--- a/backend/layout/http_admin_orders.go
+++ b/backend/layout/http_admin_orders.go
@@ -20,7 +20,7 @@ func (handler httpHandler) AdminOrders(w http.ResponseWriter, r *http.Request) {
 		https.InternalError(w, "internal-error", err.Error())
 		return
 	}
-	handler.renderTemplate(w, r, "admin/orders", map[string]any{
+	handler.renderAdminTemplate(w, r, "admin/orders", map[string]any{
 		"Active": "orders",
 		"Email":  email,
 		"Orders": orders,
@@ -44,7 +44,7 @@ func (handler httpHandler) AdminOrderDetail(w http.ResponseWriter, r *http.Reque
 		https.InternalError(w, "internal-error", err.Error())
 		return
 	}
-	handler.renderTemplate(w, r, "admin/order_detail", map[string]any{
+	handler.renderAdminTemplate(w, r, "admin/order_detail", map[string]any{
 		"Active":    "orders",
 		"Email":     email,
 		"Order":     order,

--- a/backend/layout/http_admin_products.go
+++ b/backend/layout/http_admin_products.go
@@ -1,0 +1,257 @@
+package layout
+
+import (
+	"errors"
+	"math"
+	"net/http"
+	"strconv"
+	"strings"
+
+	pcapp "github.com/bkielbasa/go-ecommerce/backend/productcatalog/app"
+	"github.com/gorilla/mux"
+)
+
+// parsePriceMinorUnits parses a decimal major-units price string (e.g. "9.00"
+// or "9.5") into integer minor units (cents). It rejects negative or malformed
+// input.
+func parsePriceMinorUnits(s string) (int64, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 0, errors.New("price is required")
+	}
+	f, err := strconv.ParseFloat(s, 64)
+	if err != nil {
+		return 0, errors.New("price must be a number (major units, e.g. 9.00)")
+	}
+	if f < 0 {
+		return 0, errors.New("price cannot be negative")
+	}
+	return int64(math.Round(f * 100)), nil
+}
+
+// AdminProducts renders the product list page.
+func (handler httpHandler) AdminProducts(w http.ResponseWriter, r *http.Request) {
+	email, ok := handler.requireAdmin(w, r)
+	if !ok {
+		return
+	}
+	products, err := handler.catalogSrv.AllProducts(r.Context())
+	if err != nil {
+		products = nil
+	}
+	handler.renderTemplate(w, r, "admin/products", map[string]any{
+		"Active":   "products",
+		"Email":    email,
+		"Products": products,
+	})
+}
+
+// AdminCreateProduct handles the create-product form (a simple product with a
+// single default variant). Price is entered in major units (e.g. "9.00").
+func (handler httpHandler) AdminCreateProduct(w http.ResponseWriter, r *http.Request) {
+	if _, ok := handler.requireAdmin(w, r); !ok {
+		return
+	}
+	_ = r.ParseForm()
+	id := strings.TrimSpace(r.FormValue("id"))
+	currency := strings.TrimSpace(r.FormValue("currency"))
+	if currency == "" {
+		currency = "USD"
+	}
+	price, err := parsePriceMinorUnits(r.FormValue("price"))
+	if err != nil {
+		handler.flash(w, r, err.Error(), "error")
+		http.Redirect(w, r, "/admin/products", http.StatusSeeOther)
+		return
+	}
+	err = handler.catalogSrv.Add(r.Context(), id, r.FormValue("name"), r.FormValue("description"), price, currency, r.FormValue("thumbnail"))
+	if err != nil {
+		handler.flash(w, r, err.Error(), "error")
+		http.Redirect(w, r, "/admin/products", http.StatusSeeOther)
+		return
+	}
+	handler.flash(w, r, "Product created", "info")
+	http.Redirect(w, r, "/admin/products/"+id+"/edit", http.StatusSeeOther)
+}
+
+// AdminEditProductForm renders the multi-section product edit page.
+func (handler httpHandler) AdminEditProductForm(w http.ResponseWriter, r *http.Request) {
+	email, ok := handler.requireAdmin(w, r)
+	if !ok {
+		return
+	}
+	id := mux.Vars(r)["id"]
+	product, err := handler.catalogSrv.Find(r.Context(), id)
+	if err != nil {
+		handler.flash(w, r, "Product not found", "error")
+		http.Redirect(w, r, "/admin/products", http.StatusSeeOther)
+		return
+	}
+
+	categories, err := handler.catalogSrv.Categories(r.Context())
+	if err != nil {
+		categories = nil
+	}
+	assigned := map[string]bool{}
+	for _, c := range product.Categories() {
+		assigned[c.ID()] = true
+	}
+
+	attrTypes, err := handler.catalogSrv.AttributeTypes(r.Context())
+	if err != nil {
+		attrTypes = nil
+	}
+	// Current value per attribute-type id, for prefilling the inputs.
+	attrValues := map[string]string{}
+	for _, av := range product.Attributes() {
+		if av.Type().IsNumeric() {
+			attrValues[av.Type().ID()] = strconv.FormatFloat(av.NumValue(), 'f', -1, 64)
+		} else {
+			attrValues[av.Type().ID()] = av.TextValue()
+		}
+	}
+
+	handler.renderTemplate(w, r, "admin/product_edit", map[string]any{
+		"Active":     "products",
+		"Email":      email,
+		"Product":    product,
+		"Categories": categories,
+		"Assigned":   assigned,
+		"AttrTypes":  attrTypes,
+		"AttrValues": attrValues,
+	})
+}
+
+// AdminUpdateProduct handles the core-fields form on the edit page.
+func (handler httpHandler) AdminUpdateProduct(w http.ResponseWriter, r *http.Request) {
+	if _, ok := handler.requireAdmin(w, r); !ok {
+		return
+	}
+	id := mux.Vars(r)["id"]
+	_ = r.ParseForm()
+	currency := strings.TrimSpace(r.FormValue("currency"))
+	if currency == "" {
+		currency = "USD"
+	}
+	price, err := parsePriceMinorUnits(r.FormValue("price"))
+	if err != nil {
+		handler.flash(w, r, err.Error(), "error")
+		http.Redirect(w, r, "/admin/products/"+id+"/edit", http.StatusSeeOther)
+		return
+	}
+	err = handler.catalogSrv.UpdateProduct(r.Context(), id, r.FormValue("name"), r.FormValue("description"), price, currency, r.FormValue("thumbnail"))
+	if err != nil {
+		handler.flash(w, r, err.Error(), "error")
+	} else {
+		handler.flash(w, r, "Product updated", "info")
+	}
+	http.Redirect(w, r, "/admin/products/"+id+"/edit", http.StatusSeeOther)
+}
+
+// AdminUpdateProductStock parses each variant's stock input (stock_<variantID>)
+// and persists it.
+func (handler httpHandler) AdminUpdateProductStock(w http.ResponseWriter, r *http.Request) {
+	if _, ok := handler.requireAdmin(w, r); !ok {
+		return
+	}
+	id := mux.Vars(r)["id"]
+	product, err := handler.catalogSrv.Find(r.Context(), id)
+	if err != nil {
+		handler.flash(w, r, "Product not found", "error")
+		http.Redirect(w, r, "/admin/products", http.StatusSeeOther)
+		return
+	}
+	_ = r.ParseForm()
+	for _, v := range product.Variants() {
+		raw := strings.TrimSpace(r.FormValue("stock_" + v.ID()))
+		if raw == "" {
+			continue
+		}
+		stock, convErr := strconv.Atoi(raw)
+		if convErr != nil {
+			handler.flash(w, r, "Invalid stock for "+v.ID(), "error")
+			http.Redirect(w, r, "/admin/products/"+id+"/edit", http.StatusSeeOther)
+			return
+		}
+		if err = handler.catalogSrv.SetVariantStock(r.Context(), v.ID(), stock); err != nil {
+			handler.flash(w, r, err.Error(), "error")
+			http.Redirect(w, r, "/admin/products/"+id+"/edit", http.StatusSeeOther)
+			return
+		}
+	}
+	handler.flash(w, r, "Stock updated", "info")
+	http.Redirect(w, r, "/admin/products/"+id+"/edit", http.StatusSeeOther)
+}
+
+// AdminUpdateProductCategories replaces the product's category assignments with
+// the checked boxes.
+func (handler httpHandler) AdminUpdateProductCategories(w http.ResponseWriter, r *http.Request) {
+	if _, ok := handler.requireAdmin(w, r); !ok {
+		return
+	}
+	id := mux.Vars(r)["id"]
+	_ = r.ParseForm()
+	categoryIDs := r.Form["category"]
+	if err := handler.catalogSrv.SetProductCategories(r.Context(), id, categoryIDs); err != nil {
+		handler.flash(w, r, err.Error(), "error")
+	} else {
+		handler.flash(w, r, "Categories updated", "info")
+	}
+	http.Redirect(w, r, "/admin/products/"+id+"/edit", http.StatusSeeOther)
+}
+
+// AdminUpdateProductAttributes reads one input per attribute type
+// (attr_<typeID>); a non-empty value becomes an assignment (numeric values are
+// parsed as floats, enum values stored verbatim). Empty inputs are omitted,
+// i.e. cleared.
+func (handler httpHandler) AdminUpdateProductAttributes(w http.ResponseWriter, r *http.Request) {
+	if _, ok := handler.requireAdmin(w, r); !ok {
+		return
+	}
+	id := mux.Vars(r)["id"]
+	attrTypes, err := handler.catalogSrv.AttributeTypes(r.Context())
+	if err != nil {
+		handler.flash(w, r, err.Error(), "error")
+		http.Redirect(w, r, "/admin/products/"+id+"/edit", http.StatusSeeOther)
+		return
+	}
+	_ = r.ParseForm()
+	var values []pcapp.AttributeAssignment
+	for _, t := range attrTypes {
+		raw := strings.TrimSpace(r.FormValue("attr_" + t.ID()))
+		if raw == "" {
+			continue
+		}
+		if t.IsNumeric() {
+			f, convErr := strconv.ParseFloat(raw, 64)
+			if convErr != nil {
+				handler.flash(w, r, "Invalid number for "+t.Name(), "error")
+				http.Redirect(w, r, "/admin/products/"+id+"/edit", http.StatusSeeOther)
+				return
+			}
+			values = append(values, pcapp.AttributeAssignment{TypeID: t.ID(), Num: &f})
+		} else {
+			values = append(values, pcapp.AttributeAssignment{TypeID: t.ID(), Text: raw})
+		}
+	}
+	if err := handler.catalogSrv.SetProductAttributes(r.Context(), id, values); err != nil {
+		handler.flash(w, r, err.Error(), "error")
+	} else {
+		handler.flash(w, r, "Attributes updated", "info")
+	}
+	http.Redirect(w, r, "/admin/products/"+id+"/edit", http.StatusSeeOther)
+}
+
+// AdminDeleteProduct deletes a product (variants/links cascade).
+func (handler httpHandler) AdminDeleteProduct(w http.ResponseWriter, r *http.Request) {
+	if _, ok := handler.requireAdmin(w, r); !ok {
+		return
+	}
+	id := mux.Vars(r)["id"]
+	if err := handler.catalogSrv.DeleteProduct(r.Context(), id); err != nil {
+		handler.flash(w, r, err.Error(), "error")
+	} else {
+		handler.flash(w, r, "Product deleted", "info")
+	}
+	http.Redirect(w, r, "/admin/products", http.StatusSeeOther)
+}

--- a/backend/layout/http_admin_products.go
+++ b/backend/layout/http_admin_products.go
@@ -39,7 +39,7 @@ func (handler httpHandler) AdminProducts(w http.ResponseWriter, r *http.Request)
 	if err != nil {
 		products = nil
 	}
-	handler.renderTemplate(w, r, "admin/products", map[string]any{
+	handler.renderAdminTemplate(w, r, "admin/products", map[string]any{
 		"Active":   "products",
 		"Email":    email,
 		"Products": products,
@@ -111,7 +111,7 @@ func (handler httpHandler) AdminEditProductForm(w http.ResponseWriter, r *http.R
 		}
 	}
 
-	handler.renderTemplate(w, r, "admin/product_edit", map[string]any{
+	handler.renderAdminTemplate(w, r, "admin/product_edit", map[string]any{
 		"Active":     "products",
 		"Email":      email,
 		"Product":    product,

--- a/backend/layout/static/admin.css
+++ b/backend/layout/static/admin.css
@@ -1,0 +1,433 @@
+/* ==========================================================================
+   Store Admin theme
+   A restrained, high-contrast, full-width admin shell — deliberately distinct
+   from the editorial storefront. System sans font, sidebar + main column,
+   scannable tables and readable forms.
+   ========================================================================== */
+
+:root {
+  --a-bg: #f4f5f7;
+  --a-surface: #ffffff;
+  --a-sidebar: #1d2330;
+  --a-sidebar-2: #161b26;
+  --a-text: #1f2430;
+  --a-muted: #6b7280;
+  --a-border: #e1e4ea;
+  --a-border-strong: #cfd4dd;
+  --a-accent: #2d6cdf;
+  --a-accent-dark: #2257bd;
+  --a-danger: #c23b3b;
+  --a-danger-dark: #a52f2f;
+  --a-zebra: #f7f8fa;
+  --a-radius: 6px;
+}
+
+* { box-sizing: border-box; }
+
+html, body { height: 100%; }
+
+.admin-body {
+  margin: 0;
+  display: flex;
+  min-height: 100vh;
+  background: var(--a-bg);
+  color: var(--a-text);
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica,
+    Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji";
+  font-size: 15.5px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+}
+
+a { color: var(--a-accent); text-decoration: none; }
+a:hover { text-decoration: underline; }
+code {
+  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+  font-size: 0.85em;
+  background: rgba(0, 0, 0, 0.05);
+  padding: 0.1em 0.35em;
+  border-radius: 4px;
+}
+.muted { color: var(--a-muted); }
+
+/* --- Sidebar ------------------------------------------------------------- */
+.admin-sidebar {
+  position: sticky;
+  top: 0;
+  align-self: flex-start;
+  flex: 0 0 220px;
+  width: 220px;
+  height: 100vh;
+  background: var(--a-sidebar);
+  color: #c8cdd8;
+  display: flex;
+  flex-direction: column;
+  padding: 20px 14px;
+}
+
+.admin-sidebar__brand {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding: 4px 8px 18px;
+  font-weight: 600;
+  font-size: 1.05rem;
+  color: #fff;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  margin-bottom: 14px;
+}
+.admin-sidebar__brand-mark { color: var(--a-accent); font-size: 0.9rem; }
+
+.admin-nav { display: flex; flex-direction: column; gap: 2px; }
+.admin-nav__link {
+  display: block;
+  padding: 9px 12px;
+  border-radius: var(--a-radius);
+  color: #c8cdd8;
+  font-size: 0.93rem;
+  text-transform: capitalize;
+}
+.admin-nav__link:hover {
+  background: rgba(255, 255, 255, 0.06);
+  color: #fff;
+  text-decoration: none;
+}
+.admin-nav__link.is-active {
+  background: var(--a-accent);
+  color: #fff;
+}
+.admin-nav__link--muted { color: #8a90a0; }
+.admin-nav__rule {
+  display: block;
+  height: 1px;
+  background: rgba(255, 255, 255, 0.08);
+  margin: 10px 4px;
+}
+
+.admin-sidebar__foot {
+  margin-top: auto;
+  padding-top: 16px;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.admin-sidebar__foot-link {
+  color: #9aa0ae;
+  font-size: 0.88rem;
+  padding: 5px 8px;
+  border-radius: var(--a-radius);
+}
+.admin-sidebar__foot-link:hover {
+  background: rgba(255, 255, 255, 0.06);
+  color: #fff;
+  text-decoration: none;
+}
+
+/* --- Main column --------------------------------------------------------- */
+.admin-main {
+  flex: 1 1 auto;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.admin-topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  background: var(--a-surface);
+  border-bottom: 1px solid var(--a-border);
+  padding: 16px 28px;
+  position: sticky;
+  top: 0;
+  z-index: 5;
+}
+.admin-topbar__heading {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 600;
+  text-transform: capitalize;
+}
+.admin-topbar__user {
+  color: var(--a-muted);
+  font-size: 0.88rem;
+}
+
+.admin-flash { padding: 0 28px; }
+.admin-flash:empty { padding: 0; }
+.flash {
+  margin: 14px 0 0;
+  padding: 10px 14px;
+  border-radius: var(--a-radius);
+  font-size: 0.92rem;
+  border: 1px solid transparent;
+}
+.flash--info { background: #e8f0fe; border-color: #b9d2fb; color: #1d4ed8; }
+.flash--error { background: #fdecec; border-color: #f3bcbc; color: #a52f2f; }
+
+.admin-content {
+  padding: 24px 28px 48px;
+  max-width: 1180px;
+  width: 100%;
+}
+
+/* --- Headings ------------------------------------------------------------ */
+.account-card__title {
+  margin: 0 0 16px;
+  font-size: 1.05rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: capitalize;
+}
+.crumbs { margin: 0 0 6px; font-size: 0.85rem; color: var(--a-muted); }
+.crumbs a { color: var(--a-muted); }
+
+/* --- Cards / sections ---------------------------------------------------- */
+.admin-section,
+.admin-form,
+.admin__stats > .admin-stat,
+.order {
+  background: var(--a-surface);
+  border: 1px solid var(--a-border);
+  border-radius: var(--a-radius);
+  padding: 20px 22px;
+  margin-bottom: 20px;
+}
+.admin-section__title {
+  margin: 0 0 14px;
+  font-size: 0.95rem;
+  font-weight: 600;
+  text-transform: capitalize;
+  color: var(--a-text);
+}
+
+/* Dashboard */
+.admin__hello { margin: 0 0 18px; color: var(--a-muted); }
+.admin__stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 18px;
+}
+.admin__stats > .admin-stat { margin-bottom: 0; }
+.admin-stat__value {
+  display: block;
+  font-size: 2.2rem;
+  font-weight: 700;
+  line-height: 1.1;
+}
+.admin-stat__label {
+  margin: 4px 0 12px;
+  font-size: 0.85rem;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--a-muted);
+}
+.admin-stat__link { font-size: 0.9rem; font-weight: 500; }
+
+/* --- Tables -------------------------------------------------------------- */
+.admin-table,
+.cart-table {
+  width: 100%;
+  border-collapse: collapse;
+  background: var(--a-surface);
+  border: 1px solid var(--a-border);
+  border-radius: var(--a-radius);
+  overflow: hidden;
+  margin-bottom: 20px;
+  font-size: 0.93rem;
+}
+.admin-table thead th,
+.cart-table thead th {
+  text-align: left;
+  background: #eef0f4;
+  color: #3a4150;
+  font-weight: 600;
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--a-border-strong);
+  white-space: nowrap;
+}
+.admin-table tbody td,
+.cart-table tbody td,
+.cart-table tfoot td {
+  padding: 11px 14px;
+  border-bottom: 1px solid var(--a-border);
+  vertical-align: top;
+}
+.admin-table tbody tr:nth-child(even) { background: var(--a-zebra); }
+.admin-table tbody tr:hover { background: #eef3fc; }
+.admin-table tbody tr:last-child td,
+.cart-table tbody tr:last-child td { border-bottom: 1px solid var(--a-border); }
+.cart-table tfoot td { font-weight: 600; border-bottom: none; }
+.cart-table tfoot tr:last-child td { border-top: 1px solid var(--a-border-strong); }
+
+.admin-table__actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  white-space: nowrap;
+}
+.admin-table__actions form { margin: 0; display: inline; }
+
+.col-qty, .col-price, .col-total { text-align: right; white-space: nowrap; }
+
+.admin-table input[type="number"] {
+  width: 90px;
+}
+
+/* --- Forms --------------------------------------------------------------- */
+.form { display: flex; flex-direction: column; gap: 14px; max-width: 560px; }
+.field { display: flex; flex-direction: column; gap: 5px; }
+.field label {
+  font-size: 0.83rem;
+  font-weight: 600;
+  color: #3a4150;
+}
+.field--check { flex-direction: row; align-items: center; }
+.field--check label {
+  flex-direction: row;
+  align-items: center;
+  gap: 8px;
+  display: flex;
+  font-weight: 500;
+}
+
+input[type="text"],
+input[type="number"],
+input:not([type]),
+select,
+textarea {
+  font: inherit;
+  color: var(--a-text);
+  background: #fff;
+  border: 1px solid var(--a-border-strong);
+  border-radius: var(--a-radius);
+  padding: 8px 10px;
+  width: 100%;
+}
+textarea { min-height: 90px; resize: vertical; }
+input:focus, select:focus, textarea:focus {
+  outline: none;
+  border-color: var(--a-accent);
+  box-shadow: 0 0 0 3px rgba(45, 108, 223, 0.15);
+}
+
+.admin-checks {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  gap: 8px;
+}
+.admin-check {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.92rem;
+}
+.admin-check input { width: auto; }
+
+.form__aside { margin: 4px 0 0; font-size: 0.85rem; }
+
+/* --- Buttons ------------------------------------------------------------- */
+.btn {
+  align-self: flex-start;
+  display: inline-block;
+  font: inherit;
+  font-weight: 600;
+  font-size: 0.92rem;
+  cursor: pointer;
+  border: 1px solid var(--a-accent);
+  background: var(--a-accent);
+  color: #fff;
+  padding: 9px 18px;
+  border-radius: var(--a-radius);
+}
+.btn:hover { background: var(--a-accent-dark); border-color: var(--a-accent-dark); text-decoration: none; }
+
+.btn--ghost {
+  background: transparent;
+  color: var(--a-text);
+  border-color: var(--a-border-strong);
+}
+.btn--ghost:hover { background: #eef0f4; color: var(--a-text); }
+
+.linkbtn {
+  font: inherit;
+  font-size: 0.9rem;
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  color: var(--a-accent);
+}
+.linkbtn:hover { text-decoration: underline; }
+.linkbtn--danger { color: var(--a-danger); }
+.linkbtn--danger:hover { color: var(--a-danger-dark); }
+
+/* --- Status badges ------------------------------------------------------- */
+.order-status {
+  display: inline-block;
+  padding: 2px 9px;
+  border-radius: 999px;
+  font-size: 0.74rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  border: 1px solid transparent;
+}
+.order-status--paid { background: #e3f5ea; color: #1f7a44; border-color: #b8e6c9; }
+.order-status--pending { background: #fef3e0; color: #9a6300; border-color: #f6d99e; }
+.order-status--shipped { background: #e6effd; color: #1f5bbf; border-color: #bcd6fb; }
+.order-status--cancelled,
+.order-status--canceled { background: #fdecec; color: #a52f2f; border-color: #f3bcbc; }
+.order-status--refunded { background: #efeafd; color: #5a3fbf; border-color: #d6cbf6; }
+
+/* --- Order detail -------------------------------------------------------- */
+.order__header { margin-bottom: 16px; }
+.order__id { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+.order__subtitle { margin: 6px 0 0; font-size: 0.88rem; }
+.order__ship {
+  border-top: 1px solid var(--a-border);
+  padding-top: 14px;
+  margin-top: 14px;
+}
+.order__ship-heading {
+  margin: 0 0 6px;
+  font-size: 0.82rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--a-muted);
+}
+.order__address { font-style: normal; line-height: 1.6; }
+.order__actions {
+  display: flex;
+  align-items: center;
+  gap: 18px;
+  border-top: 1px solid var(--a-border);
+  margin-top: 18px;
+  padding-top: 16px;
+}
+.order__actions form { margin: 0; }
+
+/* --- Responsive ---------------------------------------------------------- */
+@media (max-width: 760px) {
+  .admin-body { flex-direction: column; }
+  .admin-sidebar {
+    position: static;
+    width: 100%;
+    flex-basis: auto;
+    height: auto;
+  }
+  .admin-nav {
+    flex-direction: row;
+    flex-wrap: wrap;
+  }
+  .admin-sidebar__foot { flex-direction: row; }
+  .admin-topbar { position: static; }
+  .admin-content { padding: 18px 16px 36px; }
+  .admin-flash { padding: 0 16px; }
+}

--- a/backend/layout/static/main.css
+++ b/backend/layout/static/main.css
@@ -627,6 +627,42 @@ main {
   margin-bottom: var(--space-2);
 }
 
+/* ---------- admin panel ---------- */
+.admin {
+  display: grid;
+  grid-template-columns: 12rem 1fr;
+  gap: var(--space-5);
+  align-items: start;
+}
+@media (max-width: 48rem) {
+  .admin { grid-template-columns: 1fr; gap: var(--space-3); }
+}
+.admin-nav {
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+}
+.admin-nav__link {
+  border: 0;
+  padding: var(--space-1) 0;
+  color: var(--fg-muted);
+  text-transform: lowercase;
+  letter-spacing: .02em;
+  transition: color .15s ease;
+}
+.admin-nav__link:hover { color: var(--fg); border: 0; }
+.admin-nav__link.is-active { color: var(--fg); border-left: 2px solid var(--fg); padding-left: var(--space-2); margin-left: calc(-1 * var(--space-2) - 2px); }
+.admin-nav__link--muted { color: var(--fg-muted); }
+.admin-nav__rule { display: block; border-top: 1px solid var(--rule); margin: var(--space-2) 0; }
+
+.admin__hello { font-size: var(--step-1); margin-bottom: var(--space-4); }
+.admin__stats { display: grid; grid-template-columns: repeat(auto-fit, minmax(10rem, 1fr)); gap: var(--space-3); }
+.admin-stat { border-top: 1px solid var(--rule); padding-top: var(--space-2); display: flex; flex-direction: column; gap: var(--space-1); }
+.admin-stat__value { font-family: var(--serif); font-size: var(--step-3); line-height: 1; }
+.admin-stat__label { font-size: var(--step-0); text-transform: lowercase; letter-spacing: .02em; color: var(--fg-muted); margin: 0; }
+.admin-stat__link { font-size: 0.85rem; color: var(--fg-muted); }
+.admin-stat__link:hover { color: var(--fg); }
+
 /* address book */
 .addr-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(15rem, 1fr)); gap: var(--space-3); margin-bottom: var(--space-4); }
 .addr-card { position: relative; border: 1px solid var(--rule); padding: var(--space-3); display: flex; flex-direction: column; gap: var(--space-2); }

--- a/backend/layout/static/main.css
+++ b/backend/layout/static/main.css
@@ -108,7 +108,9 @@ main {
 .brand:hover { border: 0; }
 .nav {
   display: flex;
-  gap: var(--space-3);
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: var(--space-2) var(--space-3);
   list-style: none;
   padding: 0;
   font-size: 0.95rem;
@@ -161,6 +163,22 @@ main {
   text-transform: lowercase;
 }
 .crumbs a { border: 0; }
+
+/* ---------- home / new arrivals ---------- */
+.home-hero {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: var(--space-3);
+}
+.home-hero .page-title { margin-bottom: var(--space-4); }
+.home-hero__shop { white-space: nowrap; }
+.home-browse {
+  margin-top: var(--space-4);
+  text-align: center;
+}
+.home-browse a { border: 0; text-transform: lowercase; letter-spacing: .02em; }
 
 /* ---------- product list ---------- */
 .product-grid {

--- a/backend/layout/static/main.css
+++ b/backend/layout/static/main.css
@@ -663,6 +663,18 @@ main {
 .admin-stat__link { font-size: 0.85rem; color: var(--fg-muted); }
 .admin-stat__link:hover { color: var(--fg); }
 
+/* admin crud tables + forms */
+.admin-table { width: 100%; border-collapse: collapse; margin-bottom: var(--space-5); font-size: var(--step-0); }
+.admin-table th { text-align: left; font-weight: 400; text-transform: lowercase; letter-spacing: .02em; color: var(--fg-muted); border-bottom: 1px solid var(--fg); padding: var(--space-1) var(--space-2) var(--space-1) 0; }
+.admin-table td { border-bottom: 1px solid var(--rule); padding: var(--space-2) var(--space-2) var(--space-2) 0; vertical-align: middle; }
+.admin-table code { font-size: 0.85em; color: var(--fg-muted); }
+.admin-table__actions { display: flex; align-items: center; gap: var(--space-3); white-space: nowrap; }
+.admin-table__actions form { display: inline; margin: 0; }
+.admin-form { border-top: 1px solid var(--rule); padding-top: var(--space-3); max-width: 28rem; }
+.admin-form .field--check { flex-direction: row; align-items: center; gap: var(--space-2); }
+.admin-form .field--check label { display: flex; align-items: center; gap: var(--space-2); }
+.field--check input[type="checkbox"] { width: auto; }
+
 /* address book */
 .addr-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(15rem, 1fr)); gap: var(--space-3); margin-bottom: var(--space-4); }
 .addr-card { position: relative; border: 1px solid var(--rule); padding: var(--space-3); display: flex; flex-direction: column; gap: var(--space-2); }

--- a/backend/layout/static/main.css
+++ b/backend/layout/static/main.css
@@ -675,6 +675,15 @@ main {
 .admin-form .field--check label { display: flex; align-items: center; gap: var(--space-2); }
 .field--check input[type="checkbox"] { width: auto; }
 
+/* admin product edit: stacked sections */
+.admin-section { border-top: 1px solid var(--rule); padding-top: var(--space-3); margin-bottom: var(--space-5); max-width: 32rem; }
+.admin-section__title { text-transform: lowercase; letter-spacing: .02em; color: var(--fg-muted); font-weight: 400; margin-bottom: var(--space-3); }
+.admin-section .admin-table { max-width: none; }
+.admin-section input[type="number"] { width: 6rem; }
+.admin-checks { display: flex; flex-direction: column; gap: var(--space-2); margin-bottom: var(--space-3); }
+.admin-check { display: flex; align-items: center; gap: var(--space-2); }
+.admin-check input[type="checkbox"] { width: auto; }
+
 /* address book */
 .addr-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(15rem, 1fr)); gap: var(--space-3); margin-bottom: var(--space-4); }
 .addr-card { position: relative; border: 1px solid var(--rule); padding: var(--space-3); display: flex; flex-direction: column; gap: var(--space-2); }

--- a/backend/layout/tmpl/admin/attribute_edit.gohtml
+++ b/backend/layout/tmpl/admin/attribute_edit.gohtml
@@ -1,0 +1,28 @@
+{{define "main"}}
+  <h1 class="page-title">admin</h1>
+  <div class="admin">
+    <aside class="admin__side">{{template "admin-nav" .}}</aside>
+    <div class="admin__content">
+      <p class="crumbs"><a href="/admin/attributes">attributes</a> / edit</p>
+      <h2 class="account-card__title">edit attribute type</h2>
+
+      <form class="form" method="post" action="/admin/attributes/{{.Attribute.ID}}">
+        <div class="field"><label for="a-name">name</label><input id="a-name" name="name" value="{{.Attribute.Name}}" required></div>
+        <div class="field"><label for="a-unit">unit (optional)</label><input id="a-unit" name="unit" value="{{.Attribute.Unit}}"></div>
+        <div class="field">
+          <label for="a-kind">kind</label>
+          <select id="a-kind" name="kind">
+            <option value="numeric" {{if .Attribute.IsNumeric}}selected{{end}}>numeric</option>
+            <option value="enum" {{if .Attribute.IsEnum}}selected{{end}}>enum</option>
+          </select>
+        </div>
+        <div class="field field--check">
+          <label><input type="checkbox" name="filterable" value="1" {{if .Attribute.Filterable}}checked{{end}}> filterable</label>
+        </div>
+        <div class="field"><label for="a-position">position</label><input id="a-position" name="position" type="number" value="{{.Attribute.Position}}"></div>
+        <button type="submit" class="btn">save changes</button>
+        <p class="form__aside"><a href="/admin/attributes">&larr; back to attributes</a></p>
+      </form>
+    </div>
+  </div>
+{{end}}

--- a/backend/layout/tmpl/admin/attribute_edit.gohtml
+++ b/backend/layout/tmpl/admin/attribute_edit.gohtml
@@ -1,28 +1,22 @@
 {{define "main"}}
-  <h1 class="page-title">admin</h1>
-  <div class="admin">
-    <aside class="admin__side">{{template "admin-nav" .}}</aside>
-    <div class="admin__content">
-      <p class="crumbs"><a href="/admin/attributes">attributes</a> / edit</p>
-      <h2 class="account-card__title">edit attribute type</h2>
+  <p class="crumbs"><a href="/admin/attributes">attributes</a> / edit</p>
+  <h2 class="account-card__title">edit attribute type</h2>
 
-      <form class="form" method="post" action="/admin/attributes/{{.Attribute.ID}}">
-        <div class="field"><label for="a-name">name</label><input id="a-name" name="name" value="{{.Attribute.Name}}" required></div>
-        <div class="field"><label for="a-unit">unit (optional)</label><input id="a-unit" name="unit" value="{{.Attribute.Unit}}"></div>
-        <div class="field">
-          <label for="a-kind">kind</label>
-          <select id="a-kind" name="kind">
-            <option value="numeric" {{if .Attribute.IsNumeric}}selected{{end}}>numeric</option>
-            <option value="enum" {{if .Attribute.IsEnum}}selected{{end}}>enum</option>
-          </select>
-        </div>
-        <div class="field field--check">
-          <label><input type="checkbox" name="filterable" value="1" {{if .Attribute.Filterable}}checked{{end}}> filterable</label>
-        </div>
-        <div class="field"><label for="a-position">position</label><input id="a-position" name="position" type="number" value="{{.Attribute.Position}}"></div>
-        <button type="submit" class="btn">save changes</button>
-        <p class="form__aside"><a href="/admin/attributes">&larr; back to attributes</a></p>
-      </form>
+  <form class="form" method="post" action="/admin/attributes/{{.Attribute.ID}}">
+    <div class="field"><label for="a-name">name</label><input id="a-name" name="name" value="{{.Attribute.Name}}" required></div>
+    <div class="field"><label for="a-unit">unit (optional)</label><input id="a-unit" name="unit" value="{{.Attribute.Unit}}"></div>
+    <div class="field">
+      <label for="a-kind">kind</label>
+      <select id="a-kind" name="kind">
+        <option value="numeric" {{if .Attribute.IsNumeric}}selected{{end}}>numeric</option>
+        <option value="enum" {{if .Attribute.IsEnum}}selected{{end}}>enum</option>
+      </select>
     </div>
-  </div>
+    <div class="field field--check">
+      <label><input type="checkbox" name="filterable" value="1" {{if .Attribute.Filterable}}checked{{end}}> filterable</label>
+    </div>
+    <div class="field"><label for="a-position">position</label><input id="a-position" name="position" type="number" value="{{.Attribute.Position}}"></div>
+    <button type="submit" class="btn">save changes</button>
+    <p class="form__aside"><a href="/admin/attributes">&larr; back to attributes</a></p>
+  </form>
 {{end}}

--- a/backend/layout/tmpl/admin/attributes.gohtml
+++ b/backend/layout/tmpl/admin/attributes.gohtml
@@ -1,56 +1,50 @@
 {{define "main"}}
-  <h1 class="page-title">admin</h1>
-  <div class="admin">
-    <aside class="admin__side">{{template "admin-nav" .}}</aside>
-    <div class="admin__content">
-      <h2 class="account-card__title">attribute types</h2>
+  <h2 class="account-card__title">attribute types</h2>
 
-      {{if .Attributes}}
-        <table class="admin-table">
-          <thead>
-            <tr><th>name</th><th>unit</th><th>kind</th><th>filterable</th><th>position</th><th></th></tr>
-          </thead>
-          <tbody>
-            {{range $t := .Attributes}}
-              <tr>
-                <td>{{$t.Name}}</td>
-                <td>{{with $t.Unit}}{{.}}{{else}}&mdash;{{end}}</td>
-                <td>{{$t.Kind}}</td>
-                <td>{{if $t.Filterable}}yes{{else}}no{{end}}</td>
-                <td>{{$t.Position}}</td>
-                <td class="admin-table__actions">
-                  <a href="/admin/attributes/{{$t.ID}}/edit">edit</a>
-                  <form method="post" action="/admin/attributes/{{$t.ID}}/delete"
-                        onsubmit="return confirm('Delete this attribute type? Its product values will be removed.');">
-                    <button type="submit" class="linkbtn linkbtn--danger">delete</button>
-                  </form>
-                </td>
-              </tr>
-            {{end}}
-          </tbody>
-        </table>
-      {{else}}
-        <p class="muted">no attribute types yet.</p>
-      {{end}}
+  {{if .Attributes}}
+    <table class="admin-table">
+      <thead>
+        <tr><th>name</th><th>unit</th><th>kind</th><th>filterable</th><th>position</th><th></th></tr>
+      </thead>
+      <tbody>
+        {{range $t := .Attributes}}
+          <tr>
+            <td>{{$t.Name}}</td>
+            <td>{{with $t.Unit}}{{.}}{{else}}&mdash;{{end}}</td>
+            <td>{{$t.Kind}}</td>
+            <td>{{if $t.Filterable}}yes{{else}}no{{end}}</td>
+            <td>{{$t.Position}}</td>
+            <td class="admin-table__actions">
+              <a href="/admin/attributes/{{$t.ID}}/edit">edit</a>
+              <form method="post" action="/admin/attributes/{{$t.ID}}/delete"
+                    onsubmit="return confirm('Delete this attribute type? Its product values will be removed.');">
+                <button type="submit" class="linkbtn linkbtn--danger">delete</button>
+              </form>
+            </td>
+          </tr>
+        {{end}}
+      </tbody>
+    </table>
+  {{else}}
+    <p class="muted">no attribute types yet.</p>
+  {{end}}
 
-      <section class="admin-form">
-        <h3 class="account-card__title">add an attribute type</h3>
-        <form class="form" method="post" action="/admin/attributes">
-          <div class="field"><label for="a-name">name</label><input id="a-name" name="name" required></div>
-          <div class="field"><label for="a-unit">unit (optional)</label><input id="a-unit" name="unit"></div>
-          <div class="field">
-            <label for="a-kind">kind</label>
-            <select id="a-kind" name="kind">
-              <option value="numeric">numeric</option>
-              <option value="enum">enum</option>
-            </select>
-          </div>
-          <div class="field field--check">
-            <label><input type="checkbox" name="filterable" value="1"> filterable</label>
-          </div>
-          <button type="submit" class="btn">create attribute type</button>
-        </form>
-      </section>
-    </div>
-  </div>
+  <section class="admin-form">
+    <h3 class="account-card__title">add an attribute type</h3>
+    <form class="form" method="post" action="/admin/attributes">
+      <div class="field"><label for="a-name">name</label><input id="a-name" name="name" required></div>
+      <div class="field"><label for="a-unit">unit (optional)</label><input id="a-unit" name="unit"></div>
+      <div class="field">
+        <label for="a-kind">kind</label>
+        <select id="a-kind" name="kind">
+          <option value="numeric">numeric</option>
+          <option value="enum">enum</option>
+        </select>
+      </div>
+      <div class="field field--check">
+        <label><input type="checkbox" name="filterable" value="1"> filterable</label>
+      </div>
+      <button type="submit" class="btn">create attribute type</button>
+    </form>
+  </section>
 {{end}}

--- a/backend/layout/tmpl/admin/attributes.gohtml
+++ b/backend/layout/tmpl/admin/attributes.gohtml
@@ -1,0 +1,56 @@
+{{define "main"}}
+  <h1 class="page-title">admin</h1>
+  <div class="admin">
+    <aside class="admin__side">{{template "admin-nav" .}}</aside>
+    <div class="admin__content">
+      <h2 class="account-card__title">attribute types</h2>
+
+      {{if .Attributes}}
+        <table class="admin-table">
+          <thead>
+            <tr><th>name</th><th>unit</th><th>kind</th><th>filterable</th><th>position</th><th></th></tr>
+          </thead>
+          <tbody>
+            {{range $t := .Attributes}}
+              <tr>
+                <td>{{$t.Name}}</td>
+                <td>{{with $t.Unit}}{{.}}{{else}}&mdash;{{end}}</td>
+                <td>{{$t.Kind}}</td>
+                <td>{{if $t.Filterable}}yes{{else}}no{{end}}</td>
+                <td>{{$t.Position}}</td>
+                <td class="admin-table__actions">
+                  <a href="/admin/attributes/{{$t.ID}}/edit">edit</a>
+                  <form method="post" action="/admin/attributes/{{$t.ID}}/delete"
+                        onsubmit="return confirm('Delete this attribute type? Its product values will be removed.');">
+                    <button type="submit" class="linkbtn linkbtn--danger">delete</button>
+                  </form>
+                </td>
+              </tr>
+            {{end}}
+          </tbody>
+        </table>
+      {{else}}
+        <p class="muted">no attribute types yet.</p>
+      {{end}}
+
+      <section class="admin-form">
+        <h3 class="account-card__title">add an attribute type</h3>
+        <form class="form" method="post" action="/admin/attributes">
+          <div class="field"><label for="a-name">name</label><input id="a-name" name="name" required></div>
+          <div class="field"><label for="a-unit">unit (optional)</label><input id="a-unit" name="unit"></div>
+          <div class="field">
+            <label for="a-kind">kind</label>
+            <select id="a-kind" name="kind">
+              <option value="numeric">numeric</option>
+              <option value="enum">enum</option>
+            </select>
+          </div>
+          <div class="field field--check">
+            <label><input type="checkbox" name="filterable" value="1"> filterable</label>
+          </div>
+          <button type="submit" class="btn">create attribute type</button>
+        </form>
+      </section>
+    </div>
+  </div>
+{{end}}

--- a/backend/layout/tmpl/admin/categories.gohtml
+++ b/backend/layout/tmpl/admin/categories.gohtml
@@ -1,0 +1,44 @@
+{{define "main"}}
+  <h1 class="page-title">admin</h1>
+  <div class="admin">
+    <aside class="admin__side">{{template "admin-nav" .}}</aside>
+    <div class="admin__content">
+      <h2 class="account-card__title">categories</h2>
+
+      {{if .Categories}}
+        <table class="admin-table">
+          <thead>
+            <tr><th>name</th><th>slug</th><th>position</th><th></th></tr>
+          </thead>
+          <tbody>
+            {{range $c := .Categories}}
+              <tr>
+                <td>{{$c.Name}}</td>
+                <td><code>{{$c.Slug}}</code></td>
+                <td>{{$c.Position}}</td>
+                <td class="admin-table__actions">
+                  <a href="/admin/categories/{{$c.ID}}/edit">edit</a>
+                  <form method="post" action="/admin/categories/{{$c.ID}}/delete"
+                        onsubmit="return confirm('Delete this category? Its product links will be removed.');">
+                    <button type="submit" class="linkbtn linkbtn--danger">delete</button>
+                  </form>
+                </td>
+              </tr>
+            {{end}}
+          </tbody>
+        </table>
+      {{else}}
+        <p class="muted">no categories yet.</p>
+      {{end}}
+
+      <section class="admin-form">
+        <h3 class="account-card__title">add a category</h3>
+        <form class="form" method="post" action="/admin/categories">
+          <div class="field"><label for="c-name">name</label><input id="c-name" name="name" required></div>
+          <div class="field"><label for="c-slug">slug</label><input id="c-slug" name="slug" required placeholder="lowercase-with-hyphens"></div>
+          <button type="submit" class="btn">create category</button>
+        </form>
+      </section>
+    </div>
+  </div>
+{{end}}

--- a/backend/layout/tmpl/admin/categories.gohtml
+++ b/backend/layout/tmpl/admin/categories.gohtml
@@ -1,44 +1,38 @@
 {{define "main"}}
-  <h1 class="page-title">admin</h1>
-  <div class="admin">
-    <aside class="admin__side">{{template "admin-nav" .}}</aside>
-    <div class="admin__content">
-      <h2 class="account-card__title">categories</h2>
+  <h2 class="account-card__title">categories</h2>
 
-      {{if .Categories}}
-        <table class="admin-table">
-          <thead>
-            <tr><th>name</th><th>slug</th><th>position</th><th></th></tr>
-          </thead>
-          <tbody>
-            {{range $c := .Categories}}
-              <tr>
-                <td>{{$c.Name}}</td>
-                <td><code>{{$c.Slug}}</code></td>
-                <td>{{$c.Position}}</td>
-                <td class="admin-table__actions">
-                  <a href="/admin/categories/{{$c.ID}}/edit">edit</a>
-                  <form method="post" action="/admin/categories/{{$c.ID}}/delete"
-                        onsubmit="return confirm('Delete this category? Its product links will be removed.');">
-                    <button type="submit" class="linkbtn linkbtn--danger">delete</button>
-                  </form>
-                </td>
-              </tr>
-            {{end}}
-          </tbody>
-        </table>
-      {{else}}
-        <p class="muted">no categories yet.</p>
-      {{end}}
+  {{if .Categories}}
+    <table class="admin-table">
+      <thead>
+        <tr><th>name</th><th>slug</th><th>position</th><th></th></tr>
+      </thead>
+      <tbody>
+        {{range $c := .Categories}}
+          <tr>
+            <td>{{$c.Name}}</td>
+            <td><code>{{$c.Slug}}</code></td>
+            <td>{{$c.Position}}</td>
+            <td class="admin-table__actions">
+              <a href="/admin/categories/{{$c.ID}}/edit">edit</a>
+              <form method="post" action="/admin/categories/{{$c.ID}}/delete"
+                    onsubmit="return confirm('Delete this category? Its product links will be removed.');">
+                <button type="submit" class="linkbtn linkbtn--danger">delete</button>
+              </form>
+            </td>
+          </tr>
+        {{end}}
+      </tbody>
+    </table>
+  {{else}}
+    <p class="muted">no categories yet.</p>
+  {{end}}
 
-      <section class="admin-form">
-        <h3 class="account-card__title">add a category</h3>
-        <form class="form" method="post" action="/admin/categories">
-          <div class="field"><label for="c-name">name</label><input id="c-name" name="name" required></div>
-          <div class="field"><label for="c-slug">slug</label><input id="c-slug" name="slug" required placeholder="lowercase-with-hyphens"></div>
-          <button type="submit" class="btn">create category</button>
-        </form>
-      </section>
-    </div>
-  </div>
+  <section class="admin-form">
+    <h3 class="account-card__title">add a category</h3>
+    <form class="form" method="post" action="/admin/categories">
+      <div class="field"><label for="c-name">name</label><input id="c-name" name="name" required></div>
+      <div class="field"><label for="c-slug">slug</label><input id="c-slug" name="slug" required placeholder="lowercase-with-hyphens"></div>
+      <button type="submit" class="btn">create category</button>
+    </form>
+  </section>
 {{end}}

--- a/backend/layout/tmpl/admin/category_edit.gohtml
+++ b/backend/layout/tmpl/admin/category_edit.gohtml
@@ -1,0 +1,18 @@
+{{define "main"}}
+  <h1 class="page-title">admin</h1>
+  <div class="admin">
+    <aside class="admin__side">{{template "admin-nav" .}}</aside>
+    <div class="admin__content">
+      <p class="crumbs"><a href="/admin/categories">categories</a> / edit</p>
+      <h2 class="account-card__title">edit category</h2>
+
+      <form class="form" method="post" action="/admin/categories/{{.Category.ID}}">
+        <div class="field"><label for="c-name">name</label><input id="c-name" name="name" value="{{.Category.Name}}" required></div>
+        <div class="field"><label for="c-slug">slug</label><input id="c-slug" name="slug" value="{{.Category.Slug}}" required placeholder="lowercase-with-hyphens"></div>
+        <div class="field"><label for="c-position">position</label><input id="c-position" name="position" type="number" value="{{.Category.Position}}"></div>
+        <button type="submit" class="btn">save changes</button>
+        <p class="form__aside"><a href="/admin/categories">&larr; back to categories</a></p>
+      </form>
+    </div>
+  </div>
+{{end}}

--- a/backend/layout/tmpl/admin/category_edit.gohtml
+++ b/backend/layout/tmpl/admin/category_edit.gohtml
@@ -1,18 +1,12 @@
 {{define "main"}}
-  <h1 class="page-title">admin</h1>
-  <div class="admin">
-    <aside class="admin__side">{{template "admin-nav" .}}</aside>
-    <div class="admin__content">
-      <p class="crumbs"><a href="/admin/categories">categories</a> / edit</p>
-      <h2 class="account-card__title">edit category</h2>
+  <p class="crumbs"><a href="/admin/categories">categories</a> / edit</p>
+  <h2 class="account-card__title">edit category</h2>
 
-      <form class="form" method="post" action="/admin/categories/{{.Category.ID}}">
-        <div class="field"><label for="c-name">name</label><input id="c-name" name="name" value="{{.Category.Name}}" required></div>
-        <div class="field"><label for="c-slug">slug</label><input id="c-slug" name="slug" value="{{.Category.Slug}}" required placeholder="lowercase-with-hyphens"></div>
-        <div class="field"><label for="c-position">position</label><input id="c-position" name="position" type="number" value="{{.Category.Position}}"></div>
-        <button type="submit" class="btn">save changes</button>
-        <p class="form__aside"><a href="/admin/categories">&larr; back to categories</a></p>
-      </form>
-    </div>
-  </div>
+  <form class="form" method="post" action="/admin/categories/{{.Category.ID}}">
+    <div class="field"><label for="c-name">name</label><input id="c-name" name="name" value="{{.Category.Name}}" required></div>
+    <div class="field"><label for="c-slug">slug</label><input id="c-slug" name="slug" value="{{.Category.Slug}}" required placeholder="lowercase-with-hyphens"></div>
+    <div class="field"><label for="c-position">position</label><input id="c-position" name="position" type="number" value="{{.Category.Position}}"></div>
+    <button type="submit" class="btn">save changes</button>
+    <p class="form__aside"><a href="/admin/categories">&larr; back to categories</a></p>
+  </form>
 {{end}}

--- a/backend/layout/tmpl/admin/dashboard.gohtml
+++ b/backend/layout/tmpl/admin/dashboard.gohtml
@@ -1,27 +1,21 @@
 {{define "main"}}
-  <h1 class="page-title">admin</h1>
-  <div class="admin">
-    <aside class="admin__side">{{template "admin-nav" .}}</aside>
-    <div class="admin__content">
-      <p class="admin__hello">Signed in as <strong>{{.Email}}</strong>.</p>
+  <p class="admin__hello">Signed in as <strong>{{.Email}}</strong>.</p>
 
-      <div class="admin__stats">
-        <section class="admin-stat">
-          <span class="admin-stat__value">{{.ProductCount}}</span>
-          <h2 class="admin-stat__label">products</h2>
-          <a href="/admin/products" class="admin-stat__link">manage &rarr;</a>
-        </section>
-        <section class="admin-stat">
-          <span class="admin-stat__value">{{.CategoryCount}}</span>
-          <h2 class="admin-stat__label">categories</h2>
-          <a href="/admin/categories" class="admin-stat__link">manage &rarr;</a>
-        </section>
-        <section class="admin-stat">
-          <span class="admin-stat__value">{{.OrderCount}}</span>
-          <h2 class="admin-stat__label">orders</h2>
-          <a href="/admin/orders" class="admin-stat__link">manage &rarr;</a>
-        </section>
-      </div>
-    </div>
+  <div class="admin__stats">
+    <section class="admin-stat">
+      <span class="admin-stat__value">{{.ProductCount}}</span>
+      <h2 class="admin-stat__label">products</h2>
+      <a href="/admin/products" class="admin-stat__link">manage &rarr;</a>
+    </section>
+    <section class="admin-stat">
+      <span class="admin-stat__value">{{.CategoryCount}}</span>
+      <h2 class="admin-stat__label">categories</h2>
+      <a href="/admin/categories" class="admin-stat__link">manage &rarr;</a>
+    </section>
+    <section class="admin-stat">
+      <span class="admin-stat__value">{{.OrderCount}}</span>
+      <h2 class="admin-stat__label">orders</h2>
+      <a href="/admin/orders" class="admin-stat__link">manage &rarr;</a>
+    </section>
   </div>
 {{end}}

--- a/backend/layout/tmpl/admin/dashboard.gohtml
+++ b/backend/layout/tmpl/admin/dashboard.gohtml
@@ -16,6 +16,11 @@
           <h2 class="admin-stat__label">categories</h2>
           <a href="/admin/categories" class="admin-stat__link">manage &rarr;</a>
         </section>
+        <section class="admin-stat">
+          <span class="admin-stat__value">{{.OrderCount}}</span>
+          <h2 class="admin-stat__label">orders</h2>
+          <a href="/admin/orders" class="admin-stat__link">manage &rarr;</a>
+        </section>
       </div>
     </div>
   </div>

--- a/backend/layout/tmpl/admin/dashboard.gohtml
+++ b/backend/layout/tmpl/admin/dashboard.gohtml
@@ -1,0 +1,22 @@
+{{define "main"}}
+  <h1 class="page-title">admin</h1>
+  <div class="admin">
+    <aside class="admin__side">{{template "admin-nav" .}}</aside>
+    <div class="admin__content">
+      <p class="admin__hello">Signed in as <strong>{{.Email}}</strong>.</p>
+
+      <div class="admin__stats">
+        <section class="admin-stat">
+          <span class="admin-stat__value">{{.ProductCount}}</span>
+          <h2 class="admin-stat__label">products</h2>
+          <a href="/admin/products" class="admin-stat__link">manage &rarr;</a>
+        </section>
+        <section class="admin-stat">
+          <span class="admin-stat__value">{{.CategoryCount}}</span>
+          <h2 class="admin-stat__label">categories</h2>
+          <a href="/admin/categories" class="admin-stat__link">manage &rarr;</a>
+        </section>
+      </div>
+    </div>
+  </div>
+{{end}}

--- a/backend/layout/tmpl/admin/layout.gohtml
+++ b/backend/layout/tmpl/admin/layout.gohtml
@@ -1,0 +1,50 @@
+{{define "adminbase"}}
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Store Admin</title>
+
+    <link rel="stylesheet" href="/static/admin.css">
+    <script src="https://unpkg.com/htmx.org@1.9.5"></script>
+  </head>
+  <body class="admin-body">
+
+    <aside class="admin-sidebar">
+      <div class="admin-sidebar__brand">
+        <span class="admin-sidebar__brand-mark">◆</span>
+        <span class="admin-sidebar__brand-name">Store Admin</span>
+      </div>
+
+      {{template "admin-nav" .}}
+
+      <div class="admin-sidebar__foot">
+        <a href="/" class="admin-sidebar__foot-link">&#8617; View store</a>
+        <a href="/auth/logout" class="admin-sidebar__foot-link">Log out</a>
+      </div>
+    </aside>
+
+    <div class="admin-main">
+      <header class="admin-topbar">
+        <h1 class="admin-topbar__heading">{{with .Active}}{{.}}{{else}}admin{{end}}</h1>
+        {{with .AdminEmail}}<span class="admin-topbar__user">{{.}}</span>{{end}}
+      </header>
+
+      <div class="admin-flash">
+        {{ range .FlashInfo }}
+          <p class="flash flash--info">{{ . }}</p>
+        {{ end }}
+        {{ range .FlashError }}
+          <p class="flash flash--error">{{ . }}</p>
+        {{ end }}
+      </div>
+
+      <main class="admin-content">
+        {{template "main" .}}
+      </main>
+    </div>
+
+  </body>
+</html>
+{{end}}

--- a/backend/layout/tmpl/admin/order_detail.gohtml
+++ b/backend/layout/tmpl/admin/order_detail.gohtml
@@ -1,11 +1,7 @@
 {{define "main"}}
-  <h1 class="page-title">admin</h1>
-  <div class="admin">
-    <aside class="admin__side">{{template "admin-nav" .}}</aside>
-    <div class="admin__content">
-      <p class="crumbs"><a href="/admin/orders">orders</a> / order</p>
+  <p class="crumbs"><a href="/admin/orders">orders</a> / order</p>
 
-      <article class="order">
+  <article class="order">
         <header class="order__header">
           <h2 class="account-card__title">order <span class="order__id">{{.Order.ID}}</span></h2>
           <p class="order__subtitle muted">
@@ -85,8 +81,6 @@
               <button type="submit" class="linkbtn linkbtn--danger">cancel order</button>
             </form>
           {{end}}
-        </div>
-      </article>
     </div>
-  </div>
+  </article>
 {{end}}

--- a/backend/layout/tmpl/admin/order_detail.gohtml
+++ b/backend/layout/tmpl/admin/order_detail.gohtml
@@ -1,0 +1,92 @@
+{{define "main"}}
+  <h1 class="page-title">admin</h1>
+  <div class="admin">
+    <aside class="admin__side">{{template "admin-nav" .}}</aside>
+    <div class="admin__content">
+      <p class="crumbs"><a href="/admin/orders">orders</a> / order</p>
+
+      <article class="order">
+        <header class="order__header">
+          <h2 class="account-card__title">order <span class="order__id">{{.Order.ID}}</span></h2>
+          <p class="order__subtitle muted">
+            <span class="order-status order-status--{{.Order.Status}}">{{.Order.Status}}</span> &middot;
+            placed {{.Order.PlacedAt.Format "Jan 2, 2006 15:04 MST"}} &middot;
+            customer {{if .Order.CustomerID}}{{.Order.CustomerID}}{{else}}<span class="muted">guest</span>{{end}}
+          </p>
+        </header>
+
+        <table class="cart-table order__lines">
+          <thead>
+            <tr>
+              <th>item</th>
+              <th class="col-qty">qty</th>
+              <th class="col-price">unit</th>
+              <th class="col-total">subtotal</th>
+            </tr>
+          </thead>
+          <tbody>
+            {{range $line := .Order.Items}}
+              <tr>
+                <td>{{$line.ProductName}}</td>
+                <td class="col-qty">{{$line.Quantity}}</td>
+                <td class="col-price">{{$line.PriceDisplay}} {{$line.PriceCurrency}}</td>
+                <td class="col-total">{{$line.LineTotalDisplay}} {{$line.PriceCurrency}}</td>
+              </tr>
+            {{end}}
+          </tbody>
+          <tfoot>
+            <tr>
+              <td colspan="3">subtotal</td>
+              <td class="col-total">{{.Order.SubtotalDisplay}} {{.Order.TotalCurrency}}</td>
+            </tr>
+            {{if not .Order.ShippingMethod.IsZero}}
+              <tr>
+                <td colspan="3">shipping &middot; {{.Order.ShippingMethod.Label}}</td>
+                <td class="col-total">{{.Order.ShippingCostDisplay}} {{.Order.TotalCurrency}}</td>
+              </tr>
+            {{end}}
+            <tr>
+              <td colspan="3">total</td>
+              <td class="col-total">{{.Order.TotalDisplay}} {{.Order.TotalCurrency}}</td>
+            </tr>
+          </tfoot>
+        </table>
+
+        {{if eq .Order.ShippingMethod.Code "pickup"}}
+          <section class="order__ship">
+            <h2 class="order__ship-heading">collection</h2>
+            <p>Personal pickup — collect in store.</p>
+          </section>
+        {{else if not .Order.ShipTo.IsZero}}
+          <section class="order__ship">
+            <h2 class="order__ship-heading">shipping to</h2>
+            <address class="order__address">
+              {{.Order.ShipTo.Name}}<br>
+              {{.Order.ShipTo.Street1}}<br>
+              {{with .Order.ShipTo.Street2}}{{.}}<br>{{end}}
+              {{.Order.ShipTo.City}}, {{.Order.ShipTo.Zip}}<br>
+              {{.Order.ShipTo.Country}}
+            </address>
+          </section>
+        {{end}}
+
+        {{if not .Order.PaymentMethod.IsZero}}
+          <section class="order__ship">
+            <h2 class="order__ship-heading">payment</h2>
+            <p>{{.Order.PaymentMethod.Label}}</p>
+          </section>
+        {{end}}
+
+        <div class="order__actions">
+          <a href="/admin/orders" class="btn btn--ghost">back to orders</a>
+          {{if .CanCancel}}
+            <form method="post" action="/admin/orders/{{.Order.ID}}/cancel"
+                  onsubmit="return confirm('Cancel this order as admin? Reserved stock will be released.');">
+              <button type="submit" class="linkbtn linkbtn--danger">cancel order</button>
+            </form>
+          {{end}}
+        </div>
+      </article>
+    </div>
+  </div>
+{{end}}

--- a/backend/layout/tmpl/admin/orders.gohtml
+++ b/backend/layout/tmpl/admin/orders.gohtml
@@ -1,0 +1,31 @@
+{{define "main"}}
+  <h1 class="page-title">admin</h1>
+  <div class="admin">
+    <aside class="admin__side">{{template "admin-nav" .}}</aside>
+    <div class="admin__content">
+      <h2 class="account-card__title">orders</h2>
+
+      {{if .Orders}}
+        <table class="admin-table">
+          <thead>
+            <tr><th>order</th><th>customer</th><th>status</th><th>placed</th><th>items</th><th>total</th></tr>
+          </thead>
+          <tbody>
+            {{range $o := .Orders}}
+              <tr>
+                <td><a href="/admin/orders/{{$o.ID}}"><code>{{$o.ID}}</code></a></td>
+                <td>{{if $o.CustomerID}}{{$o.CustomerID}}{{else}}<span class="muted">guest</span>{{end}}</td>
+                <td><span class="order-status order-status--{{$o.Status}}">{{$o.Status}}</span></td>
+                <td>{{$o.PlacedAt.Format "Jan 2, 2006 15:04 MST"}}</td>
+                <td>{{$o.ItemCount}}</td>
+                <td>{{$o.TotalDisplay}} {{$o.TotalCurrency}}</td>
+              </tr>
+            {{end}}
+          </tbody>
+        </table>
+      {{else}}
+        <p class="muted">no orders yet.</p>
+      {{end}}
+    </div>
+  </div>
+{{end}}

--- a/backend/layout/tmpl/admin/orders.gohtml
+++ b/backend/layout/tmpl/admin/orders.gohtml
@@ -1,31 +1,25 @@
 {{define "main"}}
-  <h1 class="page-title">admin</h1>
-  <div class="admin">
-    <aside class="admin__side">{{template "admin-nav" .}}</aside>
-    <div class="admin__content">
-      <h2 class="account-card__title">orders</h2>
+  <h2 class="account-card__title">orders</h2>
 
-      {{if .Orders}}
-        <table class="admin-table">
-          <thead>
-            <tr><th>order</th><th>customer</th><th>status</th><th>placed</th><th>items</th><th>total</th></tr>
-          </thead>
-          <tbody>
-            {{range $o := .Orders}}
-              <tr>
-                <td><a href="/admin/orders/{{$o.ID}}"><code>{{$o.ID}}</code></a></td>
-                <td>{{if $o.CustomerID}}{{$o.CustomerID}}{{else}}<span class="muted">guest</span>{{end}}</td>
-                <td><span class="order-status order-status--{{$o.Status}}">{{$o.Status}}</span></td>
-                <td>{{$o.PlacedAt.Format "Jan 2, 2006 15:04 MST"}}</td>
-                <td>{{$o.ItemCount}}</td>
-                <td>{{$o.TotalDisplay}} {{$o.TotalCurrency}}</td>
-              </tr>
-            {{end}}
-          </tbody>
-        </table>
-      {{else}}
-        <p class="muted">no orders yet.</p>
-      {{end}}
-    </div>
-  </div>
+  {{if .Orders}}
+    <table class="admin-table">
+      <thead>
+        <tr><th>order</th><th>customer</th><th>status</th><th>placed</th><th>items</th><th>total</th></tr>
+      </thead>
+      <tbody>
+        {{range $o := .Orders}}
+          <tr>
+            <td><a href="/admin/orders/{{$o.ID}}"><code>{{$o.ID}}</code></a></td>
+            <td>{{if $o.CustomerID}}{{$o.CustomerID}}{{else}}<span class="muted">guest</span>{{end}}</td>
+            <td><span class="order-status order-status--{{$o.Status}}">{{$o.Status}}</span></td>
+            <td>{{$o.PlacedAt.Format "Jan 2, 2006 15:04 MST"}}</td>
+            <td>{{$o.ItemCount}}</td>
+            <td>{{$o.TotalDisplay}} {{$o.TotalCurrency}}</td>
+          </tr>
+        {{end}}
+      </tbody>
+    </table>
+  {{else}}
+    <p class="muted">no orders yet.</p>
+  {{end}}
 {{end}}

--- a/backend/layout/tmpl/admin/product_edit.gohtml
+++ b/backend/layout/tmpl/admin/product_edit.gohtml
@@ -1,0 +1,86 @@
+{{define "main"}}
+  <h1 class="page-title">admin</h1>
+  <div class="admin">
+    <aside class="admin__side">{{template "admin-nav" .}}</aside>
+    <div class="admin__content">
+      <p class="crumbs"><a href="/admin/products">products</a> / edit</p>
+      <h2 class="account-card__title">edit product <code>{{.Product.ID}}</code></h2>
+
+      <section class="admin-section">
+        <h3 class="admin-section__title">core fields</h3>
+        <form class="form" method="post" action="/admin/products/{{.Product.ID}}">
+          <div class="field"><label for="p-name">name</label><input id="p-name" name="name" value="{{.Product.Name}}" required></div>
+          <div class="field"><label for="p-description">description</label><textarea id="p-description" name="description" required>{{.Product.Description}}</textarea></div>
+          <div class="field"><label for="p-price">price (major units, e.g. 9.00)</label><input id="p-price" name="price" value="{{.Product.Price.Display}}" required></div>
+          <div class="field"><label for="p-currency">currency</label><input id="p-currency" name="currency" value="{{.Product.Price.Currency}}"></div>
+          <div class="field"><label for="p-thumbnail">thumbnail URL</label><input id="p-thumbnail" name="thumbnail" value="{{.Product.Thumbnail}}"></div>
+          <button type="submit" class="btn">save core fields</button>
+        </form>
+      </section>
+
+      <section class="admin-section">
+        <h3 class="admin-section__title">variant stock</h3>
+        {{if .Product.Variants}}
+          <form class="form" method="post" action="/admin/products/{{.Product.ID}}/stock">
+            <table class="admin-table">
+              <thead><tr><th>variant</th><th>sku</th><th>stock</th></tr></thead>
+              <tbody>
+                {{$ots := .Product.OptionTypes}}
+                {{range $v := .Product.Variants}}
+                  <tr>
+                    <td>{{with $v.Label $ots}}{{.}}{{else}}default{{end}}</td>
+                    <td><code>{{$v.SKU}}</code></td>
+                    <td><input type="number" name="stock_{{$v.ID}}" value="{{$v.Stock}}" min="0"></td>
+                  </tr>
+                {{end}}
+              </tbody>
+            </table>
+            <button type="submit" class="btn">save stock</button>
+          </form>
+        {{else}}
+          <p class="muted">no variants.</p>
+        {{end}}
+      </section>
+
+      <section class="admin-section">
+        <h3 class="admin-section__title">categories</h3>
+        {{if .Categories}}
+          <form class="form" method="post" action="/admin/products/{{.Product.ID}}/categories">
+            <div class="admin-checks">
+              {{range $c := .Categories}}
+                <label class="admin-check"><input type="checkbox" name="category" value="{{$c.ID}}" {{if index $.Assigned $c.ID}}checked{{end}}> {{$c.Name}}</label>
+              {{end}}
+            </div>
+            <button type="submit" class="btn">save categories</button>
+          </form>
+        {{else}}
+          <p class="muted">no categories defined.</p>
+        {{end}}
+      </section>
+
+      <section class="admin-section">
+        <h3 class="admin-section__title">attributes</h3>
+        {{if .AttrTypes}}
+          <form class="form" method="post" action="/admin/products/{{.Product.ID}}/attributes">
+            {{range $t := .AttrTypes}}
+              <div class="field">
+                <label for="attr-{{$t.ID}}">{{$t.Name}}{{with $t.Unit}} ({{.}}){{end}}</label>
+                {{if $t.IsNumeric}}
+                  <input id="attr-{{$t.ID}}" type="number" step="any" name="attr_{{$t.ID}}" value="{{index $.AttrValues $t.ID}}">
+                {{else}}
+                  <input id="attr-{{$t.ID}}" type="text" name="attr_{{$t.ID}}" value="{{index $.AttrValues $t.ID}}">
+                {{end}}
+              </div>
+            {{end}}
+            <button type="submit" class="btn">save attributes</button>
+            <p class="form__aside muted">leave a field empty to clear that attribute.</p>
+          </form>
+        {{else}}
+          <p class="muted">no attribute types defined.</p>
+        {{end}}
+      </section>
+
+      <p class="form__aside"><a href="/admin/products">&larr; back to products</a></p>
+    </div>
+  </div>
+{{end}}

--- a/backend/layout/tmpl/admin/product_edit.gohtml
+++ b/backend/layout/tmpl/admin/product_edit.gohtml
@@ -1,86 +1,80 @@
 {{define "main"}}
-  <h1 class="page-title">admin</h1>
-  <div class="admin">
-    <aside class="admin__side">{{template "admin-nav" .}}</aside>
-    <div class="admin__content">
-      <p class="crumbs"><a href="/admin/products">products</a> / edit</p>
-      <h2 class="account-card__title">edit product <code>{{.Product.ID}}</code></h2>
+  <p class="crumbs"><a href="/admin/products">products</a> / edit</p>
+  <h2 class="account-card__title">edit product <code>{{.Product.ID}}</code></h2>
 
-      <section class="admin-section">
-        <h3 class="admin-section__title">core fields</h3>
-        <form class="form" method="post" action="/admin/products/{{.Product.ID}}">
-          <div class="field"><label for="p-name">name</label><input id="p-name" name="name" value="{{.Product.Name}}" required></div>
-          <div class="field"><label for="p-description">description</label><textarea id="p-description" name="description" required>{{.Product.Description}}</textarea></div>
-          <div class="field"><label for="p-price">price (major units, e.g. 9.00)</label><input id="p-price" name="price" value="{{.Product.Price.Display}}" required></div>
-          <div class="field"><label for="p-currency">currency</label><input id="p-currency" name="currency" value="{{.Product.Price.Currency}}"></div>
-          <div class="field"><label for="p-thumbnail">thumbnail URL</label><input id="p-thumbnail" name="thumbnail" value="{{.Product.Thumbnail}}"></div>
-          <button type="submit" class="btn">save core fields</button>
-        </form>
-      </section>
+  <section class="admin-section">
+    <h3 class="admin-section__title">core fields</h3>
+    <form class="form" method="post" action="/admin/products/{{.Product.ID}}">
+      <div class="field"><label for="p-name">name</label><input id="p-name" name="name" value="{{.Product.Name}}" required></div>
+      <div class="field"><label for="p-description">description</label><textarea id="p-description" name="description" required>{{.Product.Description}}</textarea></div>
+      <div class="field"><label for="p-price">price (major units, e.g. 9.00)</label><input id="p-price" name="price" value="{{.Product.Price.Display}}" required></div>
+      <div class="field"><label for="p-currency">currency</label><input id="p-currency" name="currency" value="{{.Product.Price.Currency}}"></div>
+      <div class="field"><label for="p-thumbnail">thumbnail URL</label><input id="p-thumbnail" name="thumbnail" value="{{.Product.Thumbnail}}"></div>
+      <button type="submit" class="btn">save core fields</button>
+    </form>
+  </section>
 
-      <section class="admin-section">
-        <h3 class="admin-section__title">variant stock</h3>
-        {{if .Product.Variants}}
-          <form class="form" method="post" action="/admin/products/{{.Product.ID}}/stock">
-            <table class="admin-table">
-              <thead><tr><th>variant</th><th>sku</th><th>stock</th></tr></thead>
-              <tbody>
-                {{$ots := .Product.OptionTypes}}
-                {{range $v := .Product.Variants}}
-                  <tr>
-                    <td>{{with $v.Label $ots}}{{.}}{{else}}default{{end}}</td>
-                    <td><code>{{$v.SKU}}</code></td>
-                    <td><input type="number" name="stock_{{$v.ID}}" value="{{$v.Stock}}" min="0"></td>
-                  </tr>
-                {{end}}
-              </tbody>
-            </table>
-            <button type="submit" class="btn">save stock</button>
-          </form>
-        {{else}}
-          <p class="muted">no variants.</p>
-        {{end}}
-      </section>
-
-      <section class="admin-section">
-        <h3 class="admin-section__title">categories</h3>
-        {{if .Categories}}
-          <form class="form" method="post" action="/admin/products/{{.Product.ID}}/categories">
-            <div class="admin-checks">
-              {{range $c := .Categories}}
-                <label class="admin-check"><input type="checkbox" name="category" value="{{$c.ID}}" {{if index $.Assigned $c.ID}}checked{{end}}> {{$c.Name}}</label>
-              {{end}}
-            </div>
-            <button type="submit" class="btn">save categories</button>
-          </form>
-        {{else}}
-          <p class="muted">no categories defined.</p>
-        {{end}}
-      </section>
-
-      <section class="admin-section">
-        <h3 class="admin-section__title">attributes</h3>
-        {{if .AttrTypes}}
-          <form class="form" method="post" action="/admin/products/{{.Product.ID}}/attributes">
-            {{range $t := .AttrTypes}}
-              <div class="field">
-                <label for="attr-{{$t.ID}}">{{$t.Name}}{{with $t.Unit}} ({{.}}){{end}}</label>
-                {{if $t.IsNumeric}}
-                  <input id="attr-{{$t.ID}}" type="number" step="any" name="attr_{{$t.ID}}" value="{{index $.AttrValues $t.ID}}">
-                {{else}}
-                  <input id="attr-{{$t.ID}}" type="text" name="attr_{{$t.ID}}" value="{{index $.AttrValues $t.ID}}">
-                {{end}}
-              </div>
+  <section class="admin-section">
+    <h3 class="admin-section__title">variant stock</h3>
+    {{if .Product.Variants}}
+      <form class="form" method="post" action="/admin/products/{{.Product.ID}}/stock">
+        <table class="admin-table">
+          <thead><tr><th>variant</th><th>sku</th><th>stock</th></tr></thead>
+          <tbody>
+            {{$ots := .Product.OptionTypes}}
+            {{range $v := .Product.Variants}}
+              <tr>
+                <td>{{with $v.Label $ots}}{{.}}{{else}}default{{end}}</td>
+                <td><code>{{$v.SKU}}</code></td>
+                <td><input type="number" name="stock_{{$v.ID}}" value="{{$v.Stock}}" min="0"></td>
+              </tr>
             {{end}}
-            <button type="submit" class="btn">save attributes</button>
-            <p class="form__aside muted">leave a field empty to clear that attribute.</p>
-          </form>
-        {{else}}
-          <p class="muted">no attribute types defined.</p>
-        {{end}}
-      </section>
+          </tbody>
+        </table>
+        <button type="submit" class="btn">save stock</button>
+      </form>
+    {{else}}
+      <p class="muted">no variants.</p>
+    {{end}}
+  </section>
 
-      <p class="form__aside"><a href="/admin/products">&larr; back to products</a></p>
-    </div>
-  </div>
+  <section class="admin-section">
+    <h3 class="admin-section__title">categories</h3>
+    {{if .Categories}}
+      <form class="form" method="post" action="/admin/products/{{.Product.ID}}/categories">
+        <div class="admin-checks">
+          {{range $c := .Categories}}
+            <label class="admin-check"><input type="checkbox" name="category" value="{{$c.ID}}" {{if index $.Assigned $c.ID}}checked{{end}}> {{$c.Name}}</label>
+          {{end}}
+        </div>
+        <button type="submit" class="btn">save categories</button>
+      </form>
+    {{else}}
+      <p class="muted">no categories defined.</p>
+    {{end}}
+  </section>
+
+  <section class="admin-section">
+    <h3 class="admin-section__title">attributes</h3>
+    {{if .AttrTypes}}
+      <form class="form" method="post" action="/admin/products/{{.Product.ID}}/attributes">
+        {{range $t := .AttrTypes}}
+          <div class="field">
+            <label for="attr-{{$t.ID}}">{{$t.Name}}{{with $t.Unit}} ({{.}}){{end}}</label>
+            {{if $t.IsNumeric}}
+              <input id="attr-{{$t.ID}}" type="number" step="any" name="attr_{{$t.ID}}" value="{{index $.AttrValues $t.ID}}">
+            {{else}}
+              <input id="attr-{{$t.ID}}" type="text" name="attr_{{$t.ID}}" value="{{index $.AttrValues $t.ID}}">
+            {{end}}
+          </div>
+        {{end}}
+        <button type="submit" class="btn">save attributes</button>
+        <p class="form__aside muted">leave a field empty to clear that attribute.</p>
+      </form>
+    {{else}}
+      <p class="muted">no attribute types defined.</p>
+    {{end}}
+  </section>
+
+  <p class="form__aside"><a href="/admin/products">&larr; back to products</a></p>
 {{end}}

--- a/backend/layout/tmpl/admin/products.gohtml
+++ b/backend/layout/tmpl/admin/products.gohtml
@@ -1,56 +1,50 @@
 {{define "main"}}
-  <h1 class="page-title">admin</h1>
-  <div class="admin">
-    <aside class="admin__side">{{template "admin-nav" .}}</aside>
-    <div class="admin__content">
-      <h2 class="account-card__title">products</h2>
+  <h2 class="account-card__title">products</h2>
 
-      {{if .Products}}
-        <table class="admin-table">
-          <thead>
-            <tr><th>name</th><th>price</th><th>variants</th><th>stock</th><th>categories</th><th></th></tr>
-          </thead>
-          <tbody>
-            {{range $p := .Products}}
-              <tr>
-                <td>{{$p.Name}}<br><code>{{$p.ID}}</code></td>
-                <td>{{$p.Price.Currency}} {{$p.Price.Display}}</td>
-                <td>{{len $p.Variants}}</td>
-                <td>
-                  {{$total := 0}}
-                  {{range $v := $p.Variants}}{{$total = add $total $v.Stock}}{{end}}
-                  {{$total}}
-                </td>
-                <td>
-                  {{range $i, $c := $p.Categories}}{{if $i}}, {{end}}{{$c.Name}}{{else}}<span class="muted">&mdash;</span>{{end}}
-                </td>
-                <td class="admin-table__actions">
-                  <a href="/admin/products/{{$p.ID}}/edit">edit</a>
-                  <form method="post" action="/admin/products/{{$p.ID}}/delete"
-                        onsubmit="return confirm('Delete this product? Its variants, category and attribute links will be removed.');">
-                    <button type="submit" class="linkbtn linkbtn--danger">delete</button>
-                  </form>
-                </td>
-              </tr>
-            {{end}}
-          </tbody>
-        </table>
-      {{else}}
-        <p class="muted">no products yet.</p>
-      {{end}}
+  {{if .Products}}
+    <table class="admin-table">
+      <thead>
+        <tr><th>name</th><th>price</th><th>variants</th><th>stock</th><th>categories</th><th></th></tr>
+      </thead>
+      <tbody>
+        {{range $p := .Products}}
+          <tr>
+            <td>{{$p.Name}}<br><code>{{$p.ID}}</code></td>
+            <td>{{$p.Price.Currency}} {{$p.Price.Display}}</td>
+            <td>{{len $p.Variants}}</td>
+            <td>
+              {{$total := 0}}
+              {{range $v := $p.Variants}}{{$total = add $total $v.Stock}}{{end}}
+              {{$total}}
+            </td>
+            <td>
+              {{range $i, $c := $p.Categories}}{{if $i}}, {{end}}{{$c.Name}}{{else}}<span class="muted">&mdash;</span>{{end}}
+            </td>
+            <td class="admin-table__actions">
+              <a href="/admin/products/{{$p.ID}}/edit">edit</a>
+              <form method="post" action="/admin/products/{{$p.ID}}/delete"
+                    onsubmit="return confirm('Delete this product? Its variants, category and attribute links will be removed.');">
+                <button type="submit" class="linkbtn linkbtn--danger">delete</button>
+              </form>
+            </td>
+          </tr>
+        {{end}}
+      </tbody>
+    </table>
+  {{else}}
+    <p class="muted">no products yet.</p>
+  {{end}}
 
-      <section class="admin-form">
-        <h3 class="account-card__title">add a product</h3>
-        <form class="form" method="post" action="/admin/products">
-          <div class="field"><label for="p-id">id (slug)</label><input id="p-id" name="id" required placeholder="lowercase-with-hyphens"></div>
-          <div class="field"><label for="p-name">name</label><input id="p-name" name="name" required></div>
-          <div class="field"><label for="p-description">description</label><textarea id="p-description" name="description" required></textarea></div>
-          <div class="field"><label for="p-price">price (major units, e.g. 9.00)</label><input id="p-price" name="price" required placeholder="9.00"></div>
-          <div class="field"><label for="p-currency">currency</label><input id="p-currency" name="currency" value="USD"></div>
-          <div class="field"><label for="p-thumbnail">thumbnail URL</label><input id="p-thumbnail" name="thumbnail"></div>
-          <button type="submit" class="btn">create product</button>
-        </form>
-      </section>
-    </div>
-  </div>
+  <section class="admin-form">
+    <h3 class="account-card__title">add a product</h3>
+    <form class="form" method="post" action="/admin/products">
+      <div class="field"><label for="p-id">id (slug)</label><input id="p-id" name="id" required placeholder="lowercase-with-hyphens"></div>
+      <div class="field"><label for="p-name">name</label><input id="p-name" name="name" required></div>
+      <div class="field"><label for="p-description">description</label><textarea id="p-description" name="description" required></textarea></div>
+      <div class="field"><label for="p-price">price (major units, e.g. 9.00)</label><input id="p-price" name="price" required placeholder="9.00"></div>
+      <div class="field"><label for="p-currency">currency</label><input id="p-currency" name="currency" value="USD"></div>
+      <div class="field"><label for="p-thumbnail">thumbnail URL</label><input id="p-thumbnail" name="thumbnail"></div>
+      <button type="submit" class="btn">create product</button>
+    </form>
+  </section>
 {{end}}

--- a/backend/layout/tmpl/admin/products.gohtml
+++ b/backend/layout/tmpl/admin/products.gohtml
@@ -1,0 +1,56 @@
+{{define "main"}}
+  <h1 class="page-title">admin</h1>
+  <div class="admin">
+    <aside class="admin__side">{{template "admin-nav" .}}</aside>
+    <div class="admin__content">
+      <h2 class="account-card__title">products</h2>
+
+      {{if .Products}}
+        <table class="admin-table">
+          <thead>
+            <tr><th>name</th><th>price</th><th>variants</th><th>stock</th><th>categories</th><th></th></tr>
+          </thead>
+          <tbody>
+            {{range $p := .Products}}
+              <tr>
+                <td>{{$p.Name}}<br><code>{{$p.ID}}</code></td>
+                <td>{{$p.Price.Currency}} {{$p.Price.Display}}</td>
+                <td>{{len $p.Variants}}</td>
+                <td>
+                  {{$total := 0}}
+                  {{range $v := $p.Variants}}{{$total = add $total $v.Stock}}{{end}}
+                  {{$total}}
+                </td>
+                <td>
+                  {{range $i, $c := $p.Categories}}{{if $i}}, {{end}}{{$c.Name}}{{else}}<span class="muted">&mdash;</span>{{end}}
+                </td>
+                <td class="admin-table__actions">
+                  <a href="/admin/products/{{$p.ID}}/edit">edit</a>
+                  <form method="post" action="/admin/products/{{$p.ID}}/delete"
+                        onsubmit="return confirm('Delete this product? Its variants, category and attribute links will be removed.');">
+                    <button type="submit" class="linkbtn linkbtn--danger">delete</button>
+                  </form>
+                </td>
+              </tr>
+            {{end}}
+          </tbody>
+        </table>
+      {{else}}
+        <p class="muted">no products yet.</p>
+      {{end}}
+
+      <section class="admin-form">
+        <h3 class="account-card__title">add a product</h3>
+        <form class="form" method="post" action="/admin/products">
+          <div class="field"><label for="p-id">id (slug)</label><input id="p-id" name="id" required placeholder="lowercase-with-hyphens"></div>
+          <div class="field"><label for="p-name">name</label><input id="p-name" name="name" required></div>
+          <div class="field"><label for="p-description">description</label><textarea id="p-description" name="description" required></textarea></div>
+          <div class="field"><label for="p-price">price (major units, e.g. 9.00)</label><input id="p-price" name="price" required placeholder="9.00"></div>
+          <div class="field"><label for="p-currency">currency</label><input id="p-currency" name="currency" value="USD"></div>
+          <div class="field"><label for="p-thumbnail">thumbnail URL</label><input id="p-thumbnail" name="thumbnail"></div>
+          <button type="submit" class="btn">create product</button>
+        </form>
+      </section>
+    </div>
+  </div>
+{{end}}

--- a/backend/layout/tmpl/home.gohtml
+++ b/backend/layout/tmpl/home.gohtml
@@ -1,64 +1,30 @@
 {{define "main"}}
-  <h1 class="page-title">products</h1>
-
-  <div class="catalog">
-    <aside class="filter-rail">
-      <nav class="category-nav">
-        <a class="category-nav__link{{if eq .ActiveCategory ""}} is-active{{end}}" href="/">all</a>
-        {{range .Categories}}
-          <a class="category-nav__link{{if eq $.ActiveCategory .Slug}} is-active{{end}}"
-             href="/category/{{.Slug}}">{{.Name}}</a>
-        {{end}}
-      </nav>
-
-      {{if .Facets}}
-        <form class="filter-form"
-              hx-get="/api/v1/products"
-              hx-target="#product-grid"
-              hx-trigger="submit, change delay:300ms"
-              hx-push-url="false">
-          <input type="hidden" name="category" value="{{.ActiveCategory}}">
-
-          {{range .Facets}}
-            <div class="facet">
-              <h3 class="facet__title">{{.Type.Name}}{{if .Type.Unit}} <span class="muted">({{.Type.Unit}})</span>{{end}}</h3>
-              {{if .Type.IsNumeric}}
-                <div class="facet__range">
-                  <input class="facet__num" type="number" step="any"
-                         name="{{.Type.ID}}_min" placeholder="min"
-                         aria-label="{{.Type.Name}} min">
-                  <span class="facet__sep">&ndash;</span>
-                  <input class="facet__num" type="number" step="any"
-                         name="{{.Type.ID}}_max" placeholder="max"
-                         aria-label="{{.Type.Name}} max">
-                </div>
-              {{else if .Type.IsEnum}}
-                <div class="facet__values">
-                  {{$tid := .Type.ID}}
-                  {{range .Values}}
-                    <label class="facet__check">
-                      <input type="checkbox" name="{{$tid}}" value="{{.}}">
-                      <span>{{.}}</span>
-                    </label>
-                  {{end}}
-                </div>
-              {{end}}
-            </div>
-          {{end}}
-
-          <div class="filter-form__actions">
-            <button type="submit" class="btn btn--block">apply</button>
-            <a class="filter-form__clear" href="{{if .ActiveCategory}}/category/{{.ActiveCategory}}{{else}}/{{end}}">clear</a>
-          </div>
-        </form>
-      {{end}}
-    </aside>
-
-    <div id="product-grid" class="catalog__grid"
-         hx-get="/api/v1/products?category={{.ActiveCategory}}"
-         hx-trigger="load"
-         hx-swap="innerHTML">
-      <p class="muted"><span class="loading"></span> loading&hellip;</p>
-    </div>
+  <div class="home-hero">
+    <h1 class="page-title">new arrivals</h1>
+    <a class="btn home-hero__shop" href="/products">shop all</a>
   </div>
+
+  {{if .Newest}}
+    <div class="product-grid">
+      {{range .Newest}}
+        <a class="product-card" href="/product/{{.ID}}">
+          {{if .Thumbnail}}
+            <img class="product-card__image"
+                 src="{{.Thumbnail}}"
+                 alt="{{.Name}}"
+                 loading="lazy"
+                 width="800" height="800">
+          {{end}}
+          <h2 class="product-card__name">{{.Name}}</h2>
+          <p class="product-card__price">{{if .HasPriceRange}}from {{end}}{{.PriceFrom.Display}} {{.PriceFrom.Currency}}</p>
+        </a>
+      {{end}}
+    </div>
+
+    <p class="home-browse">
+      <a href="/products">browse everything &rarr;</a>
+    </p>
+  {{else}}
+    <p class="muted">no products yet. <a href="/products">browse the shop</a>.</p>
+  {{end}}
 {{end}}

--- a/backend/layout/tmpl/layout.gohtml
+++ b/backend/layout/tmpl/layout.gohtml
@@ -20,7 +20,10 @@
         <a href="/" class="brand">Ecommerce</a>
         <nav>
           <ul class="nav">
-            <li><a href="/">products</a></li>
+            <li><a href="/products">shop</a></li>
+            {{range .NavCategories}}
+              <li><a href="/category/{{.Slug}}">{{.Name}}</a></li>
+            {{end}}
             <li>
               <a href="/cart" class="cart-link">cart
                 <span id="cartBudge"

--- a/backend/layout/tmpl/layout.gohtml
+++ b/backend/layout/tmpl/layout.gohtml
@@ -33,6 +33,9 @@
             {{if .LoggedIn}}
               <li><a href="/account">account</a></li>
             {{end}}
+            {{if .IsAdmin}}
+              <li><a href="/admin">admin</a></li>
+            {{end}}
             {{ html .AuthMenuItem }}
           </ul>
         </nav>

--- a/backend/layout/tmpl/partials/admin-nav.gohtml
+++ b/backend/layout/tmpl/partials/admin-nav.gohtml
@@ -1,0 +1,11 @@
+{{define "admin-nav"}}
+<nav class="admin-nav">
+  <a href="/admin" class="admin-nav__link {{if eq .Active "dashboard"}}is-active{{end}}">dashboard</a>
+  <a href="/admin/products" class="admin-nav__link {{if eq .Active "products"}}is-active{{end}}">products</a>
+  <a href="/admin/categories" class="admin-nav__link {{if eq .Active "categories"}}is-active{{end}}">categories</a>
+  <a href="/admin/attributes" class="admin-nav__link {{if eq .Active "attributes"}}is-active{{end}}">attributes</a>
+  <a href="/admin/orders" class="admin-nav__link {{if eq .Active "orders"}}is-active{{end}}">orders</a>
+  <span class="admin-nav__rule"></span>
+  <a href="/" class="admin-nav__link admin-nav__link--muted">back to store</a>
+</nav>
+{{end}}

--- a/backend/layout/tmpl/productCatalog/catalog.gohtml
+++ b/backend/layout/tmpl/productCatalog/catalog.gohtml
@@ -1,0 +1,64 @@
+{{define "main"}}
+  <h1 class="page-title">shop</h1>
+
+  <div class="catalog">
+    <aside class="filter-rail">
+      <nav class="category-nav">
+        <a class="category-nav__link{{if eq .ActiveCategory ""}} is-active{{end}}" href="/products">all</a>
+        {{range .Categories}}
+          <a class="category-nav__link{{if eq $.ActiveCategory .Slug}} is-active{{end}}"
+             href="/category/{{.Slug}}">{{.Name}}</a>
+        {{end}}
+      </nav>
+
+      {{if .Facets}}
+        <form class="filter-form"
+              hx-get="/api/v1/products"
+              hx-target="#product-grid"
+              hx-trigger="submit, change delay:300ms"
+              hx-push-url="false">
+          <input type="hidden" name="category" value="{{.ActiveCategory}}">
+
+          {{range .Facets}}
+            <div class="facet">
+              <h3 class="facet__title">{{.Type.Name}}{{if .Type.Unit}} <span class="muted">({{.Type.Unit}})</span>{{end}}</h3>
+              {{if .Type.IsNumeric}}
+                <div class="facet__range">
+                  <input class="facet__num" type="number" step="any"
+                         name="{{.Type.ID}}_min" placeholder="min"
+                         aria-label="{{.Type.Name}} min">
+                  <span class="facet__sep">&ndash;</span>
+                  <input class="facet__num" type="number" step="any"
+                         name="{{.Type.ID}}_max" placeholder="max"
+                         aria-label="{{.Type.Name}} max">
+                </div>
+              {{else if .Type.IsEnum}}
+                <div class="facet__values">
+                  {{$tid := .Type.ID}}
+                  {{range .Values}}
+                    <label class="facet__check">
+                      <input type="checkbox" name="{{$tid}}" value="{{.}}">
+                      <span>{{.}}</span>
+                    </label>
+                  {{end}}
+                </div>
+              {{end}}
+            </div>
+          {{end}}
+
+          <div class="filter-form__actions">
+            <button type="submit" class="btn btn--block">apply</button>
+            <a class="filter-form__clear" href="{{if .ActiveCategory}}/category/{{.ActiveCategory}}{{else}}/products{{end}}">clear</a>
+          </div>
+        </form>
+      {{end}}
+    </aside>
+
+    <div id="product-grid" class="catalog__grid"
+         hx-get="/api/v1/products?category={{.ActiveCategory}}"
+         hx-trigger="load"
+         hx-swap="innerHTML">
+      <p class="muted"><span class="loading"></span> loading&hellip;</p>
+    </div>
+  </div>
+{{end}}

--- a/backend/productcatalog/adapter/inmemory.go
+++ b/backend/productcatalog/adapter/inmemory.go
@@ -150,6 +150,50 @@ func (im *inMemory) Categories(ctx context.Context) ([]domain.Category, error) {
 	return out, nil
 }
 
+func (im *inMemory) CreateCategory(ctx context.Context, c domain.Category) error {
+	im.categories[c.ID()] = c
+	return nil
+}
+
+func (im *inMemory) UpdateCategory(ctx context.Context, c domain.Category) error {
+	im.categories[c.ID()] = c
+	return nil
+}
+
+func (im *inMemory) DeleteCategory(ctx context.Context, id string) error {
+	delete(im.categories, id)
+	return nil
+}
+
+func (im *inMemory) AllAttributeTypes(ctx context.Context) ([]domain.AttributeType, error) {
+	out := make([]domain.AttributeType, 0, len(im.attrTypes))
+	for _, t := range im.attrTypes {
+		out = append(out, t)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Position() != out[j].Position() {
+			return out[i].Position() < out[j].Position()
+		}
+		return out[i].Name() < out[j].Name()
+	})
+	return out, nil
+}
+
+func (im *inMemory) CreateAttributeType(ctx context.Context, t domain.AttributeType) error {
+	im.attrTypes[t.ID()] = t
+	return nil
+}
+
+func (im *inMemory) UpdateAttributeType(ctx context.Context, t domain.AttributeType) error {
+	im.attrTypes[t.ID()] = t
+	return nil
+}
+
+func (im *inMemory) DeleteAttributeType(ctx context.Context, id string) error {
+	delete(im.attrTypes, id)
+	return nil
+}
+
 func (im *inMemory) inCategory(productID, slug string) bool {
 	for _, c := range im.prodCats[productID] {
 		if c.Slug() == slug {

--- a/backend/productcatalog/adapter/inmemory.go
+++ b/backend/productcatalog/adapter/inmemory.go
@@ -58,6 +58,19 @@ func (im *inMemory) All(ctx context.Context) ([]domain.Product, error) {
 	return out, nil
 }
 
+// Newest returns up to limit products in insertion order (there is no
+// created_at in the in-memory store), hydrated like All.
+func (im *inMemory) Newest(ctx context.Context, limit int) ([]domain.Product, error) {
+	if limit > len(im.products) {
+		limit = len(im.products)
+	}
+	out := make([]domain.Product, 0, limit)
+	for i := 0; i < limit; i++ {
+		out = append(out, im.hydrate(im.products[i]))
+	}
+	return out, nil
+}
+
 func (im *inMemory) Find(ctx context.Context, id string) (domain.Product, error) {
 	for _, p := range im.products {
 		if string(p.ID()) == id {

--- a/backend/productcatalog/adapter/inmemory.go
+++ b/backend/productcatalog/adapter/inmemory.go
@@ -67,6 +67,76 @@ func (im *inMemory) Find(ctx context.Context, id string) (domain.Product, error)
 	return domain.Product{}, domain.ErrProductNotFound
 }
 
+// UpdateProduct replaces the core product fields (name/description/price/
+// thumbnail) for the matching id, preserving its option types/variants and
+// classification (held in separate maps).
+func (im *inMemory) UpdateProduct(ctx context.Context, p domain.Product) error {
+	for i, existing := range im.products {
+		if existing.ID() == p.ID() {
+			im.products[i] = p
+			return nil
+		}
+	}
+	return domain.ErrProductNotFound
+}
+
+// DeleteProduct removes a product and its associated option types, variants and
+// classification (mirroring the postgres ON DELETE CASCADE behaviour).
+func (im *inMemory) DeleteProduct(ctx context.Context, id string) error {
+	for i, existing := range im.products {
+		if string(existing.ID()) == id {
+			im.products = append(im.products[:i], im.products[i+1:]...)
+			break
+		}
+	}
+	delete(im.optionTypes, id)
+	delete(im.variants, id)
+	delete(im.prodCats, id)
+	delete(im.prodAttrs, id)
+	return nil
+}
+
+// SetVariantStock sets a single variant's stock, wherever it lives.
+func (im *inMemory) SetVariantStock(ctx context.Context, variantID string, stock int) error {
+	pid, i, ok := im.find(variantID)
+	if !ok {
+		return domain.ErrProductNotFound
+	}
+	v := im.variants[pid][i]
+	im.variants[pid][i] = domain.NewVariant(v.ID(), v.SKU(), v.Image(), v.Options(), v.Price(), stock)
+	return nil
+}
+
+// SetProductCategories replaces the product's category links with the given set.
+func (im *inMemory) SetProductCategories(ctx context.Context, productID string, categoryIDs []string) error {
+	cats := make([]domain.Category, 0, len(categoryIDs))
+	for _, cid := range categoryIDs {
+		if c, ok := im.categories[cid]; ok {
+			cats = append(cats, c)
+		}
+	}
+	im.prodCats[productID] = cats
+	return nil
+}
+
+// SetProductAttributes replaces the product's attribute values with the given set.
+func (im *inMemory) SetProductAttributes(ctx context.Context, productID string, values []app.AttributeAssignment) error {
+	out := make([]domain.AttributeValue, 0, len(values))
+	for _, v := range values {
+		t, ok := im.attrTypes[v.TypeID]
+		if !ok {
+			continue
+		}
+		if v.Num != nil {
+			out = append(out, domain.NewNumericValue(t, *v.Num))
+		} else {
+			out = append(out, domain.NewEnumValue(t, v.Text))
+		}
+	}
+	im.prodAttrs[productID] = out
+	return nil
+}
+
 func (im *inMemory) find(variantID string) (string, int, bool) {
 	for pid, vs := range im.variants {
 		for i, v := range vs {
@@ -126,13 +196,13 @@ func (im *inMemory) AddCategory(c domain.Category) {
 	im.categories[c.ID()] = c
 }
 
-// SetProductAttributes attaches attribute values to a product. Test/seed helper.
-func (im *inMemory) SetProductAttributes(productID string, values ...domain.AttributeValue) {
+// SeedProductAttributes attaches attribute values to a product. Test/seed helper.
+func (im *inMemory) SeedProductAttributes(productID string, values ...domain.AttributeValue) {
 	im.prodAttrs[productID] = append(im.prodAttrs[productID], values...)
 }
 
-// SetProductCategories attaches categories to a product. Test/seed helper.
-func (im *inMemory) SetProductCategories(productID string, cats ...domain.Category) {
+// SeedProductCategories attaches categories to a product. Test/seed helper.
+func (im *inMemory) SeedProductCategories(productID string, cats ...domain.Category) {
 	im.prodCats[productID] = append(im.prodCats[productID], cats...)
 }
 

--- a/backend/productcatalog/adapter/postgres.go
+++ b/backend/productcatalog/adapter/postgres.go
@@ -484,6 +484,107 @@ func (db postgres) DeleteAttributeType(ctx context.Context, id string) error {
 	return nil
 }
 
+// UpdateProduct updates the core product row (name, description, thumbnail,
+// price) by id. Variants, categories and attributes are untouched.
+func (db postgres) UpdateProduct(ctx context.Context, p domain.Product) error {
+	_, err := db.db.ExecContext(ctx, `
+		UPDATE productcatalog_product
+		SET name = $2, description = $3, thumbnail = $4, price_amount = $5, price_currency = $6
+		WHERE id = $1
+	`, string(p.ID()), p.Name(), p.Description(), p.Thumbnail(), p.Price().Amount(), string(p.Price().Currency()))
+	if err != nil {
+		return fmt.Errorf("update product: %w", err)
+	}
+	return nil
+}
+
+// DeleteProduct removes a product row; variants, category and attribute links
+// cascade via ON DELETE CASCADE foreign keys.
+func (db postgres) DeleteProduct(ctx context.Context, id string) error {
+	_, err := db.db.ExecContext(ctx, `DELETE FROM productcatalog_product WHERE id = $1`, id)
+	if err != nil {
+		return fmt.Errorf("delete product: %w", err)
+	}
+	return nil
+}
+
+// SetVariantStock sets a single variant's stock level.
+func (db postgres) SetVariantStock(ctx context.Context, variantID string, stock int) error {
+	_, err := db.db.ExecContext(ctx, `UPDATE productcatalog_variant SET stock = $2 WHERE id = $1`, variantID, stock)
+	if err != nil {
+		return fmt.Errorf("set variant stock: %w", err)
+	}
+	return nil
+}
+
+// SetProductCategories replaces the product's category links: it deletes the
+// existing links and inserts the given set in a single transaction.
+func (db postgres) SetProductCategories(ctx context.Context, productID string, categoryIDs []string) error {
+	tx, err := db.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer func() {
+		if err != nil {
+			_ = tx.Rollback()
+		}
+	}()
+
+	if _, err = tx.ExecContext(ctx, `DELETE FROM productcatalog_product_category WHERE product_id = $1`, productID); err != nil {
+		return fmt.Errorf("clear product categories: %w", err)
+	}
+	for _, cid := range categoryIDs {
+		if _, err = tx.ExecContext(ctx, `
+			INSERT INTO productcatalog_product_category (product_id, category_id) VALUES ($1, $2)
+		`, productID, cid); err != nil {
+			return fmt.Errorf("insert product category: %w", err)
+		}
+	}
+	if err = tx.Commit(); err != nil {
+		return fmt.Errorf("commit product categories: %w", err)
+	}
+	return nil
+}
+
+// SetProductAttributes replaces the product's attribute rows: it deletes the
+// existing rows and inserts the given set in a single transaction. Numeric
+// assignments set num_value (text null); enum assignments set text_value (num
+// null).
+func (db postgres) SetProductAttributes(ctx context.Context, productID string, values []app.AttributeAssignment) error {
+	tx, err := db.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer func() {
+		if err != nil {
+			_ = tx.Rollback()
+		}
+	}()
+
+	if _, err = tx.ExecContext(ctx, `DELETE FROM productcatalog_product_attribute WHERE product_id = $1`, productID); err != nil {
+		return fmt.Errorf("clear product attributes: %w", err)
+	}
+	for _, v := range values {
+		var num sql.NullFloat64
+		var text sql.NullString
+		if v.Num != nil {
+			num = sql.NullFloat64{Float64: *v.Num, Valid: true}
+		} else {
+			text = sql.NullString{String: v.Text, Valid: true}
+		}
+		if _, err = tx.ExecContext(ctx, `
+			INSERT INTO productcatalog_product_attribute (product_id, attribute_type_id, num_value, text_value)
+			VALUES ($1, $2, $3, $4)
+		`, productID, v.TypeID, num, text); err != nil {
+			return fmt.Errorf("insert product attribute: %w", err)
+		}
+	}
+	if err = tx.Commit(); err != nil {
+		return fmt.Errorf("commit product attributes: %w", err)
+	}
+	return nil
+}
+
 // ListProducts returns the products matching the query. The WHERE clause is
 // built dynamically with parameterised placeholders only (never interpolating
 // user values), then each matching id is hydrated through the existing Find

--- a/backend/productcatalog/adapter/postgres.go
+++ b/backend/productcatalog/adapter/postgres.go
@@ -393,6 +393,97 @@ func (db postgres) Categories(ctx context.Context) ([]domain.Category, error) {
 	return out, rows.Err()
 }
 
+// CreateCategory inserts a new category.
+func (db postgres) CreateCategory(ctx context.Context, c domain.Category) error {
+	_, err := db.db.ExecContext(ctx, `
+		INSERT INTO productcatalog_category (id, name, slug, position)
+		VALUES ($1, $2, $3, $4)
+	`, c.ID(), c.Name(), c.Slug(), c.Position())
+	if err != nil {
+		return fmt.Errorf("create category: %w", err)
+	}
+	return nil
+}
+
+// UpdateCategory updates an existing category by id.
+func (db postgres) UpdateCategory(ctx context.Context, c domain.Category) error {
+	_, err := db.db.ExecContext(ctx, `
+		UPDATE productcatalog_category SET name = $2, slug = $3, position = $4 WHERE id = $1
+	`, c.ID(), c.Name(), c.Slug(), c.Position())
+	if err != nil {
+		return fmt.Errorf("update category: %w", err)
+	}
+	return nil
+}
+
+// DeleteCategory removes a category; its product links cascade.
+func (db postgres) DeleteCategory(ctx context.Context, id string) error {
+	_, err := db.db.ExecContext(ctx, `DELETE FROM productcatalog_category WHERE id = $1`, id)
+	if err != nil {
+		return fmt.Errorf("delete category: %w", err)
+	}
+	return nil
+}
+
+// AllAttributeTypes returns every attribute type in display order.
+func (db postgres) AllAttributeTypes(ctx context.Context) ([]domain.AttributeType, error) {
+	rows, err := db.db.QueryContext(ctx, `
+		SELECT id, name, unit, kind, filterable, position
+		FROM productcatalog_attribute_type
+		ORDER BY position, name
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("query attribute types: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []domain.AttributeType
+	for rows.Next() {
+		var id, name, unit, kind string
+		var filterable bool
+		var position int
+		if err := rows.Scan(&id, &name, &unit, &kind, &filterable, &position); err != nil {
+			return nil, fmt.Errorf("scan attribute type: %w", err)
+		}
+		out = append(out, domain.RebuildAttributeType(id, name, unit, domain.AttributeKind(kind), filterable, position))
+	}
+	return out, rows.Err()
+}
+
+// CreateAttributeType inserts a new attribute type.
+func (db postgres) CreateAttributeType(ctx context.Context, t domain.AttributeType) error {
+	_, err := db.db.ExecContext(ctx, `
+		INSERT INTO productcatalog_attribute_type (id, name, unit, kind, filterable, position)
+		VALUES ($1, $2, $3, $4, $5, $6)
+	`, t.ID(), t.Name(), t.Unit(), string(t.Kind()), t.Filterable(), t.Position())
+	if err != nil {
+		return fmt.Errorf("create attribute type: %w", err)
+	}
+	return nil
+}
+
+// UpdateAttributeType updates an existing attribute type by id.
+func (db postgres) UpdateAttributeType(ctx context.Context, t domain.AttributeType) error {
+	_, err := db.db.ExecContext(ctx, `
+		UPDATE productcatalog_attribute_type
+		SET name = $2, unit = $3, kind = $4, filterable = $5, position = $6
+		WHERE id = $1
+	`, t.ID(), t.Name(), t.Unit(), string(t.Kind()), t.Filterable(), t.Position())
+	if err != nil {
+		return fmt.Errorf("update attribute type: %w", err)
+	}
+	return nil
+}
+
+// DeleteAttributeType removes an attribute type; its product links cascade.
+func (db postgres) DeleteAttributeType(ctx context.Context, id string) error {
+	_, err := db.db.ExecContext(ctx, `DELETE FROM productcatalog_attribute_type WHERE id = $1`, id)
+	if err != nil {
+		return fmt.Errorf("delete attribute type: %w", err)
+	}
+	return nil
+}
+
 // ListProducts returns the products matching the query. The WHERE clause is
 // built dynamically with parameterised placeholders only (never interpolating
 // user values), then each matching id is hydrated through the existing Find

--- a/backend/productcatalog/adapter/postgres.go
+++ b/backend/productcatalog/adapter/postgres.go
@@ -225,6 +225,46 @@ func (db postgres) All(ctx context.Context) ([]domain.Product, error) {
 	return products, nil
 }
 
+// Newest returns up to limit products ordered newest-first by created_at
+// (ties broken by id), each hydrated with its catalog/classification the same
+// way All does.
+func (db postgres) Newest(ctx context.Context, limit int) ([]domain.Product, error) {
+	q := `SELECT id, name, description, thumbnail, price_amount, price_currency
+		FROM productcatalog_product
+		ORDER BY created_at DESC, id DESC
+		LIMIT $1`
+
+	rows, err := db.db.QueryContext(ctx, q, limit)
+	if err != nil {
+		return nil, fmt.Errorf("cannot query newest products: %w", err)
+	}
+
+	var base []domain.Product
+	func() {
+		defer func() { _ = rows.Close() }()
+		for rows.Next() {
+			p, err := scanProduct(rows)
+			if err != nil {
+				return
+			}
+			base = append(base, p)
+		}
+	}()
+	if err = rows.Err(); err != nil {
+		return nil, fmt.Errorf("cannot fetch newest products: %w", err)
+	}
+
+	products := make([]domain.Product, 0, len(base))
+	for _, p := range base {
+		full, err := db.withCatalog(ctx, p)
+		if err != nil {
+			return nil, err
+		}
+		products = append(products, full)
+	}
+	return products, nil
+}
+
 func (db postgres) Find(ctx context.Context, id string) (domain.Product, error) {
 	q := `SELECT id, name, description, thumbnail, price_amount, price_currency FROM productcatalog_product WHERE id = $1`
 	p, err := scanProduct(db.db.QueryRowContext(ctx, q, id))

--- a/backend/productcatalog/app/list_test.go
+++ b/backend/productcatalog/app/list_test.go
@@ -18,8 +18,8 @@ type inMemoryClassifier interface {
 	app.ProductStorage
 	AddAttributeType(t domain.AttributeType)
 	AddCategory(c domain.Category)
-	SetProductAttributes(productID string, values ...domain.AttributeValue)
-	SetProductCategories(productID string, cats ...domain.Category)
+	SeedProductAttributes(productID string, values ...domain.AttributeValue)
+	SeedProductCategories(productID string, cats ...domain.Category)
 }
 
 func fptr(v float64) *float64 { return &v }
@@ -52,9 +52,9 @@ func seedListFixtures(ctx context.Context, store inMemoryClassifier) error {
 		if err := store.Add(ctx, p); err != nil {
 			return err
 		}
-		store.SetProductAttributes(f.id, domain.NewNumericValue(weight, f.weight), domain.NewEnumValue(material, f.material))
+		store.SeedProductAttributes(f.id, domain.NewNumericValue(weight, f.weight), domain.NewEnumValue(material, f.material))
 		if f.inTools {
-			store.SetProductCategories(f.id, tools)
+			store.SeedProductCategories(f.id, tools)
 		}
 	}
 	return nil

--- a/backend/productcatalog/app/product.go
+++ b/backend/productcatalog/app/product.go
@@ -14,6 +14,7 @@ type ProductService struct {
 
 type ProductStorage interface {
 	All(ctx context.Context) ([]domain.Product, error)
+	Newest(ctx context.Context, limit int) ([]domain.Product, error)
 	Add(ctx context.Context, p domain.Product) error
 	UpdateProduct(ctx context.Context, p domain.Product) error
 	DeleteProduct(ctx context.Context, id string) error
@@ -46,6 +47,18 @@ func NewProductService(s ProductStorage) ProductService {
 
 func (ps ProductService) AllProducts(ctx context.Context) ([]domain.Product, error) {
 	return ps.storage.All(ctx)
+}
+
+// defaultNewestLimit is used when Newest is called with a non-positive limit.
+const defaultNewestLimit = 8
+
+// Newest returns up to limit most-recently-created products ("new arrivals").
+// A non-positive limit falls back to defaultNewestLimit.
+func (ps ProductService) Newest(ctx context.Context, limit int) ([]domain.Product, error) {
+	if limit <= 0 {
+		limit = defaultNewestLimit
+	}
+	return ps.storage.Newest(ctx, limit)
 }
 
 func (ps ProductService) Find(ctx context.Context, id string) (domain.Product, error) {

--- a/backend/productcatalog/app/product.go
+++ b/backend/productcatalog/app/product.go
@@ -15,6 +15,11 @@ type ProductService struct {
 type ProductStorage interface {
 	All(ctx context.Context) ([]domain.Product, error)
 	Add(ctx context.Context, p domain.Product) error
+	UpdateProduct(ctx context.Context, p domain.Product) error
+	DeleteProduct(ctx context.Context, id string) error
+	SetVariantStock(ctx context.Context, variantID string, stock int) error
+	SetProductCategories(ctx context.Context, productID string, categoryIDs []string) error
+	SetProductAttributes(ctx context.Context, productID string, values []AttributeAssignment) error
 	Find(ctx context.Context, id string) (domain.Product, error)
 	FindVariant(ctx context.Context, variantID string) (domain.Product, domain.Variant, error)
 	AddOptionType(ctx context.Context, productID string, position int, ot domain.OptionType) error
@@ -194,6 +199,53 @@ func (ps ProductService) Add(ctx context.Context, id, name, desc string, priceMi
 	// carrying its price (no options) and the product image.
 	defaultVariant := domain.NewVariant("var-"+id, id, thumbnail, nil, priceVO, defaultStock)
 	return ps.storage.AddVariant(ctx, id, 0, defaultVariant)
+}
+
+// UpdateProduct validates the core product fields and persists them. It only
+// touches the product row (name/description/price/thumbnail); variants,
+// categories and attributes are managed by their own methods.
+func (ps ProductService) UpdateProduct(ctx context.Context, id, name, desc string, priceMinorUnits int64, currency, thumbnail string) error {
+	pID, err := domain.NewProductId(id)
+	if err != nil {
+		return err
+	}
+	cur, err := domain.NewCurrency(currency)
+	if err != nil {
+		return fmt.Errorf("invalid currency: %w", err)
+	}
+	priceVO, err := domain.NewPrice(priceMinorUnits, cur)
+	if err != nil {
+		return fmt.Errorf("invalid price: %w", err)
+	}
+	p, err := domain.NewProduct(pID, name, desc, priceVO, thumbnail)
+	if err != nil {
+		return err
+	}
+	return ps.storage.UpdateProduct(ctx, p)
+}
+
+// DeleteProduct removes a product; its variants, category and attribute links
+// cascade in storage.
+func (ps ProductService) DeleteProduct(ctx context.Context, id string) error {
+	return ps.storage.DeleteProduct(ctx, id)
+}
+
+// SetVariantStock sets a single variant's stock level (rejecting negatives).
+func (ps ProductService) SetVariantStock(ctx context.Context, variantID string, stock int) error {
+	if stock < 0 {
+		return fmt.Errorf("stock cannot be negative: %d", stock)
+	}
+	return ps.storage.SetVariantStock(ctx, variantID, stock)
+}
+
+// SetProductCategories replaces the product's category links with the given set.
+func (ps ProductService) SetProductCategories(ctx context.Context, productID string, categoryIDs []string) error {
+	return ps.storage.SetProductCategories(ctx, productID, categoryIDs)
+}
+
+// SetProductAttributes replaces the product's attribute values with the given set.
+func (ps ProductService) SetProductAttributes(ctx context.Context, productID string, values []AttributeAssignment) error {
+	return ps.storage.SetProductAttributes(ctx, productID, values)
 }
 
 // OptionTypeInput / VariantInput describe a product's options and variants for

--- a/backend/productcatalog/app/product.go
+++ b/backend/productcatalog/app/product.go
@@ -3,6 +3,7 @@ package app
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/bkielbasa/go-ecommerce/backend/productcatalog/domain"
 )
@@ -23,6 +24,15 @@ type ProductStorage interface {
 	ListProducts(ctx context.Context, q ProductQuery) ([]domain.Product, error)
 	Categories(ctx context.Context) ([]domain.Category, error)
 	Facets(ctx context.Context, categorySlug string) ([]Facet, error)
+
+	CreateCategory(ctx context.Context, c domain.Category) error
+	UpdateCategory(ctx context.Context, c domain.Category) error
+	DeleteCategory(ctx context.Context, id string) error
+
+	AllAttributeTypes(ctx context.Context) ([]domain.AttributeType, error)
+	CreateAttributeType(ctx context.Context, t domain.AttributeType) error
+	UpdateAttributeType(ctx context.Context, t domain.AttributeType) error
+	DeleteAttributeType(ctx context.Context, id string) error
 }
 
 func NewProductService(s ProductStorage) ProductService {
@@ -67,6 +77,89 @@ func (ps ProductService) Categories(ctx context.Context) ([]domain.Category, err
 // Facets returns the available filter facets, optionally scoped to a category.
 func (ps ProductService) Facets(ctx context.Context, categorySlug string) ([]Facet, error) {
 	return ps.storage.Facets(ctx, categorySlug)
+}
+
+// CreateCategory validates and persists a new category. The id equals the slug
+// and the position is appended after the current categories.
+func (ps ProductService) CreateCategory(ctx context.Context, name, slug string) error {
+	existing, err := ps.storage.Categories(ctx)
+	if err != nil {
+		return err
+	}
+	c, err := domain.NewCategory(slug, name, slug, len(existing)+1)
+	if err != nil {
+		return err
+	}
+	return ps.storage.CreateCategory(ctx, c)
+}
+
+// UpdateCategory validates and persists changes to an existing category.
+func (ps ProductService) UpdateCategory(ctx context.Context, id, name, slug string, position int) error {
+	c, err := domain.NewCategory(id, name, slug, position)
+	if err != nil {
+		return err
+	}
+	return ps.storage.UpdateCategory(ctx, c)
+}
+
+// DeleteCategory removes a category (its product links cascade in storage).
+func (ps ProductService) DeleteCategory(ctx context.Context, id string) error {
+	return ps.storage.DeleteCategory(ctx, id)
+}
+
+// AttributeTypes returns every attribute type in display order (admin view).
+func (ps ProductService) AttributeTypes(ctx context.Context) ([]domain.AttributeType, error) {
+	return ps.storage.AllAttributeTypes(ctx)
+}
+
+// CreateAttributeType validates and persists a new attribute type. The id is a
+// slug derived from the name and the position is appended after existing types.
+func (ps ProductService) CreateAttributeType(ctx context.Context, name, unit string, kind domain.AttributeKind, filterable bool) error {
+	existing, err := ps.storage.AllAttributeTypes(ctx)
+	if err != nil {
+		return err
+	}
+	id := slugify(name)
+	t, err := domain.NewAttributeType(id, name, unit, kind, filterable, len(existing)+1)
+	if err != nil {
+		return err
+	}
+	return ps.storage.CreateAttributeType(ctx, t)
+}
+
+// UpdateAttributeType validates and persists changes to an attribute type.
+func (ps ProductService) UpdateAttributeType(ctx context.Context, id, name, unit string, kind domain.AttributeKind, filterable bool, position int) error {
+	t, err := domain.NewAttributeType(id, name, unit, kind, filterable, position)
+	if err != nil {
+		return err
+	}
+	return ps.storage.UpdateAttributeType(ctx, t)
+}
+
+// DeleteAttributeType removes an attribute type (its product links cascade).
+func (ps ProductService) DeleteAttributeType(ctx context.Context, id string) error {
+	return ps.storage.DeleteAttributeType(ctx, id)
+}
+
+// slugify turns a display name into a url-safe id: lowercase, spaces to
+// hyphens, dropping any character that is not a lowercase letter, digit or
+// hyphen, and collapsing repeated/edge hyphens.
+func slugify(name string) string {
+	var b strings.Builder
+	lastHyphen := false
+	for _, r := range strings.ToLower(name) {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9':
+			b.WriteRune(r)
+			lastHyphen = false
+		case r == ' ' || r == '-' || r == '_':
+			if !lastHyphen && b.Len() > 0 {
+				b.WriteByte('-')
+				lastHyphen = true
+			}
+		}
+	}
+	return strings.Trim(b.String(), "-")
 }
 
 // defaultStock is given to a simple product's auto-created default variant.

--- a/backend/productcatalog/app/product_test.go
+++ b/backend/productcatalog/app/product_test.go
@@ -14,6 +14,11 @@ import (
 type productStorage interface {
 	All(ctx context.Context) ([]domain.Product, error)
 	Add(ctx context.Context, p domain.Product) error
+	UpdateProduct(ctx context.Context, p domain.Product) error
+	DeleteProduct(ctx context.Context, id string) error
+	SetVariantStock(ctx context.Context, variantID string, stock int) error
+	SetProductCategories(ctx context.Context, productID string, categoryIDs []string) error
+	SetProductAttributes(ctx context.Context, productID string, values []app.AttributeAssignment) error
 	Find(ctx context.Context, id string) (domain.Product, error)
 	FindVariant(ctx context.Context, variantID string) (domain.Product, domain.Variant, error)
 	AddOptionType(ctx context.Context, productID string, position int, ot domain.OptionType) error

--- a/backend/productcatalog/app/product_test.go
+++ b/backend/productcatalog/app/product_test.go
@@ -13,6 +13,7 @@ import (
 
 type productStorage interface {
 	All(ctx context.Context) ([]domain.Product, error)
+	Newest(ctx context.Context, limit int) ([]domain.Product, error)
 	Add(ctx context.Context, p domain.Product) error
 	UpdateProduct(ctx context.Context, p domain.Product) error
 	DeleteProduct(ctx context.Context, id string) error

--- a/backend/productcatalog/app/product_test.go
+++ b/backend/productcatalog/app/product_test.go
@@ -23,6 +23,13 @@ type productStorage interface {
 	ListProducts(ctx context.Context, q app.ProductQuery) ([]domain.Product, error)
 	Categories(ctx context.Context) ([]domain.Category, error)
 	Facets(ctx context.Context, categorySlug string) ([]app.Facet, error)
+	CreateCategory(ctx context.Context, c domain.Category) error
+	UpdateCategory(ctx context.Context, c domain.Category) error
+	DeleteCategory(ctx context.Context, id string) error
+	AllAttributeTypes(ctx context.Context) ([]domain.AttributeType, error)
+	CreateAttributeType(ctx context.Context, t domain.AttributeType) error
+	UpdateAttributeType(ctx context.Context, t domain.AttributeType) error
+	DeleteAttributeType(ctx context.Context, id string) error
 }
 
 var storage productStorage

--- a/backend/productcatalog/app/query.go
+++ b/backend/productcatalog/app/query.go
@@ -17,6 +17,15 @@ type ProductQuery struct {
 	EnumSelections map[string][]string
 }
 
+// AttributeAssignment is a single product attribute value to persist. Num is
+// set (and Text empty) for numeric types; Text is set (and Num nil) for enum
+// types.
+type AttributeAssignment struct {
+	TypeID string
+	Num    *float64
+	Text   string
+}
+
 // Facet describes the available filter options for one attribute type among
 // the in-scope products. For a numeric type Min/Max bound the available range;
 // for an enum type Values lists the distinct available values, sorted.

--- a/backend/productcatalog/domain/attribute.go
+++ b/backend/productcatalog/domain/attribute.go
@@ -1,6 +1,12 @@
 package domain
 
-import "strconv"
+import (
+	"errors"
+	"strconv"
+)
+
+// ErrInvalidAttributeType is returned when an AttributeType fails validation.
+var ErrInvalidAttributeType = errors.New("invalid attribute type")
 
 // AttributeKind distinguishes the two predefined attribute shapes: numeric
 // (a number with an optional unit, e.g. Weight in kg) and enum (a value drawn
@@ -22,6 +28,25 @@ type AttributeType struct {
 	kind       AttributeKind
 	filterable bool
 	position   int
+}
+
+// NewAttributeType builds a validated AttributeType. It errors when the name is
+// empty or the kind is neither numeric nor enum.
+func NewAttributeType(id, name, unit string, kind AttributeKind, filterable bool, position int) (AttributeType, error) {
+	if name == "" {
+		return AttributeType{}, ErrInvalidAttributeType
+	}
+	if kind != AttributeNumeric && kind != AttributeEnum {
+		return AttributeType{}, ErrInvalidAttributeType
+	}
+	return AttributeType{
+		id:         id,
+		name:       name,
+		unit:       unit,
+		kind:       kind,
+		filterable: filterable,
+		position:   position,
+	}, nil
 }
 
 // RebuildAttributeType reconstructs an AttributeType from storage.

--- a/backend/productcatalog/domain/category.go
+++ b/backend/productcatalog/domain/category.go
@@ -1,5 +1,16 @@
 package domain
 
+import (
+	"errors"
+	"regexp"
+)
+
+// ErrInvalidCategory is returned when a Category fails validation.
+var ErrInvalidCategory = errors.New("invalid category")
+
+// slugPattern validates a slug: lowercase letters, digits and hyphens only.
+var slugPattern = regexp.MustCompile(`^[a-z0-9]+(?:-[a-z0-9]+)*$`)
+
 // Category is a flat catalog grouping a product can belong to (many-to-many).
 // It is a value object hydrated from storage.
 type Category struct {
@@ -7,6 +18,18 @@ type Category struct {
 	name     string
 	slug     string
 	position int
+}
+
+// NewCategory builds a validated Category. It errors when the name or slug is
+// empty, or when the slug is not lowercase letters/digits/hyphens.
+func NewCategory(id, name, slug string, position int) (Category, error) {
+	if name == "" {
+		return Category{}, ErrInvalidCategory
+	}
+	if slug == "" || !slugPattern.MatchString(slug) {
+		return Category{}, ErrInvalidCategory
+	}
+	return Category{id: id, name: name, slug: slug, position: position}, nil
 }
 
 // RebuildCategory reconstructs a Category from storage.

--- a/migrations/000015_auth_customer_is_admin.down.sql
+++ b/migrations/000015_auth_customer_is_admin.down.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+ALTER TABLE auth_customer DROP COLUMN IF EXISTS is_admin;
+
+COMMIT;

--- a/migrations/000015_auth_customer_is_admin.up.sql
+++ b/migrations/000015_auth_customer_is_admin.up.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+ALTER TABLE auth_customer ADD COLUMN is_admin boolean NOT NULL DEFAULT false;
+
+COMMIT;

--- a/migrations/000016_productcatalog_product_created_at.down.sql
+++ b/migrations/000016_productcatalog_product_created_at.down.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+ALTER TABLE productcatalog_product DROP COLUMN created_at;
+
+COMMIT;

--- a/migrations/000016_productcatalog_product_created_at.up.sql
+++ b/migrations/000016_productcatalog_product_created_at.up.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+ALTER TABLE productcatalog_product ADD COLUMN created_at timestamptz NOT NULL DEFAULT now();
+
+COMMIT;


### PR DESCRIPTION
A full admin panel to maintain the store, plus a real-store storefront nav.

**Admin (gated by an admin role):**
- is_admin on auth customers (migration 000015), seeded admin user, requireAdmin gate, dashboard.
- Products: create/edit/delete, per-variant stock, category + attribute assignment.
- Categories and attribute types: CRUD.
- Orders: list all, view, admin-cancel.
- Dedicated admin layout (sidebar shell) + admin.css, separate from the storefront.

**Storefront:**
- Homepage shows only newest products (created_at, migration 000016); full filterable catalog moved to /products.
- Top menu: category links + cart + account/log out (sign in when anonymous).

## Test plan
- [x] build (incl. -tags integration) / vet / tests / lint green
- [x] docker: admin gate (anon/non-admin/admin), full CRUD for products/categories/attributes reflected in DB and storefront, order admin-cancel, newest homepage ordering, store nav