### PR TITLE
feat(admin): variant product support

### DIFF
--- a/backend/layout/bounded_context.go
+++ b/backend/layout/bounded_context.go
@@ -24,6 +24,10 @@ type catalogService interface {
 	Facets(ctx context.Context, categorySlug string) ([]pcapp.Facet, error)
 
 	Add(ctx context.Context, id, name, desc string, priceMinorUnits int64, currency, thumbnail string) error
+	AddVariantProduct(ctx context.Context, id, name, desc, currency, thumbnail string, optionTypes []pcapp.OptionTypeInput, variants []pcapp.VariantInput) error
+	AddVariantToProduct(ctx context.Context, productID, sku, image string, priceMinor int64, currency string, stock int, options map[string]string) error
+	UpdateVariant(ctx context.Context, variantID, sku, image string, priceMinor int64, currency string, stock int) error
+	DeleteVariant(ctx context.Context, productID, variantID string) error
 	UpdateProduct(ctx context.Context, id, name, desc string, priceMinorUnits int64, currency, thumbnail string) error
 	DeleteProduct(ctx context.Context, id string) error
 	SetVariantStock(ctx context.Context, variantID string, stock int) error

--- a/backend/layout/http.go
+++ b/backend/layout/http.go
@@ -137,6 +137,13 @@ func (m boundedContext) MuxRegister(r *mux.Router) {
 
 	r.HandleFunc("/admin/products", observability.HTTPWrap(m.handler.AdminProducts, m.logger)).Methods("GET")
 	r.HandleFunc("/admin/products", observability.HTTPWrap(m.handler.AdminCreateProduct, m.logger)).Methods("POST")
+	// Variant-product routes: literal/longer paths first so they are not
+	// captured by the /admin/products/{id} catch-all below.
+	r.HandleFunc("/admin/products/new-variant", observability.HTTPWrap(m.handler.AdminNewVariantProductForm, m.logger)).Methods("GET")
+	r.HandleFunc("/admin/products/new-variant", observability.HTTPWrap(m.handler.AdminCreateVariantProduct, m.logger)).Methods("POST")
+	r.HandleFunc("/admin/products/{id}/variants/{variantID}/delete", observability.HTTPWrap(m.handler.AdminDeleteVariant, m.logger)).Methods("POST")
+	r.HandleFunc("/admin/products/{id}/variants/{variantID}", observability.HTTPWrap(m.handler.AdminUpdateVariant, m.logger)).Methods("POST")
+	r.HandleFunc("/admin/products/{id}/variants", observability.HTTPWrap(m.handler.AdminAddVariant, m.logger)).Methods("POST")
 	r.HandleFunc("/admin/products/{id}/edit", observability.HTTPWrap(m.handler.AdminEditProductForm, m.logger)).Methods("GET")
 	r.HandleFunc("/admin/products/{id}/stock", observability.HTTPWrap(m.handler.AdminUpdateProductStock, m.logger)).Methods("POST")
 	r.HandleFunc("/admin/products/{id}/categories", observability.HTTPWrap(m.handler.AdminUpdateProductCategories, m.logger)).Methods("POST")

--- a/backend/layout/http_admin_products.go
+++ b/backend/layout/http_admin_products.go
@@ -242,6 +242,291 @@ func (handler httpHandler) AdminUpdateProductAttributes(w http.ResponseWriter, r
 	http.Redirect(w, r, "/admin/products/"+id+"/edit", http.StatusSeeOther)
 }
 
+// parseOptionsSpec parses an "Name=Value, Name2=Value2" string into a map.
+// Empty pairs and pairs without an "=" are skipped; keys/values are trimmed.
+func parseOptionsSpec(s string) map[string]string {
+	out := map[string]string{}
+	for _, pair := range strings.Split(s, ",") {
+		pair = strings.TrimSpace(pair)
+		if pair == "" {
+			continue
+		}
+		eq := strings.Index(pair, "=")
+		if eq < 0 {
+			continue
+		}
+		k := strings.TrimSpace(pair[:eq])
+		v := strings.TrimSpace(pair[eq+1:])
+		if k == "" || v == "" {
+			continue
+		}
+		out[k] = v
+	}
+	return out
+}
+
+// AdminNewVariantProductForm renders the create-a-variant-product page.
+func (handler httpHandler) AdminNewVariantProductForm(w http.ResponseWriter, r *http.Request) {
+	email, ok := handler.requireAdmin(w, r)
+	if !ok {
+		return
+	}
+	handler.renderAdminTemplate(w, r, "admin/product_new_variant", map[string]any{
+		"Active": "products",
+		"Email":  email,
+	})
+}
+
+// AdminCreateVariantProduct builds option types and variants from the parallel
+// form arrays and creates a variant product.
+func (handler httpHandler) AdminCreateVariantProduct(w http.ResponseWriter, r *http.Request) {
+	if _, ok := handler.requireAdmin(w, r); !ok {
+		return
+	}
+	_ = r.ParseForm()
+	id := strings.TrimSpace(r.FormValue("id"))
+	currency := strings.TrimSpace(r.FormValue("currency"))
+	if currency == "" {
+		currency = "USD"
+	}
+
+	const back = "/admin/products/new-variant"
+
+	// Option types from ot_name[] / ot_values[].
+	otNames := r.Form["ot_name[]"]
+	otValues := r.Form["ot_values[]"]
+	var optionTypes []pcapp.OptionTypeInput
+	declared := map[string]bool{}
+	for i, name := range otNames {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		var raw string
+		if i < len(otValues) {
+			raw = otValues[i]
+		}
+		var values []string
+		for _, v := range strings.Split(raw, ",") {
+			v = strings.TrimSpace(v)
+			if v != "" {
+				values = append(values, v)
+			}
+		}
+		optionTypes = append(optionTypes, pcapp.OptionTypeInput{Name: name, Values: values})
+		declared[name] = true
+	}
+	if len(optionTypes) == 0 {
+		handler.flash(w, r, "at least one option type is required", "error")
+		http.Redirect(w, r, back, http.StatusSeeOther)
+		return
+	}
+
+	// Variants from the parallel v_*[] arrays.
+	vSKUs := r.Form["v_sku[]"]
+	vPrices := r.Form["v_price[]"]
+	vStocks := r.Form["v_stock[]"]
+	vImages := r.Form["v_image[]"]
+	vOptions := r.Form["v_options[]"]
+	var variants []pcapp.VariantInput
+	for i := range vPrices {
+		sku := ""
+		if i < len(vSKUs) {
+			sku = strings.TrimSpace(vSKUs[i])
+		}
+		image := ""
+		if i < len(vImages) {
+			image = strings.TrimSpace(vImages[i])
+		}
+		optsRaw := ""
+		if i < len(vOptions) {
+			optsRaw = vOptions[i]
+		}
+		options := parseOptionsSpec(optsRaw)
+		// Skip wholly-empty rows.
+		if sku == "" && strings.TrimSpace(vPrices[i]) == "" && len(options) == 0 {
+			continue
+		}
+		price, err := parsePriceMinorUnits(vPrices[i])
+		if err != nil {
+			handler.flash(w, r, err.Error(), "error")
+			http.Redirect(w, r, back, http.StatusSeeOther)
+			return
+		}
+		stock := 0
+		if i < len(vStocks) {
+			if raw := strings.TrimSpace(vStocks[i]); raw != "" {
+				s, convErr := strconv.Atoi(raw)
+				if convErr != nil {
+					handler.flash(w, r, "invalid stock", "error")
+					http.Redirect(w, r, back, http.StatusSeeOther)
+					return
+				}
+				stock = s
+			}
+		}
+		// Validate the variant's option keys match the declared option types.
+		for k := range options {
+			if !declared[k] {
+				handler.flash(w, r, "variant option \""+k+"\" is not a declared option type", "error")
+				http.Redirect(w, r, back, http.StatusSeeOther)
+				return
+			}
+		}
+		variantID := slugifyForID(sku)
+		if variantID == "" {
+			variantID = id + "-" + strconv.Itoa(i)
+		}
+		variants = append(variants, pcapp.VariantInput{
+			ID:      variantID,
+			SKU:     sku,
+			Image:   image,
+			Options: options,
+			Price:   price,
+			Stock:   stock,
+		})
+	}
+	if len(variants) == 0 {
+		handler.flash(w, r, "at least one variant is required", "error")
+		http.Redirect(w, r, back, http.StatusSeeOther)
+		return
+	}
+
+	err := handler.catalogSrv.AddVariantProduct(r.Context(), id, r.FormValue("name"), r.FormValue("description"), currency, r.FormValue("thumbnail"), optionTypes, variants)
+	if err != nil {
+		handler.flash(w, r, err.Error(), "error")
+		http.Redirect(w, r, back, http.StatusSeeOther)
+		return
+	}
+	handler.flash(w, r, "Variant product created", "info")
+	http.Redirect(w, r, "/admin/products/"+id+"/edit", http.StatusSeeOther)
+}
+
+// slugifyForID lowercases and url-safes a string for use as a variant id. It
+// mirrors the app-layer slug rules (lowercase letters/digits, hyphen-separated).
+func slugifyForID(s string) string {
+	var b strings.Builder
+	lastHyphen := false
+	for _, r := range strings.ToLower(s) {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9':
+			b.WriteRune(r)
+			lastHyphen = false
+		case r == ' ' || r == '-' || r == '_':
+			if !lastHyphen && b.Len() > 0 {
+				b.WriteByte('-')
+				lastHyphen = true
+			}
+		}
+	}
+	return strings.Trim(b.String(), "-")
+}
+
+// AdminAddVariant adds a single variant to an existing product. It reads one
+// opt_<OptionTypeName> value per option type plus sku/price/stock/image.
+func (handler httpHandler) AdminAddVariant(w http.ResponseWriter, r *http.Request) {
+	if _, ok := handler.requireAdmin(w, r); !ok {
+		return
+	}
+	id := mux.Vars(r)["id"]
+	product, err := handler.catalogSrv.Find(r.Context(), id)
+	if err != nil {
+		handler.flash(w, r, "Product not found", "error")
+		http.Redirect(w, r, "/admin/products", http.StatusSeeOther)
+		return
+	}
+	_ = r.ParseForm()
+	options := map[string]string{}
+	for _, ot := range product.OptionTypes() {
+		options[ot.Name()] = strings.TrimSpace(r.FormValue("opt_" + ot.Name()))
+	}
+	currency := strings.TrimSpace(r.FormValue("currency"))
+	if currency == "" {
+		currency = product.Price().Currency().String()
+	}
+	price, err := parsePriceMinorUnits(r.FormValue("price"))
+	if err != nil {
+		handler.flash(w, r, err.Error(), "error")
+		http.Redirect(w, r, "/admin/products/"+id+"/edit", http.StatusSeeOther)
+		return
+	}
+	stock := 0
+	if raw := strings.TrimSpace(r.FormValue("stock")); raw != "" {
+		s, convErr := strconv.Atoi(raw)
+		if convErr != nil {
+			handler.flash(w, r, "invalid stock", "error")
+			http.Redirect(w, r, "/admin/products/"+id+"/edit", http.StatusSeeOther)
+			return
+		}
+		stock = s
+	}
+	err = handler.catalogSrv.AddVariantToProduct(r.Context(), id, r.FormValue("sku"), r.FormValue("image"), price, currency, stock, options)
+	if err != nil {
+		handler.flash(w, r, err.Error(), "error")
+	} else {
+		handler.flash(w, r, "Variant added", "info")
+	}
+	http.Redirect(w, r, "/admin/products/"+id+"/edit", http.StatusSeeOther)
+}
+
+// AdminUpdateVariant updates a single variant's sku/price/stock/image.
+func (handler httpHandler) AdminUpdateVariant(w http.ResponseWriter, r *http.Request) {
+	if _, ok := handler.requireAdmin(w, r); !ok {
+		return
+	}
+	id := mux.Vars(r)["id"]
+	variantID := mux.Vars(r)["variantID"]
+	product, err := handler.catalogSrv.Find(r.Context(), id)
+	if err != nil {
+		handler.flash(w, r, "Product not found", "error")
+		http.Redirect(w, r, "/admin/products", http.StatusSeeOther)
+		return
+	}
+	_ = r.ParseForm()
+	currency := strings.TrimSpace(r.FormValue("currency"))
+	if currency == "" {
+		currency = product.Price().Currency().String()
+	}
+	price, err := parsePriceMinorUnits(r.FormValue("price"))
+	if err != nil {
+		handler.flash(w, r, err.Error(), "error")
+		http.Redirect(w, r, "/admin/products/"+id+"/edit", http.StatusSeeOther)
+		return
+	}
+	stock := 0
+	if raw := strings.TrimSpace(r.FormValue("stock")); raw != "" {
+		s, convErr := strconv.Atoi(raw)
+		if convErr != nil {
+			handler.flash(w, r, "invalid stock", "error")
+			http.Redirect(w, r, "/admin/products/"+id+"/edit", http.StatusSeeOther)
+			return
+		}
+		stock = s
+	}
+	err = handler.catalogSrv.UpdateVariant(r.Context(), variantID, r.FormValue("sku"), r.FormValue("image"), price, currency, stock)
+	if err != nil {
+		handler.flash(w, r, err.Error(), "error")
+	} else {
+		handler.flash(w, r, "Variant updated", "info")
+	}
+	http.Redirect(w, r, "/admin/products/"+id+"/edit", http.StatusSeeOther)
+}
+
+// AdminDeleteVariant deletes a single variant (refused if it is the last one).
+func (handler httpHandler) AdminDeleteVariant(w http.ResponseWriter, r *http.Request) {
+	if _, ok := handler.requireAdmin(w, r); !ok {
+		return
+	}
+	id := mux.Vars(r)["id"]
+	variantID := mux.Vars(r)["variantID"]
+	if err := handler.catalogSrv.DeleteVariant(r.Context(), id, variantID); err != nil {
+		handler.flash(w, r, err.Error(), "error")
+	} else {
+		handler.flash(w, r, "Variant deleted", "info")
+	}
+	http.Redirect(w, r, "/admin/products/"+id+"/edit", http.StatusSeeOther)
+}
+
 // AdminDeleteProduct deletes a product (variants/links cascade).
 func (handler httpHandler) AdminDeleteProduct(w http.ResponseWriter, r *http.Request) {
 	if _, ok := handler.requireAdmin(w, r); !ok {

--- a/backend/layout/static/admin.css
+++ b/backend/layout/static/admin.css
@@ -431,3 +431,25 @@ input:focus, select:focus, textarea:focus {
   .admin-content { padding: 18px 16px 36px; }
   .admin-flash { padding: 0 16px; }
 }
+
+/* --- Variant management -------------------------------------------------- */
+.admin-section__subtitle {
+  font-size: 0.95rem;
+  font-weight: 600;
+  margin: 18px 0 8px;
+  color: #3a4150;
+}
+.variant-table { width: 100%; }
+.variant-table input,
+.variant-table select { width: 100%; }
+.form--inline {
+  flex-direction: row;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  max-width: none;
+  margin: 0;
+}
+.form--inline input { width: auto; flex: 1 1 90px; min-width: 70px; }
+.form--inline input[type="number"] { flex: 0 0 80px; }
+.btn--small { padding: 5px 12px; font-size: 0.82rem; }

--- a/backend/layout/tmpl/admin/product_edit.gohtml
+++ b/backend/layout/tmpl/admin/product_edit.gohtml
@@ -15,26 +15,60 @@
   </section>
 
   <section class="admin-section">
-    <h3 class="admin-section__title">variant stock</h3>
+    <h3 class="admin-section__title">variants</h3>
     {{if .Product.Variants}}
-      <form class="form" method="post" action="/admin/products/{{.Product.ID}}/stock">
-        <table class="admin-table">
-          <thead><tr><th>variant</th><th>sku</th><th>stock</th></tr></thead>
-          <tbody>
-            {{$ots := .Product.OptionTypes}}
-            {{range $v := .Product.Variants}}
-              <tr>
-                <td>{{with $v.Label $ots}}{{.}}{{else}}default{{end}}</td>
-                <td><code>{{$v.SKU}}</code></td>
-                <td><input type="number" name="stock_{{$v.ID}}" value="{{$v.Stock}}" min="0"></td>
-              </tr>
-            {{end}}
-          </tbody>
-        </table>
-        <button type="submit" class="btn">save stock</button>
-      </form>
+      {{$ots := .Product.OptionTypes}}
+      {{$single := eq (len .Product.Variants) 1}}
+      <table class="admin-table variant-table">
+        <thead><tr><th>variant</th><th>sku</th><th>price</th><th>image</th><th>stock</th><th></th></tr></thead>
+        <tbody>
+          {{range $v := .Product.Variants}}
+            <tr>
+              <td>{{with $v.Label $ots}}{{.}}{{else}}default{{end}}</td>
+              <td colspan="4">
+                <form class="form form--inline" method="post" action="/admin/products/{{$.Product.ID}}/variants/{{$v.ID}}">
+                  <input name="sku" value="{{$v.SKU}}" placeholder="sku" aria-label="sku">
+                  <input name="price" value="{{$v.Price.Display}}" placeholder="9.00" aria-label="price">
+                  <input name="image" value="{{$v.Image}}" placeholder="image URL" aria-label="image">
+                  <input name="stock" type="number" min="0" value="{{$v.Stock}}" aria-label="stock">
+                  <button type="submit" class="btn btn--small">save</button>
+                </form>
+              </td>
+              <td class="admin-table__actions">
+                {{if not $single}}
+                  <form method="post" action="/admin/products/{{$.Product.ID}}/variants/{{$v.ID}}/delete"
+                        onsubmit="return confirm('Delete this variant?');">
+                    <button type="submit" class="linkbtn linkbtn--danger">delete</button>
+                  </form>
+                {{else}}
+                  <span class="muted" title="a product needs at least one variant">&mdash;</span>
+                {{end}}
+              </td>
+            </tr>
+          {{end}}
+        </tbody>
+      </table>
     {{else}}
       <p class="muted">no variants.</p>
+    {{end}}
+
+    {{if .Product.HasOptions}}
+      <h4 class="admin-section__subtitle">add a variant</h4>
+      <form class="form" method="post" action="/admin/products/{{.Product.ID}}/variants">
+        {{range $ot := .Product.OptionTypes}}
+          <div class="field">
+            <label for="opt-{{$ot.Name}}">{{$ot.Name}}</label>
+            <select id="opt-{{$ot.Name}}" name="opt_{{$ot.Name}}">
+              {{range $val := $ot.Values}}<option value="{{$val}}">{{$val}}</option>{{end}}
+            </select>
+          </div>
+        {{end}}
+        <div class="field"><label for="nv-sku">sku</label><input id="nv-sku" name="sku"></div>
+        <div class="field"><label for="nv-price">price (major units, e.g. 9.00)</label><input id="nv-price" name="price" required placeholder="9.00"></div>
+        <div class="field"><label for="nv-stock">stock</label><input id="nv-stock" name="stock" type="number" min="0" value="0"></div>
+        <div class="field"><label for="nv-image">image URL</label><input id="nv-image" name="image"></div>
+        <button type="submit" class="btn">add variant</button>
+      </form>
     {{end}}
   </section>
 

--- a/backend/layout/tmpl/admin/product_new_variant.gohtml
+++ b/backend/layout/tmpl/admin/product_new_variant.gohtml
@@ -1,0 +1,97 @@
+{{define "main"}}
+  <p class="crumbs"><a href="/admin/products">products</a> / new variant product</p>
+  <h2 class="account-card__title">create a variant product</h2>
+
+  <form class="form" method="post" action="/admin/products/new-variant">
+    <section class="admin-section">
+      <h3 class="admin-section__title">product</h3>
+      <div class="field"><label for="p-id">id (slug)</label><input id="p-id" name="id" required placeholder="lowercase-with-hyphens"></div>
+      <div class="field"><label for="p-name">name</label><input id="p-name" name="name" required></div>
+      <div class="field"><label for="p-description">description</label><textarea id="p-description" name="description" required></textarea></div>
+      <div class="field"><label for="p-currency">currency</label><input id="p-currency" name="currency" value="USD"></div>
+      <div class="field"><label for="p-thumbnail">thumbnail URL</label><input id="p-thumbnail" name="thumbnail"></div>
+    </section>
+
+    <section class="admin-section">
+      <h3 class="admin-section__title">option types</h3>
+      <p class="form__aside muted">e.g. name "Color", values "Red, Blue, Green" (comma-separated).</p>
+      <table class="admin-table variant-table">
+        <thead><tr><th>name</th><th>values (comma-separated)</th><th></th></tr></thead>
+        <tbody id="ot-rows">
+          <tr class="ot-row">
+            <td><input name="ot_name[]" placeholder="Color"></td>
+            <td><input name="ot_values[]" placeholder="Red, Blue"></td>
+            <td><button type="button" class="linkbtn linkbtn--danger ot-remove">remove</button></td>
+          </tr>
+        </tbody>
+      </table>
+      <button type="button" class="btn btn--ghost" id="add-ot">add option type</button>
+    </section>
+
+    <section class="admin-section">
+      <h3 class="admin-section__title">variants</h3>
+      <p class="form__aside muted">options formatted as "Name=Value, Name2=Value2" (must match the option type names above). price in major units (e.g. 9.00).</p>
+      <table class="admin-table variant-table">
+        <thead><tr><th>sku</th><th>price</th><th>stock</th><th>image URL</th><th>options</th><th></th></tr></thead>
+        <tbody id="v-rows">
+          <tr class="v-row">
+            <td><input name="v_sku[]" placeholder="TSHIRT-RED-L"></td>
+            <td><input name="v_price[]" placeholder="9.00"></td>
+            <td><input name="v_stock[]" type="number" min="0" value="0"></td>
+            <td><input name="v_image[]"></td>
+            <td><input name="v_options[]" placeholder="Color=Red, Size=L"></td>
+            <td><button type="button" class="linkbtn linkbtn--danger v-remove">remove</button></td>
+          </tr>
+        </tbody>
+      </table>
+      <button type="button" class="btn btn--ghost" id="add-v">add variant</button>
+    </section>
+
+    <button type="submit" class="btn">create variant product</button>
+  </form>
+
+  <p class="form__aside"><a href="/admin/products">&larr; back to products</a></p>
+
+  <script>
+    (function () {
+      function cloneLastRow(tbodyId, rowClass) {
+        var tbody = document.getElementById(tbodyId);
+        var rows = tbody.getElementsByClassName(rowClass);
+        if (rows.length === 0) { return; }
+        var clone = rows[rows.length - 1].cloneNode(true);
+        var inputs = clone.getElementsByTagName("input");
+        for (var i = 0; i < inputs.length; i++) {
+          if (inputs[i].type === "number") {
+            inputs[i].value = inputs[i].getAttribute("value") || "";
+          } else {
+            inputs[i].value = "";
+          }
+        }
+        tbody.appendChild(clone);
+      }
+
+      document.getElementById("add-ot").addEventListener("click", function () {
+        cloneLastRow("ot-rows", "ot-row");
+      });
+      document.getElementById("add-v").addEventListener("click", function () {
+        cloneLastRow("v-rows", "v-row");
+      });
+
+      document.addEventListener("click", function (e) {
+        var t = e.target;
+        if (t && t.classList && t.classList.contains("ot-remove")) {
+          var otBody = document.getElementById("ot-rows");
+          if (otBody.getElementsByClassName("ot-row").length > 1) {
+            t.closest(".ot-row").remove();
+          }
+        }
+        if (t && t.classList && t.classList.contains("v-remove")) {
+          var vBody = document.getElementById("v-rows");
+          if (vBody.getElementsByClassName("v-row").length > 1) {
+            t.closest(".v-row").remove();
+          }
+        }
+      });
+    })();
+  </script>
+{{end}}

--- a/backend/layout/tmpl/admin/products.gohtml
+++ b/backend/layout/tmpl/admin/products.gohtml
@@ -46,5 +46,6 @@
       <div class="field"><label for="p-thumbnail">thumbnail URL</label><input id="p-thumbnail" name="thumbnail"></div>
       <button type="submit" class="btn">create product</button>
     </form>
+    <p class="form__aside">Need options &amp; multiple variants? <a href="/admin/products/new-variant">Create a variant product &rarr;</a></p>
   </section>
 {{end}}

--- a/backend/productcatalog/adapter/inmemory.go
+++ b/backend/productcatalog/adapter/inmemory.go
@@ -45,6 +45,35 @@ func (im *inMemory) AddVariant(ctx context.Context, productID string, position i
 	return nil
 }
 
+// UpdateVariant updates a single variant's sku, image, price and stock by id.
+func (im *inMemory) UpdateVariant(ctx context.Context, variantID, sku, image string, priceAmount int64, currency string, stock int) error {
+	pid, i, ok := im.find(variantID)
+	if !ok {
+		return domain.ErrProductNotFound
+	}
+	cur, err := domain.NewCurrency(currency)
+	if err != nil {
+		return err
+	}
+	price, err := domain.NewPrice(priceAmount, cur)
+	if err != nil {
+		return err
+	}
+	v := im.variants[pid][i]
+	im.variants[pid][i] = domain.NewVariant(v.ID(), sku, image, v.Options(), price, stock)
+	return nil
+}
+
+// DeleteVariant removes a single variant by id.
+func (im *inMemory) DeleteVariant(ctx context.Context, variantID string) error {
+	pid, i, ok := im.find(variantID)
+	if !ok {
+		return domain.ErrProductNotFound
+	}
+	im.variants[pid] = append(im.variants[pid][:i], im.variants[pid][i+1:]...)
+	return nil
+}
+
 func (im *inMemory) hydrate(p domain.Product) domain.Product {
 	return p.WithCatalog(im.optionTypes[string(p.ID())], im.variants[string(p.ID())]).
 		WithClassification(im.prodCats[string(p.ID())], im.prodAttrs[string(p.ID())])

--- a/backend/productcatalog/adapter/postgres.go
+++ b/backend/productcatalog/adapter/postgres.go
@@ -66,6 +66,28 @@ func (db postgres) AddVariant(ctx context.Context, productID string, position in
 	return nil
 }
 
+// UpdateVariant updates a single variant row (sku, image, price, stock) by id.
+func (db postgres) UpdateVariant(ctx context.Context, variantID, sku, image string, priceAmount int64, currency string, stock int) error {
+	_, err := db.db.ExecContext(ctx, `
+		UPDATE productcatalog_variant
+		SET sku = $2, image_url = $3, price_amount = $4, price_currency = $5, stock = $6
+		WHERE id = $1
+	`, variantID, sku, image, priceAmount, currency, stock)
+	if err != nil {
+		return fmt.Errorf("update variant: %w", err)
+	}
+	return nil
+}
+
+// DeleteVariant removes a single variant row by id.
+func (db postgres) DeleteVariant(ctx context.Context, variantID string) error {
+	_, err := db.db.ExecContext(ctx, `DELETE FROM productcatalog_variant WHERE id = $1`, variantID)
+	if err != nil {
+		return fmt.Errorf("delete variant: %w", err)
+	}
+	return nil
+}
+
 func (db postgres) optionTypes(ctx context.Context, productID string) ([]domain.OptionType, error) {
 	rows, err := db.db.QueryContext(ctx, `
 		SELECT name, values FROM productcatalog_option_type

--- a/backend/productcatalog/app/product.go
+++ b/backend/productcatalog/app/product.go
@@ -25,6 +25,8 @@ type ProductStorage interface {
 	FindVariant(ctx context.Context, variantID string) (domain.Product, domain.Variant, error)
 	AddOptionType(ctx context.Context, productID string, position int, ot domain.OptionType) error
 	AddVariant(ctx context.Context, productID string, position int, v domain.Variant) error
+	UpdateVariant(ctx context.Context, variantID, sku, image string, priceAmount int64, currency string, stock int) error
+	DeleteVariant(ctx context.Context, variantID string) error
 	Reserve(ctx context.Context, quantities map[string]int) error
 	Release(ctx context.Context, quantities map[string]int) error
 	ListProducts(ctx context.Context, q ProductQuery) ([]domain.Product, error)
@@ -327,4 +329,102 @@ func (ps ProductService) AddVariantProduct(ctx context.Context, id, name, desc, 
 		}
 	}
 	return nil
+}
+
+// AddVariantToProduct adds a single variant to an existing product that has
+// option types. It validates the product exists and that options cover each
+// option type with an allowed value, generates a collision-free variant id and
+// appends the variant at the next position.
+func (ps ProductService) AddVariantToProduct(ctx context.Context, productID, sku, image string, priceMinor int64, currency string, stock int, options map[string]string) error {
+	if priceMinor < 0 {
+		return fmt.Errorf("price cannot be negative")
+	}
+	if stock < 0 {
+		return fmt.Errorf("stock cannot be negative")
+	}
+	product, err := ps.storage.Find(ctx, productID)
+	if err != nil {
+		return err
+	}
+	optionTypes := product.OptionTypes()
+	if len(optionTypes) == 0 {
+		return fmt.Errorf("product %q has no option types; cannot add a variant", productID)
+	}
+
+	// Validate that options cover each option type with an allowed value.
+	for _, ot := range optionTypes {
+		val, ok := options[ot.Name()]
+		if !ok || val == "" {
+			return fmt.Errorf("missing value for option %q", ot.Name())
+		}
+		allowed := false
+		for _, v := range ot.Values() {
+			if v == val {
+				allowed = true
+				break
+			}
+		}
+		if !allowed {
+			return fmt.Errorf("value %q is not allowed for option %q", val, ot.Name())
+		}
+	}
+
+	cur, err := domain.NewCurrency(currency)
+	if err != nil {
+		return fmt.Errorf("invalid currency: %w", err)
+	}
+	price, err := domain.NewPrice(priceMinor, cur)
+	if err != nil {
+		return fmt.Errorf("invalid price: %w", err)
+	}
+
+	existing := product.Variants()
+	variantID := ps.uniqueVariantID(productID, sku, existing)
+	position := len(existing)
+	return ps.storage.AddVariant(ctx, productID, position, domain.NewVariant(variantID, sku, image, options, price, stock))
+}
+
+// uniqueVariantID derives a variant id (slug of sku, else productID-<n>) that
+// does not collide with any existing variant id, appending a counter if needed.
+func (ps ProductService) uniqueVariantID(productID, sku string, existing []domain.Variant) string {
+	taken := make(map[string]bool, len(existing))
+	for _, v := range existing {
+		taken[v.ID()] = true
+	}
+	base := slugify(sku)
+	if base == "" {
+		base = fmt.Sprintf("%s-%d", productID, len(existing))
+	}
+	candidate := base
+	for i := 1; taken[candidate]; i++ {
+		candidate = fmt.Sprintf("%s-%d", base, i)
+	}
+	return candidate
+}
+
+// UpdateVariant updates a single variant's sku, image, price and stock.
+func (ps ProductService) UpdateVariant(ctx context.Context, variantID, sku, image string, priceMinor int64, currency string, stock int) error {
+	if priceMinor < 0 {
+		return fmt.Errorf("price cannot be negative: %d", priceMinor)
+	}
+	if stock < 0 {
+		return fmt.Errorf("stock cannot be negative: %d", stock)
+	}
+	if _, err := domain.NewCurrency(currency); err != nil {
+		return fmt.Errorf("invalid currency: %w", err)
+	}
+	return ps.storage.UpdateVariant(ctx, variantID, sku, image, priceMinor, currency, stock)
+}
+
+// DeleteVariant removes a variant from a product, refusing to delete the last
+// remaining variant (a product needs at least one to stay purchasable).
+func (ps ProductService) DeleteVariant(ctx context.Context, productID, variantID string) error {
+	product, err := ps.storage.Find(ctx, productID)
+	if err != nil {
+		return err
+	}
+	if len(product.Variants()) <= 1 {
+		return fmt.Errorf("cannot delete the last variant: a product needs at least one variant")
+	}
+	return ps.storage.DeleteVariant(ctx, variantID)
 }

--- a/backend/productcatalog/app/product_test.go
+++ b/backend/productcatalog/app/product_test.go
@@ -24,6 +24,8 @@ type productStorage interface {
 	FindVariant(ctx context.Context, variantID string) (domain.Product, domain.Variant, error)
 	AddOptionType(ctx context.Context, productID string, position int, ot domain.OptionType) error
 	AddVariant(ctx context.Context, productID string, position int, v domain.Variant) error
+	UpdateVariant(ctx context.Context, variantID, sku, image string, priceAmount int64, currency string, stock int) error
+	DeleteVariant(ctx context.Context, variantID string) error
 	Reserve(ctx context.Context, quantities map[string]int) error
 	Release(ctx context.Context, quantities map[string]int) error
 	ListProducts(ctx context.Context, q app.ProductQuery) ([]domain.Product, error)


### PR DESCRIPTION
Admins can now create and manage variant products, not just simple ones.

- **Create** (`/admin/products/new-variant`): product fields + dynamic option types + variants (SKU/price/stock/image/options); builds OptionTypeInput/VariantInput and calls AddVariantProduct.
- **Manage** on the edit page: per-variant edit (sku/price/stock/image), add variant (select per option type), delete variant (guarded — a product keeps ≥1 variant).
- productcatalog gains UpdateVariant/DeleteVariant (storage) + AddVariantToProduct/UpdateVariant/DeleteVariant (service).

## Test plan
- [x] build (incl. -tags integration) / vet / tests / lint green
- [x] docker: create variant product (option types + variants land, storefront shows selectors); update/add/delete variant; last-variant delete refused