### PR TITLE
feat(admin): attribute sets — define reusable ordered attribute groups

### DIFF
--- a/backend/layout/bounded_context.go
+++ b/backend/layout/bounded_context.go
@@ -42,9 +42,16 @@ type catalogService interface {
 	DeleteCategory(ctx context.Context, id string) error
 
 	AttributeTypes(ctx context.Context) ([]pcdomain.AttributeType, error)
+	AllAttributeTypes(ctx context.Context) ([]pcdomain.AttributeType, error)
 	CreateAttributeType(ctx context.Context, name, unit string, kind pcdomain.AttributeKind, filterable bool) error
 	UpdateAttributeType(ctx context.Context, id, name, unit string, kind pcdomain.AttributeKind, filterable bool, position int) error
 	DeleteAttributeType(ctx context.Context, id string) error
+
+	AttributeSets(ctx context.Context) ([]pcdomain.AttributeSet, error)
+	FindAttributeSet(ctx context.Context, id string) (pcdomain.AttributeSet, error)
+	CreateAttributeSet(ctx context.Context, name string, attributeTypeIDs []string) error
+	UpdateAttributeSet(ctx context.Context, id, name string, attributeTypeIDs []string) error
+	DeleteAttributeSet(ctx context.Context, id string) error
 }
 
 type cartService interface {

--- a/backend/layout/bounded_context.go
+++ b/backend/layout/bounded_context.go
@@ -36,6 +36,8 @@ type catalogService interface {
 	SetVariantStock(ctx context.Context, variantID string, stock int) error
 	SetProductCategories(ctx context.Context, productID string, categoryIDs []string) error
 	SetProductAttributes(ctx context.Context, productID string, values []pcapp.AttributeAssignment) error
+	SetProductAttributeSet(ctx context.Context, productID, setID string) error
+	ProductAttributeTypes(ctx context.Context, productID string) ([]pcdomain.AttributeType, error)
 
 	CreateCategory(ctx context.Context, name, slug string) error
 	UpdateCategory(ctx context.Context, id, name, slug string, position int) error

--- a/backend/layout/http.go
+++ b/backend/layout/http.go
@@ -152,6 +152,7 @@ func (m boundedContext) MuxRegister(r *mux.Router) {
 	r.HandleFunc("/admin/products/{id}/stock", observability.HTTPWrap(m.handler.AdminUpdateProductStock, m.logger)).Methods("POST")
 	r.HandleFunc("/admin/products/{id}/categories", observability.HTTPWrap(m.handler.AdminUpdateProductCategories, m.logger)).Methods("POST")
 	r.HandleFunc("/admin/products/{id}/attributes", observability.HTTPWrap(m.handler.AdminUpdateProductAttributes, m.logger)).Methods("POST")
+	r.HandleFunc("/admin/products/{id}/attribute-set", observability.HTTPWrap(m.handler.AdminUpdateProductAttributeSet, m.logger)).Methods("POST")
 	r.HandleFunc("/admin/products/{id}/delete", observability.HTTPWrap(m.handler.AdminDeleteProduct, m.logger)).Methods("POST")
 	r.HandleFunc("/admin/products/{id}", observability.HTTPWrap(m.handler.AdminUpdateProduct, m.logger)).Methods("POST")
 

--- a/backend/layout/http.go
+++ b/backend/layout/http.go
@@ -167,6 +167,13 @@ func (m boundedContext) MuxRegister(r *mux.Router) {
 	r.HandleFunc("/admin/attributes/{id}/delete", observability.HTTPWrap(m.handler.AdminDeleteAttribute, m.logger)).Methods("POST")
 	r.HandleFunc("/admin/attributes/{id}", observability.HTTPWrap(m.handler.AdminUpdateAttribute, m.logger)).Methods("POST")
 
+	r.HandleFunc("/admin/attribute-sets", observability.HTTPWrap(m.handler.AdminAttributeSets, m.logger)).Methods("GET")
+	r.HandleFunc("/admin/attribute-sets", observability.HTTPWrap(m.handler.AdminCreateAttributeSet, m.logger)).Methods("POST")
+	r.HandleFunc("/admin/attribute-sets/new", observability.HTTPWrap(m.handler.AdminNewAttributeSetForm, m.logger)).Methods("GET")
+	r.HandleFunc("/admin/attribute-sets/{id}/edit", observability.HTTPWrap(m.handler.AdminEditAttributeSetForm, m.logger)).Methods("GET")
+	r.HandleFunc("/admin/attribute-sets/{id}/delete", observability.HTTPWrap(m.handler.AdminDeleteAttributeSet, m.logger)).Methods("POST")
+	r.HandleFunc("/admin/attribute-sets/{id}", observability.HTTPWrap(m.handler.AdminUpdateAttributeSet, m.logger)).Methods("POST")
+
 	r.HandleFunc("/admin/orders", observability.HTTPWrap(m.handler.AdminOrders, m.logger)).Methods("GET")
 	r.HandleFunc("/admin/orders/{orderID}/cancel", observability.HTTPWrap(m.handler.AdminCancelOrder, m.logger)).Methods("POST")
 	r.HandleFunc("/admin/orders/{orderID}", observability.HTTPWrap(m.handler.AdminOrderDetail, m.logger)).Methods("GET")

--- a/backend/layout/http_admin_attribute_sets.go
+++ b/backend/layout/http_admin_attribute_sets.go
@@ -1,0 +1,195 @@
+package layout
+
+import (
+	"net/http"
+	"sort"
+	"strconv"
+
+	"github.com/gorilla/mux"
+)
+
+// orderedMembers reads the submitted member selection: the checked "member"
+// values (attribute type ids) sorted ascending by their companion
+// "order_<typeID>" numeric input. Missing/blank order values sort last (a large
+// default), ties broken by the order ids appear in the form. The returned slice
+// is the ordered attribute type ids to assign to the set.
+func orderedMembers(r *http.Request) []string {
+	const defaultOrder = 1 << 30
+	members := r.Form["member"]
+	type entry struct {
+		id    string
+		order int
+		idx   int
+	}
+	entries := make([]entry, 0, len(members))
+	for i, id := range members {
+		order := defaultOrder
+		if raw := r.FormValue("order_" + id); raw != "" {
+			if v, err := strconv.Atoi(raw); err == nil {
+				order = v
+			}
+		}
+		entries = append(entries, entry{id: id, order: order, idx: i})
+	}
+	sort.SliceStable(entries, func(i, j int) bool {
+		if entries[i].order != entries[j].order {
+			return entries[i].order < entries[j].order
+		}
+		return entries[i].idx < entries[j].idx
+	})
+	out := make([]string, 0, len(entries))
+	for _, e := range entries {
+		out = append(out, e.id)
+	}
+	return out
+}
+
+// AdminAttributeSets renders the attribute sets list page.
+func (handler httpHandler) AdminAttributeSets(w http.ResponseWriter, r *http.Request) {
+	email, ok := handler.requireAdmin(w, r)
+	if !ok {
+		return
+	}
+	sets, err := handler.catalogSrv.AttributeSets(r.Context())
+	if err != nil {
+		sets = nil
+	}
+	handler.renderAdminTemplate(w, r, "admin/attribute_sets", map[string]any{
+		"Active": "attribute-sets",
+		"Email":  email,
+		"Sets":   sets,
+	})
+}
+
+// AdminNewAttributeSetForm renders the create-set form (all attribute types
+// listed, none checked).
+func (handler httpHandler) AdminNewAttributeSetForm(w http.ResponseWriter, r *http.Request) {
+	email, ok := handler.requireAdmin(w, r)
+	if !ok {
+		return
+	}
+	types, err := handler.catalogSrv.AllAttributeTypes(r.Context())
+	if err != nil {
+		types = nil
+	}
+	rows := make([]map[string]any, 0, len(types))
+	for i := range types {
+		rows = append(rows, map[string]any{
+			"Type":    types[i],
+			"Checked": false,
+			"Order":   i + 1,
+		})
+	}
+	handler.renderAdminTemplate(w, r, "admin/attribute_set_edit", map[string]any{
+		"Active":  "attribute-sets",
+		"Email":   email,
+		"IsNew":   true,
+		"SetName": "",
+		"Members": rows,
+	})
+}
+
+// AdminCreateAttributeSet handles the create-set form submission.
+func (handler httpHandler) AdminCreateAttributeSet(w http.ResponseWriter, r *http.Request) {
+	if _, ok := handler.requireAdmin(w, r); !ok {
+		return
+	}
+	_ = r.ParseForm()
+	ids := orderedMembers(r)
+	err := handler.catalogSrv.CreateAttributeSet(r.Context(), r.FormValue("name"), ids)
+	if err != nil {
+		handler.flash(w, r, err.Error(), "error")
+		http.Redirect(w, r, "/admin/attribute-sets/new", http.StatusSeeOther)
+		return
+	}
+	handler.flash(w, r, "Attribute set created", "info")
+	http.Redirect(w, r, "/admin/attribute-sets", http.StatusSeeOther)
+}
+
+// AdminEditAttributeSetForm renders the edit form: members first (in their
+// stored order), then the remaining attribute types unchecked.
+func (handler httpHandler) AdminEditAttributeSetForm(w http.ResponseWriter, r *http.Request) {
+	email, ok := handler.requireAdmin(w, r)
+	if !ok {
+		return
+	}
+	id := mux.Vars(r)["id"]
+	set, err := handler.catalogSrv.FindAttributeSet(r.Context(), id)
+	if err != nil {
+		handler.flash(w, r, "Attribute set not found", "error")
+		http.Redirect(w, r, "/admin/attribute-sets", http.StatusSeeOther)
+		return
+	}
+	types, err := handler.catalogSrv.AllAttributeTypes(r.Context())
+	if err != nil {
+		types = nil
+	}
+
+	memberOrder := map[string]int{}
+	for i, m := range set.Members() {
+		memberOrder[m.ID()] = i + 1
+	}
+
+	// Members first (in stored order), then the rest unchecked.
+	rows := make([]map[string]any, 0, len(types))
+	for _, m := range set.Members() {
+		rows = append(rows, map[string]any{
+			"Type":    m,
+			"Checked": true,
+			"Order":   memberOrder[m.ID()],
+		})
+	}
+	next := len(set.Members()) + 1
+	for i := range types {
+		if _, isMember := memberOrder[types[i].ID()]; isMember {
+			continue
+		}
+		rows = append(rows, map[string]any{
+			"Type":    types[i],
+			"Checked": false,
+			"Order":   next,
+		})
+		next++
+	}
+
+	handler.renderAdminTemplate(w, r, "admin/attribute_set_edit", map[string]any{
+		"Active":  "attribute-sets",
+		"Email":   email,
+		"IsNew":   false,
+		"SetID":   set.ID(),
+		"SetName": set.Name(),
+		"Members": rows,
+	})
+}
+
+// AdminUpdateAttributeSet handles the edit-set form submission.
+func (handler httpHandler) AdminUpdateAttributeSet(w http.ResponseWriter, r *http.Request) {
+	if _, ok := handler.requireAdmin(w, r); !ok {
+		return
+	}
+	id := mux.Vars(r)["id"]
+	_ = r.ParseForm()
+	ids := orderedMembers(r)
+	err := handler.catalogSrv.UpdateAttributeSet(r.Context(), id, r.FormValue("name"), ids)
+	if err != nil {
+		handler.flash(w, r, err.Error(), "error")
+		http.Redirect(w, r, "/admin/attribute-sets/"+id+"/edit", http.StatusSeeOther)
+		return
+	}
+	handler.flash(w, r, "Attribute set updated", "info")
+	http.Redirect(w, r, "/admin/attribute-sets", http.StatusSeeOther)
+}
+
+// AdminDeleteAttributeSet deletes an attribute set (its members cascade).
+func (handler httpHandler) AdminDeleteAttributeSet(w http.ResponseWriter, r *http.Request) {
+	if _, ok := handler.requireAdmin(w, r); !ok {
+		return
+	}
+	id := mux.Vars(r)["id"]
+	if err := handler.catalogSrv.DeleteAttributeSet(r.Context(), id); err != nil {
+		handler.flash(w, r, err.Error(), "error")
+	} else {
+		handler.flash(w, r, "Attribute set deleted", "info")
+	}
+	http.Redirect(w, r, "/admin/attribute-sets", http.StatusSeeOther)
+}

--- a/backend/layout/http_admin_products.go
+++ b/backend/layout/http_admin_products.go
@@ -39,10 +39,15 @@ func (handler httpHandler) AdminProducts(w http.ResponseWriter, r *http.Request)
 	if err != nil {
 		products = nil
 	}
+	attrSets, err := handler.catalogSrv.AttributeSets(r.Context())
+	if err != nil {
+		attrSets = nil
+	}
 	handler.renderAdminTemplate(w, r, "admin/products", map[string]any{
-		"Active":   "products",
-		"Email":    email,
-		"Products": products,
+		"Active":        "products",
+		"Email":         email,
+		"Products":      products,
+		"AttributeSets": attrSets,
 	})
 }
 
@@ -69,6 +74,13 @@ func (handler httpHandler) AdminCreateProduct(w http.ResponseWriter, r *http.Req
 		handler.flash(w, r, err.Error(), "error")
 		http.Redirect(w, r, "/admin/products", http.StatusSeeOther)
 		return
+	}
+	if setID := strings.TrimSpace(r.FormValue("attribute_set")); setID != "" {
+		if err := handler.catalogSrv.SetProductAttributeSet(r.Context(), id, setID); err != nil {
+			handler.flash(w, r, "Product created, but the attribute set could not be assigned: "+err.Error(), "error")
+			http.Redirect(w, r, "/admin/products/"+id+"/edit", http.StatusSeeOther)
+			return
+		}
 	}
 	handler.flash(w, r, "Product created", "info")
 	http.Redirect(w, r, "/admin/products/"+id+"/edit", http.StatusSeeOther)
@@ -97,7 +109,9 @@ func (handler httpHandler) AdminEditProductForm(w http.ResponseWriter, r *http.R
 		assigned[c.ID()] = true
 	}
 
-	attrTypes, err := handler.catalogSrv.AttributeTypes(r.Context())
+	// The attributes section is driven by the product's attribute set (its
+	// ordered members), falling back to all attribute types when it has no set.
+	attrTypes, err := handler.catalogSrv.ProductAttributeTypes(r.Context(), id)
 	if err != nil {
 		attrTypes = nil
 	}
@@ -111,14 +125,30 @@ func (handler httpHandler) AdminEditProductForm(w http.ResponseWriter, r *http.R
 		}
 	}
 
+	// All sets (for the picker) and the product's current set name (if any).
+	attrSets, err := handler.catalogSrv.AttributeSets(r.Context())
+	if err != nil {
+		attrSets = nil
+	}
+	currentSetID := product.AttributeSetID()
+	currentSetName := ""
+	if currentSetID != "" {
+		if set, err := handler.catalogSrv.FindAttributeSet(r.Context(), currentSetID); err == nil {
+			currentSetName = set.Name()
+		}
+	}
+
 	handler.renderAdminTemplate(w, r, "admin/product_edit", map[string]any{
-		"Active":     "products",
-		"Email":      email,
-		"Product":    product,
-		"Categories": categories,
-		"Assigned":   assigned,
-		"AttrTypes":  attrTypes,
-		"AttrValues": attrValues,
+		"Active":         "products",
+		"Email":          email,
+		"Product":        product,
+		"Categories":     categories,
+		"Assigned":       assigned,
+		"AttrTypes":      attrTypes,
+		"AttrValues":     attrValues,
+		"AttributeSets":  attrSets,
+		"CurrentSetID":   currentSetID,
+		"CurrentSetName": currentSetName,
 	})
 }
 
@@ -209,7 +239,10 @@ func (handler httpHandler) AdminUpdateProductAttributes(w http.ResponseWriter, r
 		return
 	}
 	id := mux.Vars(r)["id"]
-	attrTypes, err := handler.catalogSrv.AttributeTypes(r.Context())
+	// Iterate the same ordered attribute types the edit form rendered (the
+	// product's set members, or all types when it has no set) so only those are
+	// processed/saved.
+	attrTypes, err := handler.catalogSrv.ProductAttributeTypes(r.Context(), id)
 	if err != nil {
 		handler.flash(w, r, err.Error(), "error")
 		http.Redirect(w, r, "/admin/products/"+id+"/edit", http.StatusSeeOther)
@@ -238,6 +271,24 @@ func (handler httpHandler) AdminUpdateProductAttributes(w http.ResponseWriter, r
 		handler.flash(w, r, err.Error(), "error")
 	} else {
 		handler.flash(w, r, "Attributes updated", "info")
+	}
+	http.Redirect(w, r, "/admin/products/"+id+"/edit", http.StatusSeeOther)
+}
+
+// AdminUpdateProductAttributeSet assigns (or clears) the product's attribute
+// set from the picker on the edit page. The set controls which attribute types
+// the product's attributes section shows.
+func (handler httpHandler) AdminUpdateProductAttributeSet(w http.ResponseWriter, r *http.Request) {
+	if _, ok := handler.requireAdmin(w, r); !ok {
+		return
+	}
+	id := mux.Vars(r)["id"]
+	_ = r.ParseForm()
+	setID := strings.TrimSpace(r.FormValue("attribute_set"))
+	if err := handler.catalogSrv.SetProductAttributeSet(r.Context(), id, setID); err != nil {
+		handler.flash(w, r, err.Error(), "error")
+	} else {
+		handler.flash(w, r, "Attribute set updated", "info")
 	}
 	http.Redirect(w, r, "/admin/products/"+id+"/edit", http.StatusSeeOther)
 }
@@ -271,9 +322,14 @@ func (handler httpHandler) AdminNewVariantProductForm(w http.ResponseWriter, r *
 	if !ok {
 		return
 	}
+	attrSets, err := handler.catalogSrv.AttributeSets(r.Context())
+	if err != nil {
+		attrSets = nil
+	}
 	handler.renderAdminTemplate(w, r, "admin/product_new_variant", map[string]any{
-		"Active": "products",
-		"Email":  email,
+		"Active":        "products",
+		"Email":         email,
+		"AttributeSets": attrSets,
 	})
 }
 
@@ -397,6 +453,13 @@ func (handler httpHandler) AdminCreateVariantProduct(w http.ResponseWriter, r *h
 		handler.flash(w, r, err.Error(), "error")
 		http.Redirect(w, r, back, http.StatusSeeOther)
 		return
+	}
+	if setID := strings.TrimSpace(r.FormValue("attribute_set")); setID != "" {
+		if err := handler.catalogSrv.SetProductAttributeSet(r.Context(), id, setID); err != nil {
+			handler.flash(w, r, "Variant product created, but the attribute set could not be assigned: "+err.Error(), "error")
+			http.Redirect(w, r, "/admin/products/"+id+"/edit", http.StatusSeeOther)
+			return
+		}
 	}
 	handler.flash(w, r, "Variant product created", "info")
 	http.Redirect(w, r, "/admin/products/"+id+"/edit", http.StatusSeeOther)

--- a/backend/layout/tmpl/admin/attribute_set_edit.gohtml
+++ b/backend/layout/tmpl/admin/attribute_set_edit.gohtml
@@ -1,0 +1,35 @@
+{{define "main"}}
+  <p class="crumbs"><a href="/admin/attribute-sets">attribute sets</a> / {{if .IsNew}}new{{else}}edit{{end}}</p>
+  <h2 class="account-card__title">{{if .IsNew}}new attribute set{{else}}edit attribute set{{end}}</h2>
+
+  <form class="form" method="post" action="{{if .IsNew}}/admin/attribute-sets{{else}}/admin/attribute-sets/{{.SetID}}{{end}}">
+    <div class="field"><label for="s-name">name</label><input id="s-name" name="name" value="{{.SetName}}" required></div>
+
+    <h3 class="account-card__title">members</h3>
+    <p class="muted">tick the attribute types this set includes and set their order.</p>
+
+    {{if .Members}}
+      <table class="admin-table">
+        <thead>
+          <tr><th>include</th><th>name</th><th>kind</th><th>order</th></tr>
+        </thead>
+        <tbody>
+          {{range $row := .Members}}
+            {{$t := $row.Type}}
+            <tr>
+              <td><input type="checkbox" name="member" value="{{$t.ID}}" {{if $row.Checked}}checked{{end}}></td>
+              <td>{{$t.Name}}</td>
+              <td>{{$t.Kind}}</td>
+              <td><input type="number" name="order_{{$t.ID}}" value="{{$row.Order}}" min="1" style="width:5rem"></td>
+            </tr>
+          {{end}}
+        </tbody>
+      </table>
+    {{else}}
+      <p class="muted">no attribute types defined yet. create some under <a href="/admin/attributes">attributes</a> first.</p>
+    {{end}}
+
+    <button type="submit" class="btn">{{if .IsNew}}create attribute set{{else}}save changes{{end}}</button>
+    <p class="form__aside"><a href="/admin/attribute-sets">&larr; back to attribute sets</a></p>
+  </form>
+{{end}}

--- a/backend/layout/tmpl/admin/attribute_sets.gohtml
+++ b/backend/layout/tmpl/admin/attribute_sets.gohtml
@@ -1,0 +1,39 @@
+{{define "main"}}
+  <h2 class="account-card__title">attribute sets</h2>
+
+  {{if .Sets}}
+    <table class="admin-table">
+      <thead>
+        <tr><th>name</th><th>members</th><th>position</th><th></th></tr>
+      </thead>
+      <tbody>
+        {{range $s := .Sets}}
+          <tr>
+            <td>{{$s.Name}}</td>
+            <td>
+              {{if $s.Members}}
+                {{len $s.Members}} (
+                {{- range $i, $m := $s.Members}}{{if $i}}, {{end}}{{$m.Name}}{{end -}}
+                )
+              {{else}}
+                &mdash;
+              {{end}}
+            </td>
+            <td>{{$s.Position}}</td>
+            <td class="admin-table__actions">
+              <a href="/admin/attribute-sets/{{$s.ID}}/edit">edit</a>
+              <form method="post" action="/admin/attribute-sets/{{$s.ID}}/delete"
+                    onsubmit="return confirm('Delete this attribute set? Its member links will be removed.');">
+                <button type="submit" class="linkbtn linkbtn--danger">delete</button>
+              </form>
+            </td>
+          </tr>
+        {{end}}
+      </tbody>
+    </table>
+  {{else}}
+    <p class="muted">no attribute sets yet.</p>
+  {{end}}
+
+  <p class="form__aside"><a href="/admin/attribute-sets/new">+ new attribute set</a></p>
+{{end}}

--- a/backend/layout/tmpl/admin/product_edit.gohtml
+++ b/backend/layout/tmpl/admin/product_edit.gohtml
@@ -130,6 +130,21 @@
   </section>
 
   <section class="admin-section">
+    <h3 class="admin-section__title">attribute set</h3>
+    <p class="form__aside muted">the chosen set controls which attributes appear below (and in what order). Choose &ldquo;none&rdquo; to fall back to all attribute types.</p>
+    <form class="form" method="post" action="/admin/products/{{.Product.ID}}/attribute-set">
+      <div class="field">
+        <label for="p-attribute-set">attribute set</label>
+        <select id="p-attribute-set" name="attribute_set">
+          <option value="" {{if eq .CurrentSetID ""}}selected{{end}}>&mdash; none &mdash;</option>
+          {{range $s := .AttributeSets}}<option value="{{$s.ID}}" {{if eq $s.ID $.CurrentSetID}}selected{{end}}>{{$s.Name}}</option>{{end}}
+        </select>
+      </div>
+      <button type="submit" class="btn">save attribute set</button>
+    </form>
+  </section>
+
+  <section class="admin-section">
     <h3 class="admin-section__title">attributes</h3>
     {{if .AttrTypes}}
       <form class="form" method="post" action="/admin/products/{{.Product.ID}}/attributes">

--- a/backend/layout/tmpl/admin/product_new_variant.gohtml
+++ b/backend/layout/tmpl/admin/product_new_variant.gohtml
@@ -10,6 +10,14 @@
       <div class="field"><label for="p-description">description</label><textarea id="p-description" name="description" required></textarea></div>
       <div class="field"><label for="p-currency">currency</label><input id="p-currency" name="currency" value="USD"></div>
       <div class="field"><label for="p-thumbnail">thumbnail URL</label><input id="p-thumbnail" name="thumbnail"></div>
+      <div class="field">
+        <label for="p-attribute-set">attribute set</label>
+        <select id="p-attribute-set" name="attribute_set">
+          <option value="">&mdash; none &mdash;</option>
+          {{range $s := .AttributeSets}}<option value="{{$s.ID}}">{{$s.Name}}</option>{{end}}
+        </select>
+        <p class="form__aside muted">the set defines which attributes this product has (and their order). You can change it later.</p>
+      </div>
     </section>
 
     <section class="admin-section">

--- a/backend/layout/tmpl/admin/products.gohtml
+++ b/backend/layout/tmpl/admin/products.gohtml
@@ -44,6 +44,14 @@
       <div class="field"><label for="p-price">price (major units, e.g. 9.00)</label><input id="p-price" name="price" required placeholder="9.00"></div>
       <div class="field"><label for="p-currency">currency</label><input id="p-currency" name="currency" value="USD"></div>
       <div class="field"><label for="p-thumbnail">thumbnail URL</label><input id="p-thumbnail" name="thumbnail"></div>
+      <div class="field">
+        <label for="p-attribute-set">attribute set</label>
+        <select id="p-attribute-set" name="attribute_set">
+          <option value="">&mdash; none &mdash;</option>
+          {{range $s := .AttributeSets}}<option value="{{$s.ID}}">{{$s.Name}}</option>{{end}}
+        </select>
+        <p class="form__aside muted">the set defines which attributes this product has (and their order). You can change it later.</p>
+      </div>
       <button type="submit" class="btn">create product</button>
     </form>
     <p class="form__aside">Need options &amp; multiple variants? <a href="/admin/products/new-variant">Create a variant product &rarr;</a></p>

--- a/backend/layout/tmpl/partials/admin-nav.gohtml
+++ b/backend/layout/tmpl/partials/admin-nav.gohtml
@@ -4,6 +4,7 @@
   <a href="/admin/products" class="admin-nav__link {{if eq .Active "products"}}is-active{{end}}">products</a>
   <a href="/admin/categories" class="admin-nav__link {{if eq .Active "categories"}}is-active{{end}}">categories</a>
   <a href="/admin/attributes" class="admin-nav__link {{if eq .Active "attributes"}}is-active{{end}}">attributes</a>
+  <a href="/admin/attribute-sets" class="admin-nav__link {{if eq .Active "attribute-sets"}}is-active{{end}}">attribute sets</a>
   <a href="/admin/orders" class="admin-nav__link {{if eq .Active "orders"}}is-active{{end}}">orders</a>
   <span class="admin-nav__rule"></span>
   <a href="/" class="admin-nav__link admin-nav__link--muted">back to store</a>

--- a/backend/productcatalog/adapter/inmemory.go
+++ b/backend/productcatalog/adapter/inmemory.go
@@ -17,6 +17,9 @@ type inMemory struct {
 	categories map[string]domain.Category
 	prodAttrs  map[string][]domain.AttributeValue
 	prodCats   map[string][]domain.Category
+	// prodSets maps a product id to its assigned attribute set id (empty/absent
+	// means no set).
+	prodSets map[string]string
 	// attribute sets: the set row plus its ordered member attribute type ids.
 	attrSets     map[string]attrSetRow
 	attrSetItems map[string][]string
@@ -37,6 +40,7 @@ func NewInMemory() *inMemory {
 		categories:   map[string]domain.Category{},
 		prodAttrs:    map[string][]domain.AttributeValue{},
 		prodCats:     map[string][]domain.Category{},
+		prodSets:     map[string]string{},
 		attrSets:     map[string]attrSetRow{},
 		attrSetItems: map[string][]string{},
 	}
@@ -44,6 +48,9 @@ func NewInMemory() *inMemory {
 
 func (im *inMemory) Add(ctx context.Context, p domain.Product) error {
 	im.products = append(im.products, p)
+	if setID := p.AttributeSetID(); setID != "" {
+		im.prodSets[string(p.ID())] = setID
+	}
 	return nil
 }
 
@@ -154,7 +161,8 @@ func (im *inMemory) DeleteVariant(ctx context.Context, variantID string) error {
 
 func (im *inMemory) hydrate(p domain.Product) domain.Product {
 	return p.WithCatalog(im.optionTypes[string(p.ID())], im.variants[string(p.ID())]).
-		WithClassification(im.prodCats[string(p.ID())], im.prodAttrs[string(p.ID())])
+		WithClassification(im.prodCats[string(p.ID())], im.prodAttrs[string(p.ID())]).
+		WithAttributeSet(im.prodSets[string(p.ID())])
 }
 
 func (im *inMemory) All(ctx context.Context) ([]domain.Product, error) {
@@ -213,6 +221,7 @@ func (im *inMemory) DeleteProduct(ctx context.Context, id string) error {
 	delete(im.variants, id)
 	delete(im.prodCats, id)
 	delete(im.prodAttrs, id)
+	delete(im.prodSets, id)
 	return nil
 }
 
@@ -254,6 +263,17 @@ func (im *inMemory) SetProductAttributes(ctx context.Context, productID string, 
 		}
 	}
 	im.prodAttrs[productID] = out
+	return nil
+}
+
+// SetProductAttributeSet sets (or clears, when setID is empty) the product's
+// attribute set id.
+func (im *inMemory) SetProductAttributeSet(ctx context.Context, productID, setID string) error {
+	if setID == "" {
+		delete(im.prodSets, productID)
+		return nil
+	}
+	im.prodSets[productID] = setID
 	return nil
 }
 

--- a/backend/productcatalog/adapter/inmemory.go
+++ b/backend/productcatalog/adapter/inmemory.go
@@ -17,16 +17,28 @@ type inMemory struct {
 	categories map[string]domain.Category
 	prodAttrs  map[string][]domain.AttributeValue
 	prodCats   map[string][]domain.Category
+	// attribute sets: the set row plus its ordered member attribute type ids.
+	attrSets     map[string]attrSetRow
+	attrSetItems map[string][]string
+}
+
+// attrSetRow holds an attribute set's own fields (members are tracked
+// separately in attrSetItems, mirroring the postgres join table).
+type attrSetRow struct {
+	name     string
+	position int
 }
 
 func NewInMemory() *inMemory {
 	return &inMemory{
-		optionTypes: map[string][]domain.OptionType{},
-		variants:    map[string][]domain.Variant{},
-		attrTypes:   map[string]domain.AttributeType{},
-		categories:  map[string]domain.Category{},
-		prodAttrs:   map[string][]domain.AttributeValue{},
-		prodCats:    map[string][]domain.Category{},
+		optionTypes:  map[string][]domain.OptionType{},
+		variants:     map[string][]domain.Variant{},
+		attrTypes:    map[string]domain.AttributeType{},
+		categories:   map[string]domain.Category{},
+		prodAttrs:    map[string][]domain.AttributeValue{},
+		prodCats:     map[string][]domain.Category{},
+		attrSets:     map[string]attrSetRow{},
+		attrSetItems: map[string][]string{},
 	}
 }
 
@@ -369,6 +381,65 @@ func (im *inMemory) UpdateAttributeType(ctx context.Context, t domain.AttributeT
 
 func (im *inMemory) DeleteAttributeType(ctx context.Context, id string) error {
 	delete(im.attrTypes, id)
+	return nil
+}
+
+// attributeSetMembers resolves a set's member ids to their attribute types in
+// the stored order, skipping any that no longer exist.
+func (im *inMemory) attributeSetMembers(setID string) []domain.AttributeType {
+	ids := im.attrSetItems[setID]
+	out := make([]domain.AttributeType, 0, len(ids))
+	for _, id := range ids {
+		if t, ok := im.attrTypes[id]; ok {
+			out = append(out, t)
+		}
+	}
+	return out
+}
+
+func (im *inMemory) AllAttributeSets(ctx context.Context) ([]domain.AttributeSet, error) {
+	out := make([]domain.AttributeSet, 0, len(im.attrSets))
+	for id, row := range im.attrSets {
+		out = append(out, domain.RebuildAttributeSet(id, row.name, row.position, im.attributeSetMembers(id)))
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Position() != out[j].Position() {
+			return out[i].Position() < out[j].Position()
+		}
+		return out[i].Name() < out[j].Name()
+	})
+	return out, nil
+}
+
+func (im *inMemory) FindAttributeSet(ctx context.Context, id string) (domain.AttributeSet, error) {
+	row, ok := im.attrSets[id]
+	if !ok {
+		return domain.AttributeSet{}, domain.ErrAttributeSetNotFound
+	}
+	return domain.RebuildAttributeSet(id, row.name, row.position, im.attributeSetMembers(id)), nil
+}
+
+func (im *inMemory) CreateAttributeSet(ctx context.Context, s domain.AttributeSet) error {
+	im.attrSets[s.ID()] = attrSetRow{name: s.Name(), position: s.Position()}
+	return nil
+}
+
+func (im *inMemory) UpdateAttributeSet(ctx context.Context, s domain.AttributeSet) error {
+	im.attrSets[s.ID()] = attrSetRow{name: s.Name(), position: s.Position()}
+	return nil
+}
+
+func (im *inMemory) DeleteAttributeSet(ctx context.Context, id string) error {
+	delete(im.attrSets, id)
+	delete(im.attrSetItems, id)
+	return nil
+}
+
+// SetAttributeSetItems replaces a set's member ids, preserving the given order.
+func (im *inMemory) SetAttributeSetItems(ctx context.Context, setID string, attributeTypeIDs []string) error {
+	items := make([]string, len(attributeTypeIDs))
+	copy(items, attributeTypeIDs)
+	im.attrSetItems[setID] = items
 	return nil
 }
 

--- a/backend/productcatalog/adapter/postgres.go
+++ b/backend/productcatalog/adapter/postgres.go
@@ -664,6 +664,158 @@ func (db postgres) DeleteAttributeType(ctx context.Context, id string) error {
 	return nil
 }
 
+// attributeSetMembers loads a set's member attribute types ordered by the join
+// table position.
+func (db postgres) attributeSetMembers(ctx context.Context, setID string) ([]domain.AttributeType, error) {
+	rows, err := db.db.QueryContext(ctx, `
+		SELECT t.id, t.name, t.unit, t.kind, t.filterable, t.position
+		FROM productcatalog_attribute_set_item i
+		JOIN productcatalog_attribute_type t ON t.id = i.attribute_type_id
+		WHERE i.set_id = $1
+		ORDER BY i.position
+	`, setID)
+	if err != nil {
+		return nil, fmt.Errorf("query attribute set members: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []domain.AttributeType
+	for rows.Next() {
+		var id, name, unit, kind string
+		var filterable bool
+		var position int
+		if err := rows.Scan(&id, &name, &unit, &kind, &filterable, &position); err != nil {
+			return nil, fmt.Errorf("scan attribute set member: %w", err)
+		}
+		out = append(out, domain.RebuildAttributeType(id, name, unit, domain.AttributeKind(kind), filterable, position))
+	}
+	return out, rows.Err()
+}
+
+// AllAttributeSets returns every attribute set in display order, each hydrated
+// with its ordered members.
+func (db postgres) AllAttributeSets(ctx context.Context) ([]domain.AttributeSet, error) {
+	rows, err := db.db.QueryContext(ctx, `
+		SELECT id, name, position FROM productcatalog_attribute_set ORDER BY position, name
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("query attribute sets: %w", err)
+	}
+	type setRow struct {
+		id       string
+		name     string
+		position int
+	}
+	var base []setRow
+	func() {
+		defer func() { _ = rows.Close() }()
+		for rows.Next() {
+			var sr setRow
+			if err = rows.Scan(&sr.id, &sr.name, &sr.position); err != nil {
+				return
+			}
+			base = append(base, sr)
+		}
+	}()
+	if err = rows.Err(); err != nil {
+		return nil, fmt.Errorf("scan attribute sets: %w", err)
+	}
+
+	out := make([]domain.AttributeSet, 0, len(base))
+	for _, sr := range base {
+		members, err := db.attributeSetMembers(ctx, sr.id)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, domain.RebuildAttributeSet(sr.id, sr.name, sr.position, members))
+	}
+	return out, nil
+}
+
+// FindAttributeSet returns a single attribute set (with members) by id,
+// returning domain.ErrAttributeSetNotFound when missing.
+func (db postgres) FindAttributeSet(ctx context.Context, id string) (domain.AttributeSet, error) {
+	var name string
+	var position int
+	err := db.db.QueryRowContext(ctx, `
+		SELECT name, position FROM productcatalog_attribute_set WHERE id = $1
+	`, id).Scan(&name, &position)
+	if errors.Is(err, sql.ErrNoRows) {
+		return domain.AttributeSet{}, domain.ErrAttributeSetNotFound
+	}
+	if err != nil {
+		return domain.AttributeSet{}, fmt.Errorf("find attribute set: %w", err)
+	}
+	members, err := db.attributeSetMembers(ctx, id)
+	if err != nil {
+		return domain.AttributeSet{}, err
+	}
+	return domain.RebuildAttributeSet(id, name, position, members), nil
+}
+
+// CreateAttributeSet inserts a new attribute set row (members are written
+// separately via SetAttributeSetItems).
+func (db postgres) CreateAttributeSet(ctx context.Context, s domain.AttributeSet) error {
+	_, err := db.db.ExecContext(ctx, `
+		INSERT INTO productcatalog_attribute_set (id, name, position) VALUES ($1, $2, $3)
+	`, s.ID(), s.Name(), s.Position())
+	if err != nil {
+		return fmt.Errorf("create attribute set: %w", err)
+	}
+	return nil
+}
+
+// UpdateAttributeSet updates an existing attribute set's name and position by id.
+func (db postgres) UpdateAttributeSet(ctx context.Context, s domain.AttributeSet) error {
+	_, err := db.db.ExecContext(ctx, `
+		UPDATE productcatalog_attribute_set SET name = $2, position = $3 WHERE id = $1
+	`, s.ID(), s.Name(), s.Position())
+	if err != nil {
+		return fmt.Errorf("update attribute set: %w", err)
+	}
+	return nil
+}
+
+// DeleteAttributeSet removes an attribute set; its member items cascade.
+func (db postgres) DeleteAttributeSet(ctx context.Context, id string) error {
+	_, err := db.db.ExecContext(ctx, `DELETE FROM productcatalog_attribute_set WHERE id = $1`, id)
+	if err != nil {
+		return fmt.Errorf("delete attribute set: %w", err)
+	}
+	return nil
+}
+
+// SetAttributeSetItems replaces a set's members: it deletes the existing items
+// and inserts the given attribute type ids with position = their index in the
+// slice (order matters), in a single transaction.
+func (db postgres) SetAttributeSetItems(ctx context.Context, setID string, attributeTypeIDs []string) error {
+	tx, err := db.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer func() {
+		if err != nil {
+			_ = tx.Rollback()
+		}
+	}()
+
+	if _, err = tx.ExecContext(ctx, `DELETE FROM productcatalog_attribute_set_item WHERE set_id = $1`, setID); err != nil {
+		return fmt.Errorf("clear attribute set items: %w", err)
+	}
+	for i, typeID := range attributeTypeIDs {
+		if _, err = tx.ExecContext(ctx, `
+			INSERT INTO productcatalog_attribute_set_item (set_id, attribute_type_id, position)
+			VALUES ($1, $2, $3)
+		`, setID, typeID, i); err != nil {
+			return fmt.Errorf("insert attribute set item: %w", err)
+		}
+	}
+	if err = tx.Commit(); err != nil {
+		return fmt.Errorf("commit attribute set items: %w", err)
+	}
+	return nil
+}
+
 // UpdateProduct updates the core product row (name, description, thumbnail,
 // price) by id. Variants, categories and attributes are untouched.
 func (db postgres) UpdateProduct(ctx context.Context, p domain.Product) error {

--- a/backend/productcatalog/adapter/postgres.go
+++ b/backend/productcatalog/adapter/postgres.go
@@ -332,7 +332,7 @@ func (db postgres) productAttributes(ctx context.Context, productID string) ([]d
 }
 
 func (db postgres) All(ctx context.Context) ([]domain.Product, error) {
-	q := `SELECT id, name, description, thumbnail, price_amount, price_currency FROM productcatalog_product ORDER BY id`
+	q := `SELECT id, name, description, thumbnail, price_amount, price_currency, attribute_set_id FROM productcatalog_product ORDER BY id`
 
 	rows, err := db.db.QueryContext(ctx, q)
 	if err != nil {
@@ -369,7 +369,7 @@ func (db postgres) All(ctx context.Context) ([]domain.Product, error) {
 // (ties broken by id), each hydrated with its catalog/classification the same
 // way All does.
 func (db postgres) Newest(ctx context.Context, limit int) ([]domain.Product, error) {
-	q := `SELECT id, name, description, thumbnail, price_amount, price_currency
+	q := `SELECT id, name, description, thumbnail, price_amount, price_currency, attribute_set_id
 		FROM productcatalog_product
 		ORDER BY created_at DESC, id DESC
 		LIMIT $1`
@@ -406,7 +406,7 @@ func (db postgres) Newest(ctx context.Context, limit int) ([]domain.Product, err
 }
 
 func (db postgres) Find(ctx context.Context, id string) (domain.Product, error) {
-	q := `SELECT id, name, description, thumbnail, price_amount, price_currency FROM productcatalog_product WHERE id = $1`
+	q := `SELECT id, name, description, thumbnail, price_amount, price_currency, attribute_set_id FROM productcatalog_product WHERE id = $1`
 	p, err := scanProduct(db.db.QueryRowContext(ctx, q, id))
 	if errors.Is(err, sql.ErrNoRows) {
 		return domain.Product{}, domain.ErrProductNotFound
@@ -445,7 +445,8 @@ type rowScanner interface {
 func scanProduct(s rowScanner) (domain.Product, error) {
 	var id, name, description, thumbnail, currency string
 	var amount int64
-	if err := s.Scan(&id, &name, &description, &thumbnail, &amount, &currency); err != nil {
+	var attributeSetID sql.NullString
+	if err := s.Scan(&id, &name, &description, &thumbnail, &amount, &currency, &attributeSetID); err != nil {
 		return domain.Product{}, err
 	}
 	pid, err := domain.NewProductId(id)
@@ -460,7 +461,11 @@ func scanProduct(s rowScanner) (domain.Product, error) {
 	if err != nil {
 		return domain.Product{}, fmt.Errorf("rebuild price: %w", err)
 	}
-	return domain.NewProduct(pid, name, description, price, thumbnail)
+	p, err := domain.NewProduct(pid, name, description, price, thumbnail)
+	if err != nil {
+		return domain.Product{}, err
+	}
+	return p.WithAttributeSet(attributeSetID.String), nil
 }
 
 func scanVariant(s rowScanner) (domain.Variant, error) {
@@ -874,6 +879,22 @@ func (db postgres) SetProductCategories(ctx context.Context, productID string, c
 	}
 	if err = tx.Commit(); err != nil {
 		return fmt.Errorf("commit product categories: %w", err)
+	}
+	return nil
+}
+
+// SetProductAttributeSet sets (or clears) the product's attribute_set_id. An
+// empty setID is written as SQL NULL.
+func (db postgres) SetProductAttributeSet(ctx context.Context, productID, setID string) error {
+	var setVal sql.NullString
+	if setID != "" {
+		setVal = sql.NullString{String: setID, Valid: true}
+	}
+	_, err := db.db.ExecContext(ctx, `
+		UPDATE productcatalog_product SET attribute_set_id = $2 WHERE id = $1
+	`, productID, setVal)
+	if err != nil {
+		return fmt.Errorf("set product attribute set: %w", err)
 	}
 	return nil
 }

--- a/backend/productcatalog/app/product.go
+++ b/backend/productcatalog/app/product.go
@@ -22,6 +22,7 @@ type ProductStorage interface {
 	SetVariantStock(ctx context.Context, variantID string, stock int) error
 	SetProductCategories(ctx context.Context, productID string, categoryIDs []string) error
 	SetProductAttributes(ctx context.Context, productID string, values []AttributeAssignment) error
+	SetProductAttributeSet(ctx context.Context, productID, setID string) error
 	Find(ctx context.Context, id string) (domain.Product, error)
 	FindVariant(ctx context.Context, variantID string) (domain.Product, domain.Variant, error)
 	AddOptionType(ctx context.Context, productID string, position int, ot domain.OptionType) error
@@ -365,6 +366,36 @@ func (ps ProductService) SetProductCategories(ctx context.Context, productID str
 // SetProductAttributes replaces the product's attribute values with the given set.
 func (ps ProductService) SetProductAttributes(ctx context.Context, productID string, values []AttributeAssignment) error {
 	return ps.storage.SetProductAttributes(ctx, productID, values)
+}
+
+// SetProductAttributeSet assigns (or clears, when setID is empty) the product's
+// attribute set. A non-empty setID is validated to exist before assignment.
+func (ps ProductService) SetProductAttributeSet(ctx context.Context, productID, setID string) error {
+	if setID != "" {
+		if _, err := ps.storage.FindAttributeSet(ctx, setID); err != nil {
+			return err
+		}
+	}
+	return ps.storage.SetProductAttributeSet(ctx, productID, setID)
+}
+
+// ProductAttributeTypes returns the ordered attribute types a product's edit
+// form should show: when the product has an attribute set, its members (already
+// ordered); otherwise every attribute type as a fallback so products without a
+// set still work.
+func (ps ProductService) ProductAttributeTypes(ctx context.Context, productID string) ([]domain.AttributeType, error) {
+	product, err := ps.storage.Find(ctx, productID)
+	if err != nil {
+		return nil, err
+	}
+	if setID := product.AttributeSetID(); setID != "" {
+		set, err := ps.storage.FindAttributeSet(ctx, setID)
+		if err != nil {
+			return nil, err
+		}
+		return set.Members(), nil
+	}
+	return ps.storage.AllAttributeTypes(ctx)
 }
 
 // OptionTypeInput / VariantInput describe a product's options and variants for

--- a/backend/productcatalog/app/product.go
+++ b/backend/productcatalog/app/product.go
@@ -45,6 +45,13 @@ type ProductStorage interface {
 	CreateAttributeType(ctx context.Context, t domain.AttributeType) error
 	UpdateAttributeType(ctx context.Context, t domain.AttributeType) error
 	DeleteAttributeType(ctx context.Context, id string) error
+
+	AllAttributeSets(ctx context.Context) ([]domain.AttributeSet, error)
+	FindAttributeSet(ctx context.Context, id string) (domain.AttributeSet, error)
+	CreateAttributeSet(ctx context.Context, s domain.AttributeSet) error
+	UpdateAttributeSet(ctx context.Context, s domain.AttributeSet) error
+	DeleteAttributeSet(ctx context.Context, id string) error
+	SetAttributeSetItems(ctx context.Context, setID string, attributeTypeIDs []string) error
 }
 
 func NewProductService(s ProductStorage) ProductService {
@@ -136,6 +143,13 @@ func (ps ProductService) AttributeTypes(ctx context.Context) ([]domain.Attribute
 	return ps.storage.AllAttributeTypes(ctx)
 }
 
+// AllAttributeTypes returns every attribute type in display order. It is an
+// alias of AttributeTypes exposed for callers (e.g. the attribute-set editor)
+// that need the full list of types to choose from.
+func (ps ProductService) AllAttributeTypes(ctx context.Context) ([]domain.AttributeType, error) {
+	return ps.storage.AllAttributeTypes(ctx)
+}
+
 // CreateAttributeType validates and persists a new attribute type. The id is a
 // slug derived from the name and the position is appended after existing types.
 func (ps ProductService) CreateAttributeType(ctx context.Context, name, unit string, kind domain.AttributeKind, filterable bool) error {
@@ -163,6 +177,92 @@ func (ps ProductService) UpdateAttributeType(ctx context.Context, id, name, unit
 // DeleteAttributeType removes an attribute type (its product links cascade).
 func (ps ProductService) DeleteAttributeType(ctx context.Context, id string) error {
 	return ps.storage.DeleteAttributeType(ctx, id)
+}
+
+// AttributeSets returns every attribute set in display order, each hydrated
+// with its ordered members.
+func (ps ProductService) AttributeSets(ctx context.Context) ([]domain.AttributeSet, error) {
+	return ps.storage.AllAttributeSets(ctx)
+}
+
+// FindAttributeSet returns a single attribute set (with its members) by id.
+func (ps ProductService) FindAttributeSet(ctx context.Context, id string) (domain.AttributeSet, error) {
+	return ps.storage.FindAttributeSet(ctx, id)
+}
+
+// CreateAttributeSet validates and persists a new attribute set. The id is a
+// slug derived from the name, the position is appended after existing sets, and
+// the given attribute type ids become its ordered members (order = slice
+// order). Unknown attribute type ids are rejected.
+func (ps ProductService) CreateAttributeSet(ctx context.Context, name string, attributeTypeIDs []string) error {
+	existing, err := ps.storage.AllAttributeSets(ctx)
+	if err != nil {
+		return err
+	}
+	id := slugify(name)
+	if id == "" {
+		return fmt.Errorf("%w: name must contain letters or digits", domain.ErrInvalidAttributeSet)
+	}
+	ids, err := ps.validateAttributeTypeIDs(ctx, attributeTypeIDs)
+	if err != nil {
+		return err
+	}
+	set, err := domain.NewAttributeSet(id, name, len(existing)+1)
+	if err != nil {
+		return err
+	}
+	if err = ps.storage.CreateAttributeSet(ctx, set); err != nil {
+		return err
+	}
+	return ps.storage.SetAttributeSetItems(ctx, id, ids)
+}
+
+// UpdateAttributeSet renames an existing set and replaces its members with the
+// given ordered attribute type ids (order = slice order). Unknown attribute
+// type ids are rejected.
+func (ps ProductService) UpdateAttributeSet(ctx context.Context, id, name string, attributeTypeIDs []string) error {
+	current, err := ps.storage.FindAttributeSet(ctx, id)
+	if err != nil {
+		return err
+	}
+	ids, err := ps.validateAttributeTypeIDs(ctx, attributeTypeIDs)
+	if err != nil {
+		return err
+	}
+	set, err := domain.NewAttributeSet(id, name, current.Position())
+	if err != nil {
+		return err
+	}
+	if err = ps.storage.UpdateAttributeSet(ctx, set); err != nil {
+		return err
+	}
+	return ps.storage.SetAttributeSetItems(ctx, id, ids)
+}
+
+// DeleteAttributeSet removes an attribute set (its member items cascade).
+func (ps ProductService) DeleteAttributeSet(ctx context.Context, id string) error {
+	return ps.storage.DeleteAttributeSet(ctx, id)
+}
+
+// validateAttributeTypeIDs checks every given id exists among the known
+// attribute types (rejecting unknown ids) while preserving the input order.
+func (ps ProductService) validateAttributeTypeIDs(ctx context.Context, attributeTypeIDs []string) ([]string, error) {
+	types, err := ps.storage.AllAttributeTypes(ctx)
+	if err != nil {
+		return nil, err
+	}
+	known := make(map[string]bool, len(types))
+	for _, t := range types {
+		known[t.ID()] = true
+	}
+	out := make([]string, 0, len(attributeTypeIDs))
+	for _, id := range attributeTypeIDs {
+		if !known[id] {
+			return nil, fmt.Errorf("unknown attribute type %q", id)
+		}
+		out = append(out, id)
+	}
+	return out, nil
 }
 
 // slugify turns a display name into a url-safe id: lowercase, spaces to

--- a/backend/productcatalog/app/product_test.go
+++ b/backend/productcatalog/app/product_test.go
@@ -20,6 +20,7 @@ type productStorage interface {
 	SetVariantStock(ctx context.Context, variantID string, stock int) error
 	SetProductCategories(ctx context.Context, productID string, categoryIDs []string) error
 	SetProductAttributes(ctx context.Context, productID string, values []app.AttributeAssignment) error
+	SetProductAttributeSet(ctx context.Context, productID, setID string) error
 	Find(ctx context.Context, id string) (domain.Product, error)
 	FindVariant(ctx context.Context, variantID string) (domain.Product, domain.Variant, error)
 	AddOptionType(ctx context.Context, productID string, position int, ot domain.OptionType) error

--- a/backend/productcatalog/app/product_test.go
+++ b/backend/productcatalog/app/product_test.go
@@ -41,6 +41,12 @@ type productStorage interface {
 	CreateAttributeType(ctx context.Context, t domain.AttributeType) error
 	UpdateAttributeType(ctx context.Context, t domain.AttributeType) error
 	DeleteAttributeType(ctx context.Context, id string) error
+	AllAttributeSets(ctx context.Context) ([]domain.AttributeSet, error)
+	FindAttributeSet(ctx context.Context, id string) (domain.AttributeSet, error)
+	CreateAttributeSet(ctx context.Context, s domain.AttributeSet) error
+	UpdateAttributeSet(ctx context.Context, s domain.AttributeSet) error
+	DeleteAttributeSet(ctx context.Context, id string) error
+	SetAttributeSetItems(ctx context.Context, setID string, attributeTypeIDs []string) error
 }
 
 var storage productStorage

--- a/backend/productcatalog/domain/attribute_set.go
+++ b/backend/productcatalog/domain/attribute_set.go
@@ -1,0 +1,57 @@
+package domain
+
+import "errors"
+
+// ErrInvalidAttributeSet is returned when an AttributeSet fails validation.
+var ErrInvalidAttributeSet = errors.New("invalid attribute set")
+
+// ErrAttributeSetNotFound is returned when a lookup for an attribute set by id
+// finds no matching set.
+var ErrAttributeSetNotFound = errors.New("attribute set not found")
+
+// AttributeSet is a named, reusable grouping that selects which attribute types
+// a product should have and in what order. It is a value object hydrated from
+// storage; members holds the set's attribute types in their configured order.
+type AttributeSet struct {
+	id       string
+	name     string
+	position int
+	members  []AttributeType
+}
+
+// NewAttributeSet builds a validated AttributeSet. It errors when the name is
+// empty. Members are attached separately via WithMembers (they are stored in a
+// join table).
+func NewAttributeSet(id, name string, position int) (AttributeSet, error) {
+	if name == "" {
+		return AttributeSet{}, ErrInvalidAttributeSet
+	}
+	return AttributeSet{
+		id:       id,
+		name:     name,
+		position: position,
+	}, nil
+}
+
+// RebuildAttributeSet reconstructs an AttributeSet (with its members) from
+// storage.
+func RebuildAttributeSet(id, name string, position int, members []AttributeType) AttributeSet {
+	return AttributeSet{
+		id:       id,
+		name:     name,
+		position: position,
+		members:  members,
+	}
+}
+
+func (s AttributeSet) ID() string               { return s.id }
+func (s AttributeSet) Name() string             { return s.name }
+func (s AttributeSet) Position() int            { return s.position }
+func (s AttributeSet) Members() []AttributeType { return s.members }
+
+// WithMembers returns a copy of the set with its members replaced (used by the
+// storage layer after loading them).
+func (s AttributeSet) WithMembers(members []AttributeType) AttributeSet {
+	s.members = members
+	return s
+}

--- a/backend/productcatalog/domain/product.go
+++ b/backend/productcatalog/domain/product.go
@@ -85,6 +85,10 @@ type Product struct {
 	variants    []Variant
 	categories  []Category
 	attributes  []AttributeValue
+	// attributeSetID is the id of the attribute set that defines which attribute
+	// types this product has and in what order. Empty when the product has no
+	// set (it then falls back to all attribute types).
+	attributeSetID string
 }
 
 var emptyProduct = Product{}
@@ -161,6 +165,17 @@ func (p Product) WithClassification(categories []Category, attributes []Attribut
 
 func (p Product) Categories() []Category       { return p.categories }
 func (p Product) Attributes() []AttributeValue { return p.attributes }
+
+// AttributeSetID returns the id of the product's attribute set (empty when it
+// has none).
+func (p Product) AttributeSetID() string { return p.attributeSetID }
+
+// WithAttributeSet returns a copy of the product with its attribute set id set
+// (used by the storage layer after loading it, or when assigning a set).
+func (p Product) WithAttributeSet(setID string) Product {
+	p.attributeSetID = setID
+	return p
+}
 
 // Variant returns the variant with the given id, if it belongs to this product.
 func (p Product) Variant(id string) (Variant, bool) {

--- a/migrations/000017_productcatalog_attribute_sets.down.sql
+++ b/migrations/000017_productcatalog_attribute_sets.down.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+DROP TABLE IF EXISTS productcatalog_attribute_set_item;
+DROP TABLE IF EXISTS productcatalog_attribute_set;
+
+COMMIT;

--- a/migrations/000017_productcatalog_attribute_sets.up.sql
+++ b/migrations/000017_productcatalog_attribute_sets.up.sql
@@ -1,0 +1,16 @@
+BEGIN;
+
+CREATE TABLE productcatalog_attribute_set (
+    id text PRIMARY KEY,
+    name text NOT NULL,
+    position int NOT NULL DEFAULT 0
+);
+
+CREATE TABLE productcatalog_attribute_set_item (
+    set_id text NOT NULL REFERENCES productcatalog_attribute_set(id) ON DELETE CASCADE,
+    attribute_type_id text NOT NULL REFERENCES productcatalog_attribute_type(id) ON DELETE CASCADE,
+    position int NOT NULL DEFAULT 0,
+    PRIMARY KEY (set_id, attribute_type_id)
+);
+
+COMMIT;

--- a/migrations/000018_productcatalog_product_attribute_set.down.sql
+++ b/migrations/000018_productcatalog_product_attribute_set.down.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+ALTER TABLE productcatalog_product DROP COLUMN IF EXISTS attribute_set_id;
+
+COMMIT;

--- a/migrations/000018_productcatalog_product_attribute_set.up.sql
+++ b/migrations/000018_productcatalog_product_attribute_set.up.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+ALTER TABLE productcatalog_product
+    ADD COLUMN attribute_set_id text REFERENCES productcatalog_attribute_set(id) ON DELETE SET NULL;
+
+COMMIT;


### PR DESCRIPTION
An attribute set is a named, reusable group selecting WHICH attribute types a product has and IN WHAT ORDER. Admins define sets; when creating a product they pick one, and the product's attribute inputs are then scoped and ordered by it.

- **Phase 1** (migration 000017): `attribute_set` + ordered `attribute_set_item`; domain `AttributeSet`; storage/service CRUD; admin pages at `/admin/attribute-sets` (checkboxes + order inputs).
- **Phase 2** (migration 000018): nullable `attribute_set_id` on products (`ON DELETE SET NULL`); create forms ask for a set; the product edit page's attributes section is driven by the set's ordered members; a picker lets you change the set. Products without a set fall back to all attribute types.

## Test plan
- [x] build (incl. -tags integration) / vet / tests / lint green
- [x] docker: create set, create product picking it (edit shows only set's attrs in order, material excluded), save values, switch set via picker, no-set fallback shows all types