### PR TITLE
feat(admin): manage option types on existing products

### DIFF
--- a/backend/layout/bounded_context.go
+++ b/backend/layout/bounded_context.go
@@ -26,6 +26,9 @@ type catalogService interface {
 	Add(ctx context.Context, id, name, desc string, priceMinorUnits int64, currency, thumbnail string) error
 	AddVariantProduct(ctx context.Context, id, name, desc, currency, thumbnail string, optionTypes []pcapp.OptionTypeInput, variants []pcapp.VariantInput) error
 	AddVariantToProduct(ctx context.Context, productID, sku, image string, priceMinor int64, currency string, stock int, options map[string]string) error
+	AddOptionType(ctx context.Context, productID, name string, values []string, variantDefault string) error
+	UpdateOptionType(ctx context.Context, productID, currentName, newName string, values []string) error
+	DeleteOptionType(ctx context.Context, productID, name string) error
 	UpdateVariant(ctx context.Context, variantID, sku, image string, priceMinor int64, currency string, stock int) error
 	DeleteVariant(ctx context.Context, productID, variantID string) error
 	UpdateProduct(ctx context.Context, id, name, desc string, priceMinorUnits int64, currency, thumbnail string) error

--- a/backend/layout/http.go
+++ b/backend/layout/http.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"net/http"
 	"path/filepath"
+	"strings"
 
 	"github.com/bkielbasa/go-ecommerce/backend/internal/observability"
 	"github.com/gorilla/mux"
@@ -144,6 +145,9 @@ func (m boundedContext) MuxRegister(r *mux.Router) {
 	r.HandleFunc("/admin/products/{id}/variants/{variantID}/delete", observability.HTTPWrap(m.handler.AdminDeleteVariant, m.logger)).Methods("POST")
 	r.HandleFunc("/admin/products/{id}/variants/{variantID}", observability.HTTPWrap(m.handler.AdminUpdateVariant, m.logger)).Methods("POST")
 	r.HandleFunc("/admin/products/{id}/variants", observability.HTTPWrap(m.handler.AdminAddVariant, m.logger)).Methods("POST")
+	r.HandleFunc("/admin/products/{id}/options/update", observability.HTTPWrap(m.handler.AdminUpdateOptionType, m.logger)).Methods("POST")
+	r.HandleFunc("/admin/products/{id}/options/delete", observability.HTTPWrap(m.handler.AdminDeleteOptionType, m.logger)).Methods("POST")
+	r.HandleFunc("/admin/products/{id}/options", observability.HTTPWrap(m.handler.AdminAddOptionType, m.logger)).Methods("POST")
 	r.HandleFunc("/admin/products/{id}/edit", observability.HTTPWrap(m.handler.AdminEditProductForm, m.logger)).Methods("GET")
 	r.HandleFunc("/admin/products/{id}/stock", observability.HTTPWrap(m.handler.AdminUpdateProductStock, m.logger)).Methods("POST")
 	r.HandleFunc("/admin/products/{id}/categories", observability.HTTPWrap(m.handler.AdminUpdateProductCategories, m.logger)).Methods("POST")
@@ -236,7 +240,8 @@ func (handler httpHandler) renderAdminTemplate(w http.ResponseWriter, r *http.Re
 		"html": func(value interface{}) template.HTML {
 			return template.HTML(fmt.Sprint(value))
 		},
-		"add": func(a, b int) int { return a + b },
+		"add":  func(a, b int) int { return a + b },
+		"join": func(sep string, items []string) string { return strings.Join(items, sep) },
 	}).ParseFiles(files...))
 
 	session, _ := store.Get(r, "ecommerce")

--- a/backend/layout/http_admin_products.go
+++ b/backend/layout/http_admin_products.go
@@ -527,6 +527,70 @@ func (handler httpHandler) AdminDeleteVariant(w http.ResponseWriter, r *http.Req
 	http.Redirect(w, r, "/admin/products/"+id+"/edit", http.StatusSeeOther)
 }
 
