### PR TITLE
refactor(admin): move product create off the list, tab the edit page

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,23 @@ If you find anything that you can improve or add - feel free to talk about it in
 
 The project is a very early stage so there's a lot of work to do so every contribution is welcome!
 
+## Features
+
+**Storefront**
+- "New arrivals" homepage; full filterable catalog at `/products`.
+- Top menu with category links, cart and account/log out.
+- Faceted filters per category (numeric ranges + enum checkboxes), scoped to the active category.
+- Variant selectors (e.g. Color / Size) on product pages; add-to-cart over HTMX.
+- Customer accounts: orders history, saved shipping addresses, password change.
+- Checkout with personal pickup / courier / flat-rate shipping and card / PayPal / cash-on-delivery payment.
+
+**Admin panel** (`/admin`, seeded user `admin@example.com` / `Admin123!`)
+- Dashboard with store counts.
+- Products: list, create (simple or with option types + variants), edit core fields, per-variant SKU/price/stock/image, add/edit/delete variants, manage option types on existing products (with consistent cascades), assign categories, attributes and an attribute set, delete.
+- Categories, attribute types and attribute sets: full CRUD.
+- Orders: list all, view detail, admin-cancel.
+- Dedicated admin shell (sidebar layout) separate from the storefront.
+
 ## Context map
 
 The backend is organised as a set of DDD bounded contexts. Each context owns its

--- a/backend/layout/http.go
+++ b/backend/layout/http.go
@@ -142,6 +142,7 @@ func (m boundedContext) MuxRegister(r *mux.Router) {
 	// captured by the /admin/products/{id} catch-all below.
 	r.HandleFunc("/admin/products/new-variant", observability.HTTPWrap(m.handler.AdminNewVariantProductForm, m.logger)).Methods("GET")
 	r.HandleFunc("/admin/products/new-variant", observability.HTTPWrap(m.handler.AdminCreateVariantProduct, m.logger)).Methods("POST")
+	r.HandleFunc("/admin/products/new", observability.HTTPWrap(m.handler.AdminNewProductForm, m.logger)).Methods("GET")
 	r.HandleFunc("/admin/products/{id}/variants/{variantID}/delete", observability.HTTPWrap(m.handler.AdminDeleteVariant, m.logger)).Methods("POST")
 	r.HandleFunc("/admin/products/{id}/variants/{variantID}", observability.HTTPWrap(m.handler.AdminUpdateVariant, m.logger)).Methods("POST")
 	r.HandleFunc("/admin/products/{id}/variants", observability.HTTPWrap(m.handler.AdminAddVariant, m.logger)).Methods("POST")

--- a/backend/layout/http_admin_products.go
+++ b/backend/layout/http_admin_products.go
@@ -39,14 +39,27 @@ func (handler httpHandler) AdminProducts(w http.ResponseWriter, r *http.Request)
 	if err != nil {
 		products = nil
 	}
+	handler.renderAdminTemplate(w, r, "admin/products", map[string]any{
+		"Active":   "products",
+		"Email":    email,
+		"Products": products,
+	})
+}
+
+// AdminNewProductForm renders the standalone "add a simple product" page.
+// The form POSTs to /admin/products (handled by AdminCreateProduct).
+func (handler httpHandler) AdminNewProductForm(w http.ResponseWriter, r *http.Request) {
+	email, ok := handler.requireAdmin(w, r)
+	if !ok {
+		return
+	}
 	attrSets, err := handler.catalogSrv.AttributeSets(r.Context())
 	if err != nil {
 		attrSets = nil
 	}
-	handler.renderAdminTemplate(w, r, "admin/products", map[string]any{
+	handler.renderAdminTemplate(w, r, "admin/product_new", map[string]any{
 		"Active":        "products",
 		"Email":         email,
-		"Products":      products,
 		"AttributeSets": attrSets,
 	})
 }

--- a/backend/layout/static/admin.css
+++ b/backend/layout/static/admin.css
@@ -453,3 +453,49 @@ input:focus, select:focus, textarea:focus {
 .form--inline input { width: auto; flex: 1 1 90px; min-width: 70px; }
 .form--inline input[type="number"] { flex: 0 0 80px; }
 .btn--small { padding: 5px 12px; font-size: 0.82rem; }
+
+/* --- Page header action row --------------------------------------------- */
+.admin-page-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+  flex-wrap: wrap;
+  margin-bottom: 16px;
+}
+.admin-page-head__actions {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+/* --- Tabs (product edit) ------------------------------------------------ */
+.admin-tabs {
+  display: flex;
+  gap: 4px;
+  flex-wrap: wrap;
+  border-bottom: 1px solid var(--a-border);
+  margin: 6px 0 18px;
+}
+.admin-tabs__btn {
+  appearance: none;
+  background: none;
+  border: 0;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px;
+  padding: 10px 16px;
+  font: inherit;
+  font-size: 0.92rem;
+  font-weight: 500;
+  color: var(--a-muted);
+  cursor: pointer;
+  letter-spacing: 0.01em;
+}
+.admin-tabs__btn:hover { color: var(--a-text); }
+.admin-tabs__btn.is-active {
+  color: var(--a-text);
+  font-weight: 700;
+  border-bottom-color: var(--a-accent);
+}
+.admin-tab { margin-top: 18px; }

--- a/backend/layout/tmpl/admin/product_edit.gohtml
+++ b/backend/layout/tmpl/admin/product_edit.gohtml
@@ -2,169 +2,229 @@
   <p class="crumbs"><a href="/admin/products">products</a> / edit</p>
   <h2 class="account-card__title">edit product <code>{{.Product.ID}}</code></h2>
 
-  <section class="admin-section">
-    <h3 class="admin-section__title">core fields</h3>
-    <form class="form" method="post" action="/admin/products/{{.Product.ID}}">
-      <div class="field"><label for="p-name">name</label><input id="p-name" name="name" value="{{.Product.Name}}" required></div>
-      <div class="field"><label for="p-description">description</label><textarea id="p-description" name="description" required>{{.Product.Description}}</textarea></div>
-      <div class="field"><label for="p-price">price (major units, e.g. 9.00)</label><input id="p-price" name="price" value="{{.Product.Price.Display}}" required></div>
-      <div class="field"><label for="p-currency">currency</label><input id="p-currency" name="currency" value="{{.Product.Price.Currency}}"></div>
-      <div class="field"><label for="p-thumbnail">thumbnail URL</label><input id="p-thumbnail" name="thumbnail" value="{{.Product.Thumbnail}}"></div>
-      <button type="submit" class="btn">save core fields</button>
-    </form>
-  </section>
+  <div class="admin-tabs" role="tablist" aria-label="product sections">
+    <button type="button" role="tab" aria-controls="tab-details" data-tab="details" class="admin-tabs__btn is-active">Details</button>
+    <button type="button" role="tab" aria-controls="tab-options-variants" data-tab="options-variants" class="admin-tabs__btn">Options &amp; variants</button>
+    <button type="button" role="tab" aria-controls="tab-attributes" data-tab="attributes" class="admin-tabs__btn">Attributes</button>
+  </div>
 
-  <section class="admin-section">
-    <h3 class="admin-section__title">option types</h3>
-    {{if .Product.OptionTypes}}
-      <table class="admin-table">
-        <thead><tr><th>name</th><th>values (comma-separated)</th><th></th></tr></thead>
-        <tbody>
-          {{range $ot := .Product.OptionTypes}}
-            <tr>
-              <td colspan="2">
-                <form class="form form--inline" method="post" action="/admin/products/{{$.Product.ID}}/options/update">
-                  <input type="hidden" name="current_name" value="{{$ot.Name}}">
-                  <input name="new_name" value="{{$ot.Name}}" placeholder="name" aria-label="name" required>
-                  <input name="values" value="{{join ", " $ot.Values}}" placeholder="Red, Blue" aria-label="values" required>
-                  <button type="submit" class="btn btn--small">save</button>
-                </form>
-              </td>
-              <td class="admin-table__actions">
-                <form method="post" action="/admin/products/{{$.Product.ID}}/options/delete"
-                      onsubmit="return confirm('Delete this option type? It will be removed from every variant.');">
-                  <input type="hidden" name="name" value="{{$ot.Name}}">
-                  <button type="submit" class="linkbtn linkbtn--danger">delete</button>
-                </form>
-              </td>
-            </tr>
-          {{end}}
-        </tbody>
-      </table>
-    {{else}}
-      <p class="muted">no option types.</p>
-    {{end}}
-
-    <h4 class="admin-section__subtitle">add an option type</h4>
-    <form class="form" method="post" action="/admin/products/{{.Product.ID}}/options">
-      <div class="field"><label for="ot-name">name</label><input id="ot-name" name="name" required placeholder="Color"></div>
-      <div class="field"><label for="ot-values">values (comma-separated)</label><input id="ot-values" name="values" required placeholder="Red, Blue"></div>
-      <div class="field"><label for="ot-default">default value</label><input id="ot-default" name="default" required placeholder="Red"></div>
-      <button type="submit" class="btn">add option type</button>
-      <p class="form__aside muted">the default value is applied to every existing variant (and must be one of the values above) so they stay resolvable.</p>
-    </form>
-  </section>
-
-  <section class="admin-section">
-    <h3 class="admin-section__title">variants</h3>
-    {{if .Product.Variants}}
-      {{$ots := .Product.OptionTypes}}
-      {{$single := eq (len .Product.Variants) 1}}
-      <table class="admin-table variant-table">
-        <thead><tr><th>variant</th><th>sku</th><th>price</th><th>image</th><th>stock</th><th></th></tr></thead>
-        <tbody>
-          {{range $v := .Product.Variants}}
-            <tr>
-              <td>{{with $v.Label $ots}}{{.}}{{else}}default{{end}}</td>
-              <td colspan="4">
-                <form class="form form--inline" method="post" action="/admin/products/{{$.Product.ID}}/variants/{{$v.ID}}">
-                  <input name="sku" value="{{$v.SKU}}" placeholder="sku" aria-label="sku">
-                  <input name="price" value="{{$v.Price.Display}}" placeholder="9.00" aria-label="price">
-                  <input name="image" value="{{$v.Image}}" placeholder="image URL" aria-label="image">
-                  <input name="stock" type="number" min="0" value="{{$v.Stock}}" aria-label="stock">
-                  <button type="submit" class="btn btn--small">save</button>
-                </form>
-              </td>
-              <td class="admin-table__actions">
-                {{if not $single}}
-                  <form method="post" action="/admin/products/{{$.Product.ID}}/variants/{{$v.ID}}/delete"
-                        onsubmit="return confirm('Delete this variant?');">
-                    <button type="submit" class="linkbtn linkbtn--danger">delete</button>
-                  </form>
-                {{else}}
-                  <span class="muted" title="a product needs at least one variant">&mdash;</span>
-                {{end}}
-              </td>
-            </tr>
-          {{end}}
-        </tbody>
-      </table>
-    {{else}}
-      <p class="muted">no variants.</p>
-    {{end}}
-
-    {{if .Product.HasOptions}}
-      <h4 class="admin-section__subtitle">add a variant</h4>
-      <form class="form" method="post" action="/admin/products/{{.Product.ID}}/variants">
-        {{range $ot := .Product.OptionTypes}}
-          <div class="field">
-            <label for="opt-{{$ot.Name}}">{{$ot.Name}}</label>
-            <select id="opt-{{$ot.Name}}" name="opt_{{$ot.Name}}">
-              {{range $val := $ot.Values}}<option value="{{$val}}">{{$val}}</option>{{end}}
-            </select>
-          </div>
-        {{end}}
-        <div class="field"><label for="nv-sku">sku</label><input id="nv-sku" name="sku"></div>
-        <div class="field"><label for="nv-price">price (major units, e.g. 9.00)</label><input id="nv-price" name="price" required placeholder="9.00"></div>
-        <div class="field"><label for="nv-stock">stock</label><input id="nv-stock" name="stock" type="number" min="0" value="0"></div>
-        <div class="field"><label for="nv-image">image URL</label><input id="nv-image" name="image"></div>
-        <button type="submit" class="btn">add variant</button>
+  <div class="admin-tab" id="tab-details" data-tab="details" role="tabpanel">
+    <section class="admin-section">
+      <h3 class="admin-section__title">core fields</h3>
+      <form class="form" method="post" action="/admin/products/{{.Product.ID}}" data-tab="details">
+        <div class="field"><label for="p-name">name</label><input id="p-name" name="name" value="{{.Product.Name}}" required></div>
+        <div class="field"><label for="p-description">description</label><textarea id="p-description" name="description" required>{{.Product.Description}}</textarea></div>
+        <div class="field"><label for="p-price">price (major units, e.g. 9.00)</label><input id="p-price" name="price" value="{{.Product.Price.Display}}" required></div>
+        <div class="field"><label for="p-currency">currency</label><input id="p-currency" name="currency" value="{{.Product.Price.Currency}}"></div>
+        <div class="field"><label for="p-thumbnail">thumbnail URL</label><input id="p-thumbnail" name="thumbnail" value="{{.Product.Thumbnail}}"></div>
+        <button type="submit" class="btn">save core fields</button>
       </form>
-    {{end}}
-  </section>
+    </section>
 
-  <section class="admin-section">
-    <h3 class="admin-section__title">categories</h3>
-    {{if .Categories}}
-      <form class="form" method="post" action="/admin/products/{{.Product.ID}}/categories">
-        <div class="admin-checks">
-          {{range $c := .Categories}}
-            <label class="admin-check"><input type="checkbox" name="category" value="{{$c.ID}}" {{if index $.Assigned $c.ID}}checked{{end}}> {{$c.Name}}</label>
-          {{end}}
-        </div>
-        <button type="submit" class="btn">save categories</button>
-      </form>
-    {{else}}
-      <p class="muted">no categories defined.</p>
-    {{end}}
-  </section>
-
-  <section class="admin-section">
-    <h3 class="admin-section__title">attribute set</h3>
-    <p class="form__aside muted">the chosen set controls which attributes appear below (and in what order). Choose &ldquo;none&rdquo; to fall back to all attribute types.</p>
-    <form class="form" method="post" action="/admin/products/{{.Product.ID}}/attribute-set">
-      <div class="field">
-        <label for="p-attribute-set">attribute set</label>
-        <select id="p-attribute-set" name="attribute_set">
-          <option value="" {{if eq .CurrentSetID ""}}selected{{end}}>&mdash; none &mdash;</option>
-          {{range $s := .AttributeSets}}<option value="{{$s.ID}}" {{if eq $s.ID $.CurrentSetID}}selected{{end}}>{{$s.Name}}</option>{{end}}
-        </select>
-      </div>
-      <button type="submit" class="btn">save attribute set</button>
-    </form>
-  </section>
-
-  <section class="admin-section">
-    <h3 class="admin-section__title">attributes</h3>
-    {{if .AttrTypes}}
-      <form class="form" method="post" action="/admin/products/{{.Product.ID}}/attributes">
-        {{range $t := .AttrTypes}}
-          <div class="field">
-            <label for="attr-{{$t.ID}}">{{$t.Name}}{{with $t.Unit}} ({{.}}){{end}}</label>
-            {{if $t.IsNumeric}}
-              <input id="attr-{{$t.ID}}" type="number" step="any" name="attr_{{$t.ID}}" value="{{index $.AttrValues $t.ID}}">
-            {{else}}
-              <input id="attr-{{$t.ID}}" type="text" name="attr_{{$t.ID}}" value="{{index $.AttrValues $t.ID}}">
+    <section class="admin-section">
+      <h3 class="admin-section__title">categories</h3>
+      {{if .Categories}}
+        <form class="form" method="post" action="/admin/products/{{.Product.ID}}/categories" data-tab="details">
+          <div class="admin-checks">
+            {{range $c := .Categories}}
+              <label class="admin-check"><input type="checkbox" name="category" value="{{$c.ID}}" {{if index $.Assigned $c.ID}}checked{{end}}> {{$c.Name}}</label>
             {{end}}
           </div>
-        {{end}}
-        <button type="submit" class="btn">save attributes</button>
-        <p class="form__aside muted">leave a field empty to clear that attribute.</p>
+          <button type="submit" class="btn">save categories</button>
+        </form>
+      {{else}}
+        <p class="muted">no categories defined.</p>
+      {{end}}
+    </section>
+  </div>
+
+  <div class="admin-tab" id="tab-options-variants" data-tab="options-variants" role="tabpanel" hidden>
+    <section class="admin-section">
+      <h3 class="admin-section__title">option types</h3>
+      {{if .Product.OptionTypes}}
+        <table class="admin-table">
+          <thead><tr><th>name</th><th>values (comma-separated)</th><th></th></tr></thead>
+          <tbody>
+            {{range $ot := .Product.OptionTypes}}
+              <tr>
+                <td colspan="2">
+                  <form class="form form--inline" method="post" action="/admin/products/{{$.Product.ID}}/options/update" data-tab="options-variants">
+                    <input type="hidden" name="current_name" value="{{$ot.Name}}">
+                    <input name="new_name" value="{{$ot.Name}}" placeholder="name" aria-label="name" required>
+                    <input name="values" value="{{join ", " $ot.Values}}" placeholder="Red, Blue" aria-label="values" required>
+                    <button type="submit" class="btn btn--small">save</button>
+                  </form>
+                </td>
+                <td class="admin-table__actions">
+                  <form method="post" action="/admin/products/{{$.Product.ID}}/options/delete" data-tab="options-variants"
+                        onsubmit="return confirm('Delete this option type? It will be removed from every variant.');">
+                    <input type="hidden" name="name" value="{{$ot.Name}}">
+                    <button type="submit" class="linkbtn linkbtn--danger">delete</button>
+                  </form>
+                </td>
+              </tr>
+            {{end}}
+          </tbody>
+        </table>
+      {{else}}
+        <p class="muted">no option types.</p>
+      {{end}}
+
+      <h4 class="admin-section__subtitle">add an option type</h4>
+      <form class="form" method="post" action="/admin/products/{{.Product.ID}}/options" data-tab="options-variants">
+        <div class="field"><label for="ot-name">name</label><input id="ot-name" name="name" required placeholder="Color"></div>
+        <div class="field"><label for="ot-values">values (comma-separated)</label><input id="ot-values" name="values" required placeholder="Red, Blue"></div>
+        <div class="field"><label for="ot-default">default value</label><input id="ot-default" name="default" required placeholder="Red"></div>
+        <button type="submit" class="btn">add option type</button>
+        <p class="form__aside muted">the default value is applied to every existing variant (and must be one of the values above) so they stay resolvable.</p>
       </form>
-    {{else}}
-      <p class="muted">no attribute types defined.</p>
-    {{end}}
-  </section>
+    </section>
+
+    <section class="admin-section">
+      <h3 class="admin-section__title">variants</h3>
+      {{if .Product.Variants}}
+        {{$ots := .Product.OptionTypes}}
+        {{$single := eq (len .Product.Variants) 1}}
+        <table class="admin-table variant-table">
+          <thead><tr><th>variant</th><th>sku</th><th>price</th><th>image</th><th>stock</th><th></th></tr></thead>
+          <tbody>
+            {{range $v := .Product.Variants}}
+              <tr>
+                <td>{{with $v.Label $ots}}{{.}}{{else}}default{{end}}</td>
+                <td colspan="4">
+                  <form class="form form--inline" method="post" action="/admin/products/{{$.Product.ID}}/variants/{{$v.ID}}" data-tab="options-variants">
+                    <input name="sku" value="{{$v.SKU}}" placeholder="sku" aria-label="sku">
+                    <input name="price" value="{{$v.Price.Display}}" placeholder="9.00" aria-label="price">
+                    <input name="image" value="{{$v.Image}}" placeholder="image URL" aria-label="image">
+                    <input name="stock" type="number" min="0" value="{{$v.Stock}}" aria-label="stock">
+                    <button type="submit" class="btn btn--small">save</button>
+                  </form>
+                </td>
+                <td class="admin-table__actions">
+                  {{if not $single}}
+                    <form method="post" action="/admin/products/{{$.Product.ID}}/variants/{{$v.ID}}/delete" data-tab="options-variants"
+                          onsubmit="return confirm('Delete this variant?');">
+                      <button type="submit" class="linkbtn linkbtn--danger">delete</button>
+                    </form>
+                  {{else}}
+                    <span class="muted" title="a product needs at least one variant">&mdash;</span>
+                  {{end}}
+                </td>
+              </tr>
+            {{end}}
+          </tbody>
+        </table>
+      {{else}}
+        <p class="muted">no variants.</p>
+      {{end}}
+
+      {{if .Product.HasOptions}}
+        <h4 class="admin-section__subtitle">add a variant</h4>
+        <form class="form" method="post" action="/admin/products/{{.Product.ID}}/variants" data-tab="options-variants">
+          {{range $ot := .Product.OptionTypes}}
+            <div class="field">
+              <label for="opt-{{$ot.Name}}">{{$ot.Name}}</label>
+              <select id="opt-{{$ot.Name}}" name="opt_{{$ot.Name}}">
+                {{range $val := $ot.Values}}<option value="{{$val}}">{{$val}}</option>{{end}}
+              </select>
+            </div>
+          {{end}}
+          <div class="field"><label for="nv-sku">sku</label><input id="nv-sku" name="sku"></div>
+          <div class="field"><label for="nv-price">price (major units, e.g. 9.00)</label><input id="nv-price" name="price" required placeholder="9.00"></div>
+          <div class="field"><label for="nv-stock">stock</label><input id="nv-stock" name="stock" type="number" min="0" value="0"></div>
+          <div class="field"><label for="nv-image">image URL</label><input id="nv-image" name="image"></div>
+          <button type="submit" class="btn">add variant</button>
+        </form>
+      {{end}}
+    </section>
+  </div>
+
+  <div class="admin-tab" id="tab-attributes" data-tab="attributes" role="tabpanel" hidden>
+    <section class="admin-section">
+      <h3 class="admin-section__title">attribute set</h3>
+      <p class="form__aside muted">the chosen set controls which attributes appear below (and in what order). Choose &ldquo;none&rdquo; to fall back to all attribute types.</p>
+      <form class="form" method="post" action="/admin/products/{{.Product.ID}}/attribute-set" data-tab="attributes">
+        <div class="field">
+          <label for="p-attribute-set">attribute set</label>
+          <select id="p-attribute-set" name="attribute_set">
+            <option value="" {{if eq .CurrentSetID ""}}selected{{end}}>&mdash; none &mdash;</option>
+            {{range $s := .AttributeSets}}<option value="{{$s.ID}}" {{if eq $s.ID $.CurrentSetID}}selected{{end}}>{{$s.Name}}</option>{{end}}
+          </select>
+        </div>
+        <button type="submit" class="btn">save attribute set</button>
+      </form>
+    </section>
+
+    <section class="admin-section">
+      <h3 class="admin-section__title">attributes</h3>
+      {{if .AttrTypes}}
+        <form class="form" method="post" action="/admin/products/{{.Product.ID}}/attributes" data-tab="attributes">
+          {{range $t := .AttrTypes}}
+            <div class="field">
+              <label for="attr-{{$t.ID}}">{{$t.Name}}{{with $t.Unit}} ({{.}}){{end}}</label>
+              {{if $t.IsNumeric}}
+                <input id="attr-{{$t.ID}}" type="number" step="any" name="attr_{{$t.ID}}" value="{{index $.AttrValues $t.ID}}">
+              {{else}}
+                <input id="attr-{{$t.ID}}" type="text" name="attr_{{$t.ID}}" value="{{index $.AttrValues $t.ID}}">
+              {{end}}
+            </div>
+          {{end}}
+          <button type="submit" class="btn">save attributes</button>
+          <p class="form__aside muted">leave a field empty to clear that attribute.</p>
+        </form>
+      {{else}}
+        <p class="muted">no attribute types defined.</p>
+      {{end}}
+    </section>
+  </div>
 
   <p class="form__aside"><a href="/admin/products">&larr; back to products</a></p>
+
+  <script>
+    (function () {
+      var tabs = document.querySelectorAll(".admin-tabs__btn");
+      var panels = document.querySelectorAll(".admin-tab");
+      function activate(name) {
+        var found = false;
+        tabs.forEach(function (b) {
+          var match = b.getAttribute("data-tab") === name;
+          if (match) { found = true; }
+          b.classList.toggle("is-active", match);
+          b.setAttribute("aria-selected", match ? "true" : "false");
+        });
+        if (!found) { return false; }
+        panels.forEach(function (p) {
+          if (p.getAttribute("data-tab") === name) {
+            p.removeAttribute("hidden");
+          } else {
+            p.setAttribute("hidden", "");
+          }
+        });
+        return true;
+      }
+      tabs.forEach(function (b) {
+        b.addEventListener("click", function () {
+          var name = b.getAttribute("data-tab");
+          if (activate(name)) {
+            history.replaceState(null, "", "#tab-" + name);
+          }
+        });
+      });
+      document.querySelectorAll("form[data-tab]").forEach(function (f) {
+        f.addEventListener("submit", function () {
+          try { sessionStorage.setItem("productEditTab", f.getAttribute("data-tab")); } catch (e) {}
+        });
+      });
+      var initial = "details";
+      if (location.hash && location.hash.indexOf("#tab-") === 0) {
+        initial = location.hash.substring(5);
+      } else {
+        try {
+          var saved = sessionStorage.getItem("productEditTab");
+          if (saved) { initial = saved; sessionStorage.removeItem("productEditTab"); }
+        } catch (e) {}
+      }
+      if (!activate(initial)) { activate("details"); }
+    })();
+  </script>
 {{end}}

--- a/backend/layout/tmpl/admin/product_new.gohtml
+++ b/backend/layout/tmpl/admin/product_new.gohtml
@@ -1,0 +1,27 @@
+{{define "main"}}
+  <p class="crumbs"><a href="/admin/products">products</a> / new</p>
+  <h2 class="account-card__title">add a product</h2>
+
+  <section class="admin-section">
+    <form class="form" method="post" action="/admin/products">
+      <div class="field"><label for="p-id">id (slug)</label><input id="p-id" name="id" required placeholder="lowercase-with-hyphens"></div>
+      <div class="field"><label for="p-name">name</label><input id="p-name" name="name" required></div>
+      <div class="field"><label for="p-description">description</label><textarea id="p-description" name="description" required></textarea></div>
+      <div class="field"><label for="p-price">price (major units, e.g. 9.00)</label><input id="p-price" name="price" required placeholder="9.00"></div>
+      <div class="field"><label for="p-currency">currency</label><input id="p-currency" name="currency" value="USD"></div>
+      <div class="field"><label for="p-thumbnail">thumbnail URL</label><input id="p-thumbnail" name="thumbnail"></div>
+      <div class="field">
+        <label for="p-attribute-set">attribute set</label>
+        <select id="p-attribute-set" name="attribute_set">
+          <option value="">&mdash; none &mdash;</option>
+          {{range $s := .AttributeSets}}<option value="{{$s.ID}}">{{$s.Name}}</option>{{end}}
+        </select>
+        <p class="form__aside muted">the set defines which attributes this product has (and their order). You can change it later.</p>
+      </div>
+      <button type="submit" class="btn">create product</button>
+    </form>
+  </section>
+
+  <p class="form__aside">Need options &amp; multiple variants? <a href="/admin/products/new-variant">Create a variant product &rarr;</a></p>
+  <p class="form__aside"><a href="/admin/products">&larr; back to products</a></p>
+{{end}}

--- a/backend/layout/tmpl/admin/products.gohtml
+++ b/backend/layout/tmpl/admin/products.gohtml
@@ -1,5 +1,11 @@
 {{define "main"}}
-  <h2 class="account-card__title">products</h2>
+  <div class="admin-page-head">
+    <h2 class="account-card__title">products</h2>
+    <div class="admin-page-head__actions">
+      <a href="/admin/products/new" class="btn">+ Add product</a>
+      <a href="/admin/products/new-variant" class="btn btn--ghost">+ Variant product</a>
+    </div>
+  </div>
 
   {{if .Products}}
     <table class="admin-table">
@@ -34,26 +40,4 @@
   {{else}}
     <p class="muted">no products yet.</p>
   {{end}}
-
-  <section class="admin-form">
-    <h3 class="account-card__title">add a product</h3>
-    <form class="form" method="post" action="/admin/products">
-      <div class="field"><label for="p-id">id (slug)</label><input id="p-id" name="id" required placeholder="lowercase-with-hyphens"></div>
-      <div class="field"><label for="p-name">name</label><input id="p-name" name="name" required></div>
-      <div class="field"><label for="p-description">description</label><textarea id="p-description" name="description" required></textarea></div>
-      <div class="field"><label for="p-price">price (major units, e.g. 9.00)</label><input id="p-price" name="price" required placeholder="9.00"></div>
-      <div class="field"><label for="p-currency">currency</label><input id="p-currency" name="currency" value="USD"></div>
-      <div class="field"><label for="p-thumbnail">thumbnail URL</label><input id="p-thumbnail" name="thumbnail"></div>
-      <div class="field">
-        <label for="p-attribute-set">attribute set</label>
-        <select id="p-attribute-set" name="attribute_set">
-          <option value="">&mdash; none &mdash;</option>
-          {{range $s := .AttributeSets}}<option value="{{$s.ID}}">{{$s.Name}}</option>{{end}}
-        </select>
-        <p class="form__aside muted">the set defines which attributes this product has (and their order). You can change it later.</p>
-      </div>
-      <button type="submit" class="btn">create product</button>
-    </form>
-    <p class="form__aside">Need options &amp; multiple variants? <a href="/admin/products/new-variant">Create a variant product &rarr;</a></p>
-  </section>
 {{end}}


### PR DESCRIPTION
Admin UX polish + README update.

- **Move product create off the list page** to `/admin/products/new` (mirrors `/admin/products/new-variant`). The list page gets clear `+ Add product` and `+ Variant product` action buttons instead of an inline form at the bottom.
- **Tab the product edit page** into Details / Options & variants / Attributes. All forms/actions unchanged — just wrapped in tab panels. Small vanilla-JS handler persists the active tab in `location.hash` + `sessionStorage` so sub-form saves (which 303-redirect) return to the right tab.
- **README**: add a Features section listing current storefront + admin capabilities (context map and quick start untouched).

## Test plan
- [x] build / vet / tests / lint green
- [x] docker: list page has the two action buttons (no inline form), `/admin/products/new` renders, real edit pages still 200, edit page shows three tab buttons + three `tab-*` panels