+// splitCSVValues splits a comma-separated string into trimmed, non-empty values.
+func splitCSVValues(raw string) []string {
+	var out []string
+	for _, v := range strings.Split(raw, ",") {
+		if v = strings.TrimSpace(v); v != "" {
+			out = append(out, v)
+		}
+	}
+	return out
+}
+
+// AdminAddOptionType adds an option type to an existing product. The chosen
+// default value is applied to every existing variant so they stay resolvable.
+func (handler httpHandler) AdminAddOptionType(w http.ResponseWriter, r *http.Request) {
+	if _, ok := handler.requireAdmin(w, r); !ok {
+		return
+	}
+	id := mux.Vars(r)["id"]
+	_ = r.ParseForm()
+	name := strings.TrimSpace(r.FormValue("name"))
+	values := splitCSVValues(r.FormValue("values"))
+	def := strings.TrimSpace(r.FormValue("default"))
+	if err := handler.catalogSrv.AddOptionType(r.Context(), id, name, values, def); err != nil {
+		handler.flash(w, r, err.Error(), "error")
+	} else {
+		handler.flash(w, r, "Option type added", "info")
+	}
+	http.Redirect(w, r, "/admin/products/"+id+"/edit", http.StatusSeeOther)
+}
+
+// AdminUpdateOptionType renames an option type and/or replaces its values.
+func (handler httpHandler) AdminUpdateOptionType(w http.ResponseWriter, r *http.Request) {
+	if _, ok := handler.requireAdmin(w, r); !ok {
+		return
+	}
+	id := mux.Vars(r)["id"]
+	_ = r.ParseForm()
+	currentName := strings.TrimSpace(r.FormValue("current_name"))
+	newName := strings.TrimSpace(r.FormValue("new_name"))
+	values := splitCSVValues(r.FormValue("values"))
+	if err := handler.catalogSrv.UpdateOptionType(r.Context(), id, currentName, newName, values); err != nil {
+		handler.flash(w, r, err.Error(), "error")
+	} else {
+		handler.flash(w, r, "Option type updated", "info")
+	}
+	http.Redirect(w, r, "/admin/products/"+id+"/edit", http.StatusSeeOther)
+}
+
+// AdminDeleteOptionType removes an option type from a product.
+func (handler httpHandler) AdminDeleteOptionType(w http.ResponseWriter, r *http.Request) {
+	if _, ok := handler.requireAdmin(w, r); !ok {
+		return
+	}
+	id := mux.Vars(r)["id"]
+	_ = r.ParseForm()
+	name := strings.TrimSpace(r.FormValue("name"))
+	if err := handler.catalogSrv.DeleteOptionType(r.Context(), id, name); err != nil {
+		handler.flash(w, r, err.Error(), "error")
+	} else {
+		handler.flash(w, r, "Option type deleted", "info")
+	}
+	http.Redirect(w, r, "/admin/products/"+id+"/edit", http.StatusSeeOther)
+}
+
 // AdminDeleteProduct deletes a product (variants/links cascade).
 func (handler httpHandler) AdminDeleteProduct(w http.ResponseWriter, r *http.Request) {
 	if _, ok := handler.requireAdmin(w, r); !ok {

--- a/backend/layout/tmpl/admin/product_edit.gohtml
+++ b/backend/layout/tmpl/admin/product_edit.gohtml
@@ -15,6 +15,47 @@
   </section>
 
   <section class="admin-section">
+    <h3 class="admin-section__title">option types</h3>
+    {{if .Product.OptionTypes}}
+      <table class="admin-table">
+        <thead><tr><th>name</th><th>values (comma-separated)</th><th></th></tr></thead>
+        <tbody>
+          {{range $ot := .Product.OptionTypes}}
+            <tr>
+              <td colspan="2">
+                <form class="form form--inline" method="post" action="/admin/products/{{$.Product.ID}}/options/update">
+                  <input type="hidden" name="current_name" value="{{$ot.Name}}">
+                  <input name="new_name" value="{{$ot.Name}}" placeholder="name" aria-label="name" required>
+                  <input name="values" value="{{join ", " $ot.Values}}" placeholder="Red, Blue" aria-label="values" required>
+                  <button type="submit" class="btn btn--small">save</button>
+                </form>
+              </td>
+              <td class="admin-table__actions">
+                <form method="post" action="/admin/products/{{$.Product.ID}}/options/delete"
+                      onsubmit="return confirm('Delete this option type? It will be removed from every variant.');">
+                  <input type="hidden" name="name" value="{{$ot.Name}}">
+                  <button type="submit" class="linkbtn linkbtn--danger">delete</button>
+                </form>
+              </td>
+            </tr>
+          {{end}}
+        </tbody>
+      </table>
+    {{else}}
+      <p class="muted">no option types.</p>
+    {{end}}
+
+    <h4 class="admin-section__subtitle">add an option type</h4>
+    <form class="form" method="post" action="/admin/products/{{.Product.ID}}/options">
+      <div class="field"><label for="ot-name">name</label><input id="ot-name" name="name" required placeholder="Color"></div>
+      <div class="field"><label for="ot-values">values (comma-separated)</label><input id="ot-values" name="values" required placeholder="Red, Blue"></div>
+      <div class="field"><label for="ot-default">default value</label><input id="ot-default" name="default" required placeholder="Red"></div>
+      <button type="submit" class="btn">add option type</button>
+      <p class="form__aside muted">the default value is applied to every existing variant (and must be one of the values above) so they stay resolvable.</p>
+    </form>
+  </section>
+
+  <section class="admin-section">
     <h3 class="admin-section__title">variants</h3>
     {{if .Product.Variants}}
       {{$ots := .Product.OptionTypes}}

--- a/backend/productcatalog/adapter/inmemory.go
+++ b/backend/productcatalog/adapter/inmemory.go
@@ -40,6 +40,72 @@ func (im *inMemory) AddOptionType(ctx context.Context, productID string, positio
 	return nil
 }
 
+// AddProductOptionType appends a new option type and seeds the chosen default
+// value onto every existing variant's options map (keyed by name), mirroring
+// the postgres transactional cascade.
+func (im *inMemory) AddProductOptionType(ctx context.Context, productID, optionTypeID, name string, position int, values []string, variantDefault string) error {
+	im.optionTypes[productID] = append(im.optionTypes[productID], domain.NewOptionType(name, values))
+	for i, v := range im.variants[productID] {
+		opts := cloneOptions(v.Options())
+		opts[name] = variantDefault
+		im.variants[productID][i] = domain.NewVariant(v.ID(), v.SKU(), v.Image(), opts, v.Price(), v.Stock())
+	}
+	return nil
+}
+
+// UpdateProductOptionType renames/re-values an option type and rekeys the
+// option in every variant's options map when the name changes.
+func (im *inMemory) UpdateProductOptionType(ctx context.Context, productID, currentName, newName string, values []string) error {
+	ots := im.optionTypes[productID]
+	for i, ot := range ots {
+		if ot.Name() == currentName {
+			ots[i] = domain.NewOptionType(newName, values)
+			break
+		}
+	}
+	if newName != currentName {
+		for i, v := range im.variants[productID] {
+			opts := cloneOptions(v.Options())
+			if val, ok := opts[currentName]; ok {
+				delete(opts, currentName)
+				opts[newName] = val
+				im.variants[productID][i] = domain.NewVariant(v.ID(), v.SKU(), v.Image(), opts, v.Price(), v.Stock())
+			}
+		}
+	}
+	return nil
+}
+
+// DeleteProductOptionType removes an option type and strips its key from every
+// variant's options map.
+func (im *inMemory) DeleteProductOptionType(ctx context.Context, productID, name string) error {
+	ots := im.optionTypes[productID]
+	for i, ot := range ots {
+		if ot.Name() == name {
+			im.optionTypes[productID] = append(ots[:i], ots[i+1:]...)
+			break
+		}
+	}
+	for i, v := range im.variants[productID] {
+		if _, ok := v.Options()[name]; ok {
+			opts := cloneOptions(v.Options())
+			delete(opts, name)
+			im.variants[productID][i] = domain.NewVariant(v.ID(), v.SKU(), v.Image(), opts, v.Price(), v.Stock())
+		}
+	}
+	return nil
+}
+
+// cloneOptions returns a shallow copy of a variant's options map so mutations
+// don't alias the original.
+func cloneOptions(in map[string]string) map[string]string {
+	out := make(map[string]string, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
+}
+
 func (im *inMemory) AddVariant(ctx context.Context, productID string, position int, v domain.Variant) error {
 	im.variants[productID] = append(im.variants[productID], v)
 	return nil

--- a/backend/productcatalog/adapter/postgres.go
+++ b/backend/productcatalog/adapter/postgres.go
@@ -51,6 +51,124 @@ func (db postgres) AddOptionType(ctx context.Context, productID string, position
 	return nil
 }
 
+// AddProductOptionType inserts a new option type row and seeds the chosen
+// default value onto every existing variant's options jsonb (keyed by the
+// option-type name) so they remain resolvable. Both writes run in one
+// transaction.
+func (db postgres) AddProductOptionType(ctx context.Context, productID, optionTypeID, name string, position int, values []string, variantDefault string) error {
+	valuesJSON, err := json.Marshal(values)
+	if err != nil {
+		return fmt.Errorf("marshal option values: %w", err)
+	}
+
+	tx, err := db.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer func() {
+		if err != nil {
+			_ = tx.Rollback()
+		}
+	}()
+
+	if _, err = tx.ExecContext(ctx, `
+		INSERT INTO productcatalog_option_type (id, product_id, name, position, values)
+		VALUES ($1, $2, $3, $4, $5)
+	`, optionTypeID, productID, name, position, valuesJSON); err != nil {
+		return fmt.Errorf("add option type: %w", err)
+	}
+
+	if _, err = tx.ExecContext(ctx, `
+		UPDATE productcatalog_variant
+		SET options = options || jsonb_build_object($2::text, $3::text)
+		WHERE product_id = $1
+	`, productID, name, variantDefault); err != nil {
+		return fmt.Errorf("seed option default on variants: %w", err)
+	}
+
+	if err = tx.Commit(); err != nil {
+		return fmt.Errorf("commit add option type: %w", err)
+	}
+	return nil
+}
+
+// UpdateProductOptionType renames/re-values an option type and, when the name
+// changes, rekeys the option in every variant's options jsonb. Runs in one
+// transaction.
+func (db postgres) UpdateProductOptionType(ctx context.Context, productID, currentName, newName string, values []string) error {
+	valuesJSON, err := json.Marshal(values)
+	if err != nil {
+		return fmt.Errorf("marshal option values: %w", err)
+	}
+
+	tx, err := db.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer func() {
+		if err != nil {
+			_ = tx.Rollback()
+		}
+	}()
+
+	if _, err = tx.ExecContext(ctx, `
+		UPDATE productcatalog_option_type
+		SET name = $3, values = $4
+		WHERE product_id = $1 AND name = $2
+	`, productID, currentName, newName, valuesJSON); err != nil {
+		return fmt.Errorf("update option type: %w", err)
+	}
+
+	if newName != currentName {
+		if _, err = tx.ExecContext(ctx, `
+			UPDATE productcatalog_variant
+			SET options = (options - $2) || jsonb_build_object($3::text, options->>$2)
+			WHERE product_id = $1 AND options ? $2
+		`, productID, currentName, newName); err != nil {
+			return fmt.Errorf("rekey option on variants: %w", err)
+		}
+	}
+
+	if err = tx.Commit(); err != nil {
+		return fmt.Errorf("commit update option type: %w", err)
+	}
+	return nil
+}
+
+// DeleteProductOptionType removes an option type and strips its key from every
+// variant's options jsonb. Runs in one transaction.
+func (db postgres) DeleteProductOptionType(ctx context.Context, productID, name string) error {
+	tx, err := db.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer func() {
+		if err != nil {
+			_ = tx.Rollback()
+		}
+	}()
+
+	if _, err = tx.ExecContext(ctx, `
+		DELETE FROM productcatalog_option_type
+		WHERE product_id = $1 AND name = $2
+	`, productID, name); err != nil {
+		return fmt.Errorf("delete option type: %w", err)
+	}
+
+	if _, err = tx.ExecContext(ctx, `
+		UPDATE productcatalog_variant
+		SET options = options - $2
+		WHERE product_id = $1
+	`, productID, name); err != nil {
+		return fmt.Errorf("strip option from variants: %w", err)
+	}
+
+	if err = tx.Commit(); err != nil {
+		return fmt.Errorf("commit delete option type: %w", err)
+	}
+	return nil
+}
+
 func (db postgres) AddVariant(ctx context.Context, productID string, position int, v domain.Variant) error {
 	options, err := json.Marshal(v.Options())
 	if err != nil {

--- a/backend/productcatalog/app/option_type_test.go
+++ b/backend/productcatalog/app/option_type_test.go
@@ -14,7 +14,15 @@ func seedVariantProduct(ctx context.Context, t *testing.T, optionTypes []app.Opt
 	t.Helper()
 	srv := app.NewProductService(storage)
 	id := randomID()
-	err := srv.AddVariantProduct(ctx, id, "Tee", "a tee", "USD", "http://img", optionTypes, variants)
+	// Variant ids are a global primary key; namespace them under the random
+	// product id so fixtures from different tests don't collide on the shared
+	// integration database.
+	scoped := make([]app.VariantInput, len(variants))
+	for i, v := range variants {
+		v.ID = id + "-" + v.ID
+		scoped[i] = v
+	}
+	err := srv.AddVariantProduct(ctx, id, "Tee", "a tee", "USD", "http://img", optionTypes, scoped)
 	if err != nil {
 		t.Fatalf("seed variant product: %s", err)
 	}
@@ -45,7 +53,7 @@ func TestAddOptionTypeSeedsExistingVariants(t *testing.T) {
 	}
 	v, ok := p.ResolveVariant(map[string]string{"Color": "Red", "Size": "S"})
 	is.True(ok)
-	is.Equal(v.ID(), "v1")
+	is.Equal(v.SKU(), "red")
 }
 
 func TestAddOptionTypeRejectsDuplicateAndBadDefault(t *testing.T) {
@@ -83,7 +91,7 @@ func TestUpdateOptionTypeRenameRekeysVariants(t *testing.T) {
 	is.Equal(p.OptionTypes()[0].Name(), "Colour")
 	v, ok := p.ResolveVariant(map[string]string{"Colour": "Red"})
 	is.True(ok)
-	is.Equal(v.ID(), "v1")
+	is.Equal(v.SKU(), "red")
 }
 
 func TestUpdateOptionTypeGuardsValueInUse(t *testing.T) {

--- a/backend/productcatalog/app/option_type_test.go
+++ b/backend/productcatalog/app/option_type_test.go
@@ -1,0 +1,145 @@
+package app_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/bkielbasa/go-ecommerce/backend/productcatalog/app"
+	"github.com/matryer/is"
+)
+
+// seedVariantProduct creates a product with the given option types and variants
+// directly through the storage, returning its id.
+func seedVariantProduct(ctx context.Context, t *testing.T, optionTypes []app.OptionTypeInput, variants []app.VariantInput) string {
+	t.Helper()
+	srv := app.NewProductService(storage)
+	id := randomID()
+	err := srv.AddVariantProduct(ctx, id, "Tee", "a tee", "USD", "http://img", optionTypes, variants)
+	if err != nil {
+		t.Fatalf("seed variant product: %s", err)
+	}
+	return id
+}
+
+func TestAddOptionTypeSeedsExistingVariants(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+	srv := app.NewProductService(storage)
+
+	id := seedVariantProduct(ctx, t,
+		[]app.OptionTypeInput{{Name: "Color", Values: []string{"Red", "Blue"}}},
+		[]app.VariantInput{
+			{ID: "v1", SKU: "red", Options: map[string]string{"Color": "Red"}, Price: 100, Stock: 5},
+			{ID: "v2", SKU: "blue", Options: map[string]string{"Color": "Blue"}, Price: 100, Stock: 5},
+		},
+	)
+
+	err := srv.AddOptionType(ctx, id, "Size", []string{"S", "M"}, "S")
+	is.NoErr(err)
+
+	p, err := srv.Find(ctx, id)
+	is.NoErr(err)
+	// Every existing variant must now carry the seeded default, staying resolvable.
+	for _, v := range p.Variants() {
+		is.Equal(v.Options()["Size"], "S")
+	}
+	v, ok := p.ResolveVariant(map[string]string{"Color": "Red", "Size": "S"})
+	is.True(ok)
+	is.Equal(v.ID(), "v1")
+}
+
+func TestAddOptionTypeRejectsDuplicateAndBadDefault(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+	srv := app.NewProductService(storage)
+	id := seedVariantProduct(ctx, t,
+		[]app.OptionTypeInput{{Name: "Color", Values: []string{"Red"}}},
+		[]app.VariantInput{{ID: "v1", SKU: "red", Options: map[string]string{"Color": "Red"}, Price: 100, Stock: 1}},
+	)
+
+	is.True(srv.AddOptionType(ctx, id, "Color", []string{"X"}, "X") != nil)     // duplicate name
+	is.True(srv.AddOptionType(ctx, id, "Size", []string{"S", "M"}, "L") != nil) // default not in values
+	is.True(srv.AddOptionType(ctx, id, "Size", []string{}, "") != nil)          // no values
+	is.True(srv.AddOptionType(ctx, id, "", []string{"S"}, "S") != nil)          // empty name
+}
+
+func TestUpdateOptionTypeRenameRekeysVariants(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+	srv := app.NewProductService(storage)
+	id := seedVariantProduct(ctx, t,
+		[]app.OptionTypeInput{{Name: "Color", Values: []string{"Red", "Blue"}}},
+		[]app.VariantInput{
+			{ID: "v1", SKU: "red", Options: map[string]string{"Color": "Red"}, Price: 100, Stock: 1},
+			{ID: "v2", SKU: "blue", Options: map[string]string{"Color": "Blue"}, Price: 100, Stock: 1},
+		},
+	)
+
+	err := srv.UpdateOptionType(ctx, id, "Color", "Colour", []string{"Red", "Blue"})
+	is.NoErr(err)
+
+	p, err := srv.Find(ctx, id)
+	is.NoErr(err)
+	is.Equal(p.OptionTypes()[0].Name(), "Colour")
+	v, ok := p.ResolveVariant(map[string]string{"Colour": "Red"})
+	is.True(ok)
+	is.Equal(v.ID(), "v1")
+}
+
+func TestUpdateOptionTypeGuardsValueInUse(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+	srv := app.NewProductService(storage)
+	id := seedVariantProduct(ctx, t,
+		[]app.OptionTypeInput{{Name: "Color", Values: []string{"Red", "Blue"}}},
+		[]app.VariantInput{
+			{ID: "v1", SKU: "red", Options: map[string]string{"Color": "Red"}, Price: 100, Stock: 1},
+			{ID: "v2", SKU: "blue", Options: map[string]string{"Color": "Blue"}, Price: 100, Stock: 1},
+		},
+	)
+
+	// Dropping "Blue" while a variant uses it must be rejected.
+	err := srv.UpdateOptionType(ctx, id, "Color", "Color", []string{"Red"})
+	is.True(err != nil)
+}
+
+func TestDeleteOptionTypeStripsAndGuardsAmbiguity(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+	srv := app.NewProductService(storage)
+	id := seedVariantProduct(ctx, t,
+		[]app.OptionTypeInput{
+			{Name: "Color", Values: []string{"Red", "Blue"}},
+			{Name: "Size", Values: []string{"S"}},
+		},
+		[]app.VariantInput{
+			{ID: "v1", SKU: "red-s", Options: map[string]string{"Color": "Red", "Size": "S"}, Price: 100, Stock: 1},
+			{ID: "v2", SKU: "blue-s", Options: map[string]string{"Color": "Blue", "Size": "S"}, Price: 100, Stock: 1},
+		},
+	)
+
+	// Deleting "Size" is safe: variants still differ by Color.
+	err := srv.DeleteOptionType(ctx, id, "Size")
+	is.NoErr(err)
+	p, err := srv.Find(ctx, id)
+	is.NoErr(err)
+	for _, v := range p.Variants() {
+		_, ok := v.Options()["Size"]
+		is.True(!ok)
+	}
+
+	// Deleting "Color" now would collapse both variants to {} -> ambiguous.
+	err = srv.DeleteOptionType(ctx, id, "Color")
+	is.True(err != nil)
+}
+
+func TestDeleteOptionTypeRejectsUnknown(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+	srv := app.NewProductService(storage)
+	id := seedVariantProduct(ctx, t,
+		[]app.OptionTypeInput{{Name: "Color", Values: []string{"Red"}}},
+		[]app.VariantInput{{ID: "v1", SKU: "red", Options: map[string]string{"Color": "Red"}, Price: 100, Stock: 1}},
+	)
+	is.True(srv.DeleteOptionType(ctx, id, "Nope") != nil)
+}

--- a/backend/productcatalog/app/product.go
+++ b/backend/productcatalog/app/product.go
@@ -3,6 +3,7 @@ package app
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/bkielbasa/go-ecommerce/backend/productcatalog/domain"
@@ -24,6 +25,9 @@ type ProductStorage interface {
 	Find(ctx context.Context, id string) (domain.Product, error)
 	FindVariant(ctx context.Context, variantID string) (domain.Product, domain.Variant, error)
 	AddOptionType(ctx context.Context, productID string, position int, ot domain.OptionType) error
+	AddProductOptionType(ctx context.Context, productID, optionTypeID, name string, position int, values []string, variantDefault string) error
+	UpdateProductOptionType(ctx context.Context, productID, currentName, newName string, values []string) error
+	DeleteProductOptionType(ctx context.Context, productID, name string) error
 	AddVariant(ctx context.Context, productID string, position int, v domain.Variant) error
 	UpdateVariant(ctx context.Context, variantID, sku, image string, priceAmount int64, currency string, stock int) error
 	DeleteVariant(ctx context.Context, variantID string) error
@@ -427,4 +431,157 @@ func (ps ProductService) DeleteVariant(ctx context.Context, productID, variantID
 		return fmt.Errorf("cannot delete the last variant: a product needs at least one variant")
 	}
 	return ps.storage.DeleteVariant(ctx, variantID)
+}
+
+// AddOptionType adds a new option type to an existing product. Because a
+// variant must carry a value for every option type to stay resolvable, the
+// chosen variantDefault is seeded onto every existing variant.
+func (ps ProductService) AddOptionType(ctx context.Context, productID, name string, values []string, variantDefault string) error {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return fmt.Errorf("option type name is required")
+	}
+	product, err := ps.storage.Find(ctx, productID)
+	if err != nil {
+		return err
+	}
+	for _, ot := range product.OptionTypes() {
+		if ot.Name() == name {
+			return fmt.Errorf("option type %q already exists", name)
+		}
+	}
+
+	cleaned := make([]string, 0, len(values))
+	seen := map[string]bool{}
+	for _, v := range values {
+		v = strings.TrimSpace(v)
+		if v == "" || seen[v] {
+			continue
+		}
+		seen[v] = true
+		cleaned = append(cleaned, v)
+	}
+	if len(cleaned) == 0 {
+		return fmt.Errorf("option type %q needs at least one value", name)
+	}
+
+	variantDefault = strings.TrimSpace(variantDefault)
+	allowed := false
+	for _, v := range cleaned {
+		if v == variantDefault {
+			allowed = true
+			break
+		}
+	}
+	if !allowed {
+		return fmt.Errorf("default value %q must be one of the option values", variantDefault)
+	}
+
+	id := fmt.Sprintf("opt-%s-%s", productID, slugify(name))
+	position := len(product.OptionTypes())
+	return ps.storage.AddProductOptionType(ctx, productID, id, name, position, cleaned, variantDefault)
+}
+
+// UpdateOptionType renames an option type and/or replaces its values. It
+// guards that every value currently used by a variant for this option remains
+// in the new values list, so no variant becomes unreachable.
+func (ps ProductService) UpdateOptionType(ctx context.Context, productID, currentName, newName string, values []string) error {
+	currentName = strings.TrimSpace(currentName)
+	newName = strings.TrimSpace(newName)
+	if newName == "" {
+		return fmt.Errorf("option type name is required")
+	}
+	product, err := ps.storage.Find(ctx, productID)
+	if err != nil {
+		return err
+	}
+
+	exists := false
+	for _, ot := range product.OptionTypes() {
+		if ot.Name() == currentName {
+			exists = true
+		} else if ot.Name() == newName {
+			return fmt.Errorf("option type %q already exists", newName)
+		}
+	}
+	if !exists {
+		return fmt.Errorf("option type %q does not exist", currentName)
+	}
+
+	cleaned := make([]string, 0, len(values))
+	seen := map[string]bool{}
+	for _, v := range values {
+		v = strings.TrimSpace(v)
+		if v == "" || seen[v] {
+			continue
+		}
+		seen[v] = true
+		cleaned = append(cleaned, v)
+	}
+	if len(cleaned) == 0 {
+		return fmt.Errorf("option type %q needs at least one value", newName)
+	}
+	allowed := map[string]bool{}
+	for _, v := range cleaned {
+		allowed[v] = true
+	}
+
+	// Guard: every value a variant currently uses for this option must survive.
+	for _, v := range product.Variants() {
+		if used, ok := v.Options()[currentName]; ok && used != "" && !allowed[used] {
+			return fmt.Errorf("cannot remove value %q: it is in use by a variant", used)
+		}
+	}
+
+	return ps.storage.UpdateProductOptionType(ctx, productID, currentName, newName, cleaned)
+}
+
+// DeleteOptionType removes an option type from a product, stripping its key
+// from every variant. It rejects the deletion when two variants would collapse
+// to the same option combination (becoming ambiguous for ResolveVariant); this
+// also prevents removing the last distinguishing option type.
+func (ps ProductService) DeleteOptionType(ctx context.Context, productID, name string) error {
+	name = strings.TrimSpace(name)
+	product, err := ps.storage.Find(ctx, productID)
+	if err != nil {
+		return err
+	}
+
+	exists := false
+	for _, ot := range product.OptionTypes() {
+		if ot.Name() == name {
+			exists = true
+			break
+		}
+	}
+	if !exists {
+		return fmt.Errorf("option type %q does not exist", name)
+	}
+
+	// Guard: simulate removing the key from every variant and detect collisions.
+	seen := map[string]bool{}
+	for _, v := range product.Variants() {
+		keys := make([]string, 0, len(v.Options()))
+		for k := range v.Options() {
+			if k == name {
+				continue
+			}
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		var b strings.Builder
+		for _, k := range keys {
+			b.WriteString(k)
+			b.WriteString("=")
+			b.WriteString(v.Options()[k])
+			b.WriteString(";")
+		}
+		sig := b.String()
+		if seen[sig] {
+			return fmt.Errorf("cannot delete option type %q: variants would become ambiguous", name)
+		}
+		seen[sig] = true
+	}
+
+	return ps.storage.DeleteProductOptionType(ctx, productID, name)
 }

--- a/backend/productcatalog/app/product_test.go
+++ b/backend/productcatalog/app/product_test.go
@@ -23,6 +23,9 @@ type productStorage interface {
 	Find(ctx context.Context, id string) (domain.Product, error)
 	FindVariant(ctx context.Context, variantID string) (domain.Product, domain.Variant, error)
 	AddOptionType(ctx context.Context, productID string, position int, ot domain.OptionType) error
+	AddProductOptionType(ctx context.Context, productID, optionTypeID, name string, position int, values []string, variantDefault string) error
+	UpdateProductOptionType(ctx context.Context, productID, currentName, newName string, values []string) error
+	DeleteProductOptionType(ctx context.Context, productID, name string) error
 	AddVariant(ctx context.Context, productID string, position int, v domain.Variant) error
 	UpdateVariant(ctx context.Context, variantID, sku, image string, priceAmount int64, currency string, stock int) error
 	DeleteVariant(ctx context.Context, variantID string) error


### PR DESCRIPTION
Admins can add/rename/edit-values/delete a product's option types, keeping variants consistent.

- Storage runs each change in a transaction: add seeds the new key with a chosen default on every existing variant; rename rekeys variant options; delete strips the key.
- Service guards reject unsafe edits: dropping a value still used by a variant, a deletion that would make two variants ambiguous, and duplicate names.
- Layout adds an option-types section to the product edit page.

## Test plan
- [x] build (incl. -tags integration) / vet / tests / lint green
- [x] docker: add (seeds default on 6 variants), rename (rekeys, no orphan), delete (strips key); guards reject in-use value drop, ambiguous delete, duplicate name; storefront still resolves variants + add-to-cart works