### PR TITLE
chore: storefront polish — structured logging, image uploads, SEO/a11y, search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,7 @@
 .vscode/
 
 __debug_bin
+
+# Uploaded admin images (bind-mounted in docker-compose).
+data/uploads/*
+!data/uploads/.gitkeep

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -23,5 +23,9 @@ RUN apk add --no-cache ca-certificates && adduser -D -u 10001 app
 WORKDIR /
 COPY --from=builder /build/cmd/web/webapp /webapp
 COPY --from=builder /build/layout/tmpl /layout/tmpl
+# /uploads is where the disk image store writes user-uploaded images. It is
+# usually backed by a docker volume in compose; we create it here so it exists
+# (and is writable by the unprivileged app user) even when no volume is mounted.
+RUN mkdir -p /uploads && chown app:app /uploads
 USER app:app
 ENTRYPOINT ["/webapp"]

--- a/backend/cmd/cli/main.go
+++ b/backend/cmd/cli/main.go
@@ -3,10 +3,10 @@ package main
 import (
 	"errors"
 	"fmt"
-	"log"
 
 	"github.com/ardanlabs/conf"
 	_ "github.com/lib/pq"
+	"github.com/sirupsen/logrus"
 	"github.com/uptrace/opentelemetry-go-extra/otelsql"
 )
 
@@ -19,16 +19,16 @@ func main() {
 			fmt.Println(conf.Usage("", &cfg))
 			return
 		}
-		log.Fatal(err)
+		logrus.WithError(err).Fatal("cannot parse configuration")
 	}
 
 	connString := cfg.Postgres.connectionString()
 	db, err := otelsql.Open("postgres", connString)
 	if err != nil {
-		log.Fatalf("cannot open connection to the DB: %s", err)
+		logrus.WithError(err).Fatal("cannot open connection to the DB")
 	}
 
 	defer func() { _ = db.Close() }()
 
-	Execute(db) 
+	Execute(db)
 }

--- a/backend/cmd/cli/productcatalog.go
+++ b/backend/cmd/cli/productcatalog.go
@@ -3,11 +3,11 @@ package main
 import (
 	"context"
 	"fmt"
-	"log"
 	"strconv"
 	"strings"
 
 	"github.com/bkielbasa/go-ecommerce/backend/productcatalog/app"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -76,12 +76,12 @@ Product with variants (each variant priced independently):
 
 	cmd.Flags().StringVarP(&id, "id", "", "", "product id")
 	if err := cmd.MarkFlagRequired("id"); err != nil {
-		log.Print(err)
+		logrus.WithError(err).Error("cannot mark --id flag as required")
 	}
 
 	cmd.Flags().StringVarP(&name, "name", "n", "", "product name")
 	if err := cmd.MarkFlagRequired("name"); err != nil {
-		log.Print(err)
+		logrus.WithError(err).Error("cannot mark --name flag as required")
 	}
 
 	cmd.Flags().Int64VarP(&price, "price", "", 0, "product price in minor units (e.g. cents) — for a simple product")

--- a/backend/cmd/web/config.go
+++ b/backend/cmd/web/config.go
@@ -6,6 +6,10 @@ type config struct {
 	ServerPort int `conf:"default:8080,SERVER_PORT"`
 	Postgres   postgresConfig
 	Env        string `conf:"default:dev"`
+	// UploadsDir is the host-side directory the disk image store writes to.
+	// It is also the directory the /uploads/* HTTP route serves from. The
+	// container default lines up with the docker-compose bind mount.
+	UploadsDir string `conf:"default:/uploads"`
 }
 
 type postgresConfig struct {

--- a/backend/cmd/web/main.go
+++ b/backend/cmd/web/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/bkielbasa/go-ecommerce/backend/internal/application"
 	"github.com/bkielbasa/go-ecommerce/backend/internal/dependency"
 	"github.com/bkielbasa/go-ecommerce/backend/internal/eventbus"
+	"github.com/bkielbasa/go-ecommerce/backend/internal/imagestore"
 	"github.com/bkielbasa/go-ecommerce/backend/internal/observability"
 	"github.com/bkielbasa/go-ecommerce/backend/layout"
 	"github.com/bkielbasa/go-ecommerce/backend/productcatalog"
@@ -93,7 +94,9 @@ func main() {
 
 	app.AddBoundedContext(cartBD)
 
-	app.AddBoundedContext(layout.New(logger, cartSrv, catalogService, authService, checkoutSrv, checkoutQry, shipSrv))
+	imgStore := imagestore.NewDisk(cfg.UploadsDir, "/uploads")
+
+	app.AddBoundedContext(layout.New(logger, cartSrv, catalogService, authService, checkoutSrv, checkoutQry, shipSrv, imgStore, cfg.UploadsDir))
 	app.AddBoundedContext(pcBD)
 	app.AddBoundedContext(authBD)
 	app.AddBoundedContext(checkoutBD)

--- a/backend/internal/https/panic.go
+++ b/backend/internal/https/panic.go
@@ -4,15 +4,18 @@ import (
 	"net/http"
 	"runtime/debug"
 
-	"log"
+	"github.com/sirupsen/logrus"
 )
 
-func WrapPanic(fn http.HandlerFunc) http.HandlerFunc {
+func WrapPanic(fn http.HandlerFunc, logger logrus.FieldLogger) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		defer func() {
-			if r := recover(); r != nil {
+			if rec := recover(); rec != nil {
 				http.Error(w, "Internal Server Error", http.StatusInternalServerError)
-				log.Printf("Panic: %v\nStack trace: %+v", r, string(debug.Stack()))
+				logger.WithFields(logrus.Fields{
+					"panic": rec,
+					"stack": string(debug.Stack()),
+				}).Error("panic recovered in HTTP handler")
 			}
 		}()
 

--- a/backend/internal/imagestore/imagestore.go
+++ b/backend/internal/imagestore/imagestore.go
@@ -1,0 +1,134 @@
+// Package imagestore provides a small interface for persisting uploaded
+// images plus a local-disk implementation. The interface is intentionally
+// narrow so an S3 (or other) backend can be swapped in later without
+// touching call sites.
+package imagestore
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// MaxImageSize is the largest image (in bytes) the disk store will accept.
+const MaxImageSize int64 = 5 << 20 // 5 MiB
+
+// ErrUnsupportedType is returned when the uploaded content type is not in the
+// allow-list.
+var ErrUnsupportedType = errors.New("unsupported image type")
+
+// ErrTooLarge is returned when the uploaded bytes exceed MaxImageSize.
+var ErrTooLarge = errors.New("image too large")
+
+// Store persists an uploaded image and returns the public URL where it will
+// be served.
+type Store interface {
+	// Save persists the uploaded file and returns the public URL it will be
+	// served at (e.g. "/uploads/ab/cdef1234.jpg"). filename is the original
+	// upload name (used for the extension fallback); contentType is the MIME
+	// type from the upload header.
+	Save(ctx context.Context, filename string, contentType string, r io.Reader) (string, error)
+}
+
+// extByContentType maps an allowed MIME type to a canonical file extension.
+var extByContentType = map[string]string{
+	"image/jpeg": ".jpg",
+	"image/png":  ".png",
+	"image/webp": ".webp",
+	"image/gif":  ".gif",
+}
+
+// Disk is a Store that writes images to a local directory. Files are
+// content-addressed (sha256), so identical uploads are de-duplicated.
+type Disk struct {
+	root      string
+	urlPrefix string
+}
+
+// NewDisk constructs a Disk store rooted at root that serves files under the
+// given URL prefix (e.g. "/uploads"). The root directory is created on first
+// write (per upload).
+func NewDisk(root, urlPrefix string) *Disk {
+	if urlPrefix == "" {
+		urlPrefix = "/uploads"
+	}
+	urlPrefix = strings.TrimRight(urlPrefix, "/")
+	return &Disk{root: root, urlPrefix: urlPrefix}
+}
+
+// Save implements Store. It enforces a 5 MiB size cap and a content-type
+// allow-list (jpeg / png / webp / gif) before writing.
+func (d *Disk) Save(_ context.Context, filename, contentType string, r io.Reader) (string, error) {
+	ct := strings.ToLower(strings.TrimSpace(contentType))
+	// Some clients send "image/jpg" instead of the canonical "image/jpeg".
+	if ct == "image/jpg" {
+		ct = "image/jpeg"
+	}
+	ext, ok := extByContentType[ct]
+	if !ok {
+		// Fall back to the filename extension if it is in the allow-list — this
+		// keeps the store working when a client sends an empty/unknown
+		// content-type but a sensible filename.
+		fallback := strings.ToLower(filepath.Ext(filename))
+		switch fallback {
+		case ".jpg", ".jpeg":
+			ext = ".jpg"
+		case ".png":
+			ext = ".png"
+		case ".webp":
+			ext = ".webp"
+		case ".gif":
+			ext = ".gif"
+		default:
+			return "", ErrUnsupportedType
+		}
+	}
+
+	// Read into memory with a +1 cap so we can detect oversize input without
+	// silently truncating it.
+	limited := io.LimitReader(r, MaxImageSize+1)
+	buf, err := io.ReadAll(limited)
+	if err != nil {
+		return "", fmt.Errorf("read image: %w", err)
+	}
+	if int64(len(buf)) > MaxImageSize {
+		return "", ErrTooLarge
+	}
+
+	sum := sha256.Sum256(buf)
+	hash := hex.EncodeToString(sum[:])
+	bucket := hash[:2]
+	relDir := bucket
+	relPath := filepath.Join(relDir, hash+ext)
+
+	dir := filepath.Join(d.root, relDir)
+	if err = os.MkdirAll(dir, 0o755); err != nil {
+		return "", fmt.Errorf("mkdir uploads: %w", err)
+	}
+	full := filepath.Join(d.root, relPath)
+	// Skip the write if a file with this hash already exists — content is
+	// identical by construction (sha256 collision aside).
+	if _, statErr := os.Stat(full); statErr != nil {
+		if err = os.WriteFile(full, buf, 0o644); err != nil {
+			return "", fmt.Errorf("write image: %w", err)
+		}
+	}
+
+	// Always use forward slashes in URLs even on Windows.
+	url := d.urlPrefix + "/" + bucket + "/" + hash + ext
+	return url, nil
+}
+
+// Serve returns an http.Handler that serves files from root under the
+// "/uploads/" URL prefix. It is intended to be wired alongside the Disk
+// store's urlPrefix.
+func Serve(root string) http.Handler {
+	return http.StripPrefix("/uploads/", http.FileServer(http.Dir(root)))
+}

--- a/backend/internal/imagestore/imagestore_test.go
+++ b/backend/internal/imagestore/imagestore_test.go
@@ -1,0 +1,90 @@
+package imagestore
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// pngBytes is the smallest possible valid-ish PNG payload: it is enough that
+// the disk store hashes it and writes it back out unchanged. The store does
+// not validate PNG structure itself.
+var pngBytes = []byte{
+	0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, // PNG signature
+	0x00, 0x00, 0x00, 0x0d, // IHDR length
+	'I', 'H', 'D', 'R',
+	0x00, 0x00, 0x00, 0x01, // width = 1
+	0x00, 0x00, 0x00, 0x01, // height = 1
+	0x08, 0x00, 0x00, 0x00, 0x00,
+}
+
+func TestDiskSaveWritesFileAndReturnsExpectedURL(t *testing.T) {
+	dir := t.TempDir()
+	store := NewDisk(dir, "/uploads")
+
+	url, err := store.Save(context.Background(), "tiny.png", "image/png", bytes.NewReader(pngBytes))
+	if err != nil {
+		t.Fatalf("Save returned error: %v", err)
+	}
+
+	sum := sha256.Sum256(pngBytes)
+	hash := hex.EncodeToString(sum[:])
+	wantURL := "/uploads/" + hash[:2] + "/" + hash + ".png"
+	if url != wantURL {
+		t.Fatalf("unexpected URL\n got: %q\nwant: %q", url, wantURL)
+	}
+
+	want := filepath.Join(dir, hash[:2], hash+".png")
+	got, err := os.ReadFile(want)
+	if err != nil {
+		t.Fatalf("expected file at %s: %v", want, err)
+	}
+	if !bytes.Equal(got, pngBytes) {
+		t.Fatalf("file contents differ from input")
+	}
+}
+
+func TestDiskSaveRejectsUnsupportedType(t *testing.T) {
+	store := NewDisk(t.TempDir(), "/uploads")
+
+	_, err := store.Save(context.Background(), "evil.exe", "application/octet-stream", bytes.NewReader([]byte("hello")))
+	if !errors.Is(err, ErrUnsupportedType) {
+		t.Fatalf("expected ErrUnsupportedType, got %v", err)
+	}
+}
+
+func TestDiskSaveRejectsOversizedInput(t *testing.T) {
+	store := NewDisk(t.TempDir(), "/uploads")
+
+	big := bytes.NewReader(make([]byte, MaxImageSize+10))
+	_, err := store.Save(context.Background(), "big.png", "image/png", big)
+	if !errors.Is(err, ErrTooLarge) {
+		t.Fatalf("expected ErrTooLarge, got %v", err)
+	}
+}
+
+func TestDiskSaveDeduplicates(t *testing.T) {
+	dir := t.TempDir()
+	store := NewDisk(dir, "/uploads")
+
+	url1, err := store.Save(context.Background(), "a.png", "image/png", bytes.NewReader(pngBytes))
+	if err != nil {
+		t.Fatalf("first Save: %v", err)
+	}
+	url2, err := store.Save(context.Background(), "b.png", "image/png", bytes.NewReader(pngBytes))
+	if err != nil {
+		t.Fatalf("second Save: %v", err)
+	}
+	if url1 != url2 {
+		t.Fatalf("expected dedupe to return same URL, got %q vs %q", url1, url2)
+	}
+	if !strings.HasPrefix(url1, "/uploads/") {
+		t.Fatalf("expected /uploads/ prefix, got %q", url1)
+	}
+}

--- a/backend/internal/observability/http.go
+++ b/backend/internal/observability/http.go
@@ -8,5 +8,5 @@ import (
 )
 
 func HTTPWrap(h http.HandlerFunc, logger logrus.FieldLogger) http.HandlerFunc {
-	return LoggerMiddleware(https.WrapPanic(h), logger)
+	return LoggerMiddleware(https.WrapPanic(h, logger), logger)
 }

--- a/backend/layout/bounded_context.go
+++ b/backend/layout/bounded_context.go
@@ -104,6 +104,7 @@ func New(logger logrus.FieldLogger, cartSrv cartService, catalogSrv catalogServi
 			checkoutSrv: checkoutSrv,
 			checkoutQry: checkoutQry,
 			shipSrv:     shipSrv,
+			logger:      logger,
 		},
 		logger: logger,
 	}

--- a/backend/layout/bounded_context.go
+++ b/backend/layout/bounded_context.go
@@ -9,6 +9,7 @@ import (
 	checkoutDomain "github.com/bkielbasa/go-ecommerce/backend/checkout/domain"
 	checkoutQuery "github.com/bkielbasa/go-ecommerce/backend/checkout/query"
 	"github.com/bkielbasa/go-ecommerce/backend/internal/application"
+	"github.com/bkielbasa/go-ecommerce/backend/internal/imagestore"
 	pcapp "github.com/bkielbasa/go-ecommerce/backend/productcatalog/app"
 	pcdomain "github.com/bkielbasa/go-ecommerce/backend/productcatalog/domain"
 	shipDomain "github.com/bkielbasa/go-ecommerce/backend/shippinginfo/domain"
@@ -95,7 +96,7 @@ type checkoutQueries interface {
 	ListAll(ctx context.Context) ([]checkoutQuery.OrderSummary, error)
 }
 
-func New(logger logrus.FieldLogger, cartSrv cartService, catalogSrv catalogService, authSrv authService, checkoutSrv checkoutCommands, checkoutQry checkoutQueries, shipSrv shippingService) application.BoundedContext {
+func New(logger logrus.FieldLogger, cartSrv cartService, catalogSrv catalogService, authSrv authService, checkoutSrv checkoutCommands, checkoutQry checkoutQueries, shipSrv shippingService, imageStore imagestore.Store, uploadsDir string) application.BoundedContext {
 	return &boundedContext{
 		handler: httpHandler{
 			cartSrv:     cartSrv,
@@ -104,13 +105,16 @@ func New(logger logrus.FieldLogger, cartSrv cartService, catalogSrv catalogServi
 			checkoutSrv: checkoutSrv,
 			checkoutQry: checkoutQry,
 			shipSrv:     shipSrv,
+			imageStore:  imageStore,
 			logger:      logger,
 		},
-		logger: logger,
+		uploadsDir: uploadsDir,
+		logger:     logger,
 	}
 }
 
 type boundedContext struct {
-	handler httpHandler
-	logger  logrus.FieldLogger
+	handler    httpHandler
+	uploadsDir string
+	logger     logrus.FieldLogger
 }

--- a/backend/layout/http.go
+++ b/backend/layout/http.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/bkielbasa/go-ecommerce/backend/internal/imagestore"
 	"github.com/bkielbasa/go-ecommerce/backend/internal/observability"
 	"github.com/gorilla/mux"
 	"github.com/gorilla/sessions"
@@ -43,6 +44,7 @@ type httpHandler struct {
 	checkoutSrv checkoutCommands
 	checkoutQry checkoutQueries
 	shipSrv     shippingService
+	imageStore  imagestore.Store
 	logger      logrus.FieldLogger
 }
 
@@ -97,6 +99,9 @@ func (handler httpHandler) renderProductsPage(w http.ResponseWriter, r *http.Req
 
 func (m boundedContext) MuxRegister(r *mux.Router) {
 	r.PathPrefix("/static/").Handler(StaticHandler())
+	// User-uploaded images live on disk (see internal/imagestore) and are
+	// served from m.uploadsDir under the /uploads/ URL prefix.
+	r.PathPrefix("/uploads/").Handler(imagestore.Serve(m.uploadsDir))
 	r.HandleFunc("/", m.handler.HomePage)
 	r.HandleFunc("/products", observability.HTTPWrap(m.handler.ShopPage, m.logger)).Methods("GET")
 	r.HandleFunc("/category/{slug}", observability.HTTPWrap(m.handler.CategoryPage, m.logger)).Methods("GET")

--- a/backend/layout/http.go
+++ b/backend/layout/http.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"html/template"
-	"log"
 	"net/http"
 	"path/filepath"
 	"strings"
@@ -12,6 +11,7 @@ import (
 	"github.com/bkielbasa/go-ecommerce/backend/internal/observability"
 	"github.com/gorilla/mux"
 	"github.com/gorilla/sessions"
+	"github.com/sirupsen/logrus"
 )
 
 var (
@@ -43,6 +43,7 @@ type httpHandler struct {
 	checkoutSrv checkoutCommands
 	checkoutQry checkoutQueries
 	shipSrv     shippingService
+	logger      logrus.FieldLogger
 }
 
 // HomePage renders the storefront landing page: a "new arrivals" grid of the
@@ -50,7 +51,7 @@ type httpHandler struct {
 func (handler httpHandler) HomePage(w http.ResponseWriter, r *http.Request) {
 	newest, err := handler.catalogSrv.Newest(r.Context(), 8)
 	if err != nil {
-		log.Printf("cannot get newest products: %s", err)
+		handler.logger.WithError(err).Warn("cannot get newest products")
 		newest = nil
 	}
 	handler.renderTemplate(w, r, "home", map[string]any{
@@ -77,13 +78,13 @@ func (handler httpHandler) CategoryPage(w http.ResponseWriter, r *http.Request) 
 func (handler httpHandler) renderProductsPage(w http.ResponseWriter, r *http.Request, activeCategory string) {
 	categories, err := handler.catalogSrv.Categories(r.Context())
 	if err != nil {
-		log.Printf("cannot get categories: %s", err)
+		handler.logger.WithError(err).Warn("cannot get categories")
 		categories = nil
 	}
 
 	facets, err := handler.catalogSrv.Facets(r.Context(), activeCategory)
 	if err != nil {
-		log.Printf("cannot get facets for %q: %s", activeCategory, err)
+		handler.logger.WithError(err).WithField("category", activeCategory).Warn("cannot get facets")
 		facets = nil
 	}
 
@@ -210,19 +211,19 @@ func (handler httpHandler) renderTemplate(w http.ResponseWriter, r *http.Request
 	// NavCategories lets the storefront header list category links on every page.
 	navCategories, err := handler.catalogSrv.Categories(r.Context())
 	if err != nil {
-		log.Printf("cannot get nav categories: %s", err)
+		handler.logger.WithError(err).Warn("cannot get nav categories")
 		navCategories = nil
 	}
 	data["NavCategories"] = navCategories
 	err = session.Save(r, w)
 	if err != nil {
-		log.Print(err.Error())
+		handler.logger.WithError(err).Error("cannot save session")
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 	}
 
 	err = ts.ExecuteTemplate(w, "base", data)
 	if err != nil {
-		log.Print(err.Error())
+		handler.logger.WithError(err).Error("cannot execute template")
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 	}
 }
@@ -259,13 +260,13 @@ func (handler httpHandler) renderAdminTemplate(w http.ResponseWriter, r *http.Re
 	data["AdminEmail"] = handler.currentCustomerID(r)
 	err := session.Save(r, w)
 	if err != nil {
-		log.Print(err.Error())
+		handler.logger.WithError(err).Error("cannot save session")
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 	}
 
 	err = ts.ExecuteTemplate(w, "adminbase", data)
 	if err != nil {
-		log.Print(err.Error())
+		handler.logger.WithError(err).Error("cannot execute admin template")
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 	}
 }

--- a/backend/layout/http.go
+++ b/backend/layout/http.go
@@ -102,6 +102,10 @@ func (m boundedContext) MuxRegister(r *mux.Router) {
 	// User-uploaded images live on disk (see internal/imagestore) and are
 	// served from m.uploadsDir under the /uploads/ URL prefix.
 	r.PathPrefix("/uploads/").Handler(imagestore.Serve(m.uploadsDir))
+	// SEO endpoints. Registered before the "/" catch-all so they are not
+	// shadowed by the home page route. Both are public (no admin gate).
+	r.HandleFunc("/robots.txt", observability.HTTPWrap(m.handler.Robots, m.logger)).Methods("GET")
+	r.HandleFunc("/sitemap.xml", observability.HTTPWrap(m.handler.Sitemap, m.logger)).Methods("GET")
 	r.HandleFunc("/", m.handler.HomePage)
 	r.HandleFunc("/products", observability.HTTPWrap(m.handler.ShopPage, m.logger)).Methods("GET")
 	r.HandleFunc("/category/{slug}", observability.HTTPWrap(m.handler.CategoryPage, m.logger)).Methods("GET")
@@ -204,7 +208,8 @@ func (handler httpHandler) renderTemplate(w http.ResponseWriter, r *http.Request
 		"html": func(value interface{}) template.HTML {
 			return template.HTML(fmt.Sprint(value))
 		},
-		"add": func(a, b int) int { return a + b },
+		"add":      func(a, b int) int { return a + b },
+		"truncate": truncateForMeta,
 	}).ParseFiles(files...))
 
 	session, _ := store.Get(r, "ecommerce")
@@ -213,6 +218,12 @@ func (handler httpHandler) renderTemplate(w http.ResponseWriter, r *http.Request
 	data["AuthMenuItem"] = renderPartial(w, r, http.HandlerFunc(handler.AuthMenuItem))
 	data["LoggedIn"] = handler.currentCustomerID(r) != ""
 	data["IsAdmin"] = handler.isAdmin(r)
+	// SEO helpers consumed by the base template's title/og/canonical blocks.
+	// SiteName is the brand suffix in <title> ("Foo · GoCommerce"); CanonicalURL
+	// is the absolute URL for the current request (scheme + host + path), used
+	// for <link rel=canonical> and og:url.
+	data["SiteName"] = "GoCommerce"
+	data["CanonicalURL"] = requestBaseURL(r) + r.URL.Path
 	// NavCategories lets the storefront header list category links on every page.
 	navCategories, err := handler.catalogSrv.Categories(r.Context())
 	if err != nil {

--- a/backend/layout/http.go
+++ b/backend/layout/http.go
@@ -94,6 +94,7 @@ func (handler httpHandler) renderProductsPage(w http.ResponseWriter, r *http.Req
 		"Categories":     categories,
 		"Facets":         facets,
 		"ActiveCategory": activeCategory,
+		"Search":         "",
 	})
 }
 
@@ -106,6 +107,8 @@ func (m boundedContext) MuxRegister(r *mux.Router) {
 	// shadowed by the home page route. Both are public (no admin gate).
 	r.HandleFunc("/robots.txt", observability.HTTPWrap(m.handler.Robots, m.logger)).Methods("GET")
 	r.HandleFunc("/sitemap.xml", observability.HTTPWrap(m.handler.Sitemap, m.logger)).Methods("GET")
+	// Public search page. Registered before the "/" catch-all.
+	r.HandleFunc("/search", observability.HTTPWrap(m.handler.SearchPage, m.logger)).Methods("GET")
 	r.HandleFunc("/", m.handler.HomePage)
 	r.HandleFunc("/products", observability.HTTPWrap(m.handler.ShopPage, m.logger)).Methods("GET")
 	r.HandleFunc("/category/{slug}", observability.HTTPWrap(m.handler.CategoryPage, m.logger)).Methods("GET")
@@ -231,6 +234,12 @@ func (handler httpHandler) renderTemplate(w http.ResponseWriter, r *http.Request
 		navCategories = nil
 	}
 	data["NavCategories"] = navCategories
+	// SearchQuery is the value the header search input shows. It defaults to
+	// "" so every page renders the box; the search/catalog pages override it
+	// from the URL `q`.
+	if _, ok := data["SearchQuery"]; !ok {
+		data["SearchQuery"] = ""
+	}
 	err = session.Save(r, w)
 	if err != nil {
 		handler.logger.WithError(err).Error("cannot save session")

--- a/backend/layout/http_admin_products.go
+++ b/backend/layout/http_admin_products.go
@@ -3,6 +3,7 @@ package layout
 import (
 	"errors"
 	"math"
+	"mime/multipart"
 	"net/http"
 	"strconv"
 	"strings"
@@ -10,6 +11,42 @@ import (
 	pcapp "github.com/bkielbasa/go-ecommerce/backend/productcatalog/app"
 	"github.com/gorilla/mux"
 )
+
+// maxMultipartSize caps multipart form parsing. The biggest payload is one
+// image (5 MiB, enforced again inside the image store) plus the other text
+// fields, so we give a small headroom for those.
+const maxMultipartSize int64 = 6 << 20
+
+// resolveImage prefers an uploaded file over a typed-in URL: if the form has a
+// file at fileField, it is saved through the image store and the resulting
+// public URL is returned. Otherwise the trimmed value of urlField is returned.
+// Returns ("", nil) when neither is provided.
+func (handler httpHandler) resolveImage(r *http.Request, fileField, urlField string) (string, error) {
+	f, fh, err := r.FormFile(fileField)
+	if err != nil {
+		if errors.Is(err, http.ErrMissingFile) {
+			return strings.TrimSpace(r.FormValue(urlField)), nil
+		}
+		return "", err
+	}
+	defer func() { _ = f.Close() }()
+	return handler.imageStore.Save(r.Context(), fh.Filename, fh.Header.Get("Content-Type"), f)
+}
+
+// resolveImageFromHeader is the parallel-array variant of resolveImage used by
+// the variant-create form. Caller passes the FileHeader (or nil) and the
+// fallback URL string. A nil header returns the trimmed URL.
+func (handler httpHandler) resolveImageFromHeader(r *http.Request, fh *multipart.FileHeader, urlValue string) (string, error) {
+	if fh == nil {
+		return strings.TrimSpace(urlValue), nil
+	}
+	f, err := fh.Open()
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = f.Close() }()
+	return handler.imageStore.Save(r.Context(), fh.Filename, fh.Header.Get("Content-Type"), f)
+}
 
 // parsePriceMinorUnits parses a decimal major-units price string (e.g. "9.00"
 // or "9.5") into integer minor units (cents). It rejects negative or malformed
@@ -70,7 +107,7 @@ func (handler httpHandler) AdminCreateProduct(w http.ResponseWriter, r *http.Req
 	if _, ok := handler.requireAdmin(w, r); !ok {
 		return
 	}
-	_ = r.ParseForm()
+	_ = r.ParseMultipartForm(maxMultipartSize)
 	id := strings.TrimSpace(r.FormValue("id"))
 	currency := strings.TrimSpace(r.FormValue("currency"))
 	if currency == "" {
@@ -82,7 +119,13 @@ func (handler httpHandler) AdminCreateProduct(w http.ResponseWriter, r *http.Req
 		http.Redirect(w, r, "/admin/products", http.StatusSeeOther)
 		return
 	}
-	err = handler.catalogSrv.Add(r.Context(), id, r.FormValue("name"), r.FormValue("description"), price, currency, r.FormValue("thumbnail"))
+	thumbnail, err := handler.resolveImage(r, "thumbnail_file", "thumbnail")
+	if err != nil {
+		handler.flash(w, r, err.Error(), "error")
+		http.Redirect(w, r, "/admin/products", http.StatusSeeOther)
+		return
+	}
+	err = handler.catalogSrv.Add(r.Context(), id, r.FormValue("name"), r.FormValue("description"), price, currency, thumbnail)
 	if err != nil {
 		handler.flash(w, r, err.Error(), "error")
 		http.Redirect(w, r, "/admin/products", http.StatusSeeOther)
@@ -171,7 +214,7 @@ func (handler httpHandler) AdminUpdateProduct(w http.ResponseWriter, r *http.Req
 		return
 	}
 	id := mux.Vars(r)["id"]
-	_ = r.ParseForm()
+	_ = r.ParseMultipartForm(maxMultipartSize)
 	currency := strings.TrimSpace(r.FormValue("currency"))
 	if currency == "" {
 		currency = "USD"
@@ -182,7 +225,13 @@ func (handler httpHandler) AdminUpdateProduct(w http.ResponseWriter, r *http.Req
 		http.Redirect(w, r, "/admin/products/"+id+"/edit", http.StatusSeeOther)
 		return
 	}
-	err = handler.catalogSrv.UpdateProduct(r.Context(), id, r.FormValue("name"), r.FormValue("description"), price, currency, r.FormValue("thumbnail"))
+	thumbnail, err := handler.resolveImage(r, "thumbnail_file", "thumbnail")
+	if err != nil {
+		handler.flash(w, r, err.Error(), "error")
+		http.Redirect(w, r, "/admin/products/"+id+"/edit", http.StatusSeeOther)
+		return
+	}
+	err = handler.catalogSrv.UpdateProduct(r.Context(), id, r.FormValue("name"), r.FormValue("description"), price, currency, thumbnail)
 	if err != nil {
 		handler.flash(w, r, err.Error(), "error")
 	} else {
@@ -352,7 +401,7 @@ func (handler httpHandler) AdminCreateVariantProduct(w http.ResponseWriter, r *h
 	if _, ok := handler.requireAdmin(w, r); !ok {
 		return
 	}
-	_ = r.ParseForm()
+	_ = r.ParseMultipartForm(maxMultipartSize)
 	id := strings.TrimSpace(r.FormValue("id"))
 	currency := strings.TrimSpace(r.FormValue("currency"))
 	if currency == "" {
@@ -397,15 +446,30 @@ func (handler httpHandler) AdminCreateVariantProduct(w http.ResponseWriter, r *h
 	vStocks := r.Form["v_stock[]"]
 	vImages := r.Form["v_image[]"]
 	vOptions := r.Form["v_options[]"]
+	// Parallel uploaded files (may be nil if there is no multipart form).
+	var vImageFiles []*multipart.FileHeader
+	if r.MultipartForm != nil {
+		vImageFiles = r.MultipartForm.File["v_image_file[]"]
+	}
 	var variants []pcapp.VariantInput
 	for i := range vPrices {
 		sku := ""
 		if i < len(vSKUs) {
 			sku = strings.TrimSpace(vSKUs[i])
 		}
-		image := ""
+		urlImage := ""
 		if i < len(vImages) {
-			image = strings.TrimSpace(vImages[i])
+			urlImage = vImages[i]
+		}
+		var fh *multipart.FileHeader
+		if i < len(vImageFiles) {
+			fh = vImageFiles[i]
+		}
+		image, imgErr := handler.resolveImageFromHeader(r, fh, urlImage)
+		if imgErr != nil {
+			handler.flash(w, r, imgErr.Error(), "error")
+			http.Redirect(w, r, back, http.StatusSeeOther)
+			return
 		}
 		optsRaw := ""
 		if i < len(vOptions) {
@@ -461,7 +525,13 @@ func (handler httpHandler) AdminCreateVariantProduct(w http.ResponseWriter, r *h
 		return
 	}
 
-	err := handler.catalogSrv.AddVariantProduct(r.Context(), id, r.FormValue("name"), r.FormValue("description"), currency, r.FormValue("thumbnail"), optionTypes, variants)
+	thumbnail, err := handler.resolveImage(r, "thumbnail_file", "thumbnail")
+	if err != nil {
+		handler.flash(w, r, err.Error(), "error")
+		http.Redirect(w, r, back, http.StatusSeeOther)
+		return
+	}
+	err = handler.catalogSrv.AddVariantProduct(r.Context(), id, r.FormValue("name"), r.FormValue("description"), currency, thumbnail, optionTypes, variants)
 	if err != nil {
 		handler.flash(w, r, err.Error(), "error")
 		http.Redirect(w, r, back, http.StatusSeeOther)
@@ -511,7 +581,7 @@ func (handler httpHandler) AdminAddVariant(w http.ResponseWriter, r *http.Reques
 		http.Redirect(w, r, "/admin/products", http.StatusSeeOther)
 		return
 	}
-	_ = r.ParseForm()
+	_ = r.ParseMultipartForm(maxMultipartSize)
 	options := map[string]string{}
 	for _, ot := range product.OptionTypes() {
 		options[ot.Name()] = strings.TrimSpace(r.FormValue("opt_" + ot.Name()))
@@ -536,7 +606,13 @@ func (handler httpHandler) AdminAddVariant(w http.ResponseWriter, r *http.Reques
 		}
 		stock = s
 	}
-	err = handler.catalogSrv.AddVariantToProduct(r.Context(), id, r.FormValue("sku"), r.FormValue("image"), price, currency, stock, options)
+	image, err := handler.resolveImage(r, "image_file", "image")
+	if err != nil {
+		handler.flash(w, r, err.Error(), "error")
+		http.Redirect(w, r, "/admin/products/"+id+"/edit", http.StatusSeeOther)
+		return
+	}
+	err = handler.catalogSrv.AddVariantToProduct(r.Context(), id, r.FormValue("sku"), image, price, currency, stock, options)
 	if err != nil {
 		handler.flash(w, r, err.Error(), "error")
 	} else {
@@ -558,7 +634,7 @@ func (handler httpHandler) AdminUpdateVariant(w http.ResponseWriter, r *http.Req
 		http.Redirect(w, r, "/admin/products", http.StatusSeeOther)
 		return
 	}
-	_ = r.ParseForm()
+	_ = r.ParseMultipartForm(maxMultipartSize)
 	currency := strings.TrimSpace(r.FormValue("currency"))
 	if currency == "" {
 		currency = product.Price().Currency().String()
@@ -579,7 +655,13 @@ func (handler httpHandler) AdminUpdateVariant(w http.ResponseWriter, r *http.Req
 		}
 		stock = s
 	}
-	err = handler.catalogSrv.UpdateVariant(r.Context(), variantID, r.FormValue("sku"), r.FormValue("image"), price, currency, stock)
+	image, err := handler.resolveImage(r, "image_file", "image")
+	if err != nil {
+		handler.flash(w, r, err.Error(), "error")
+		http.Redirect(w, r, "/admin/products/"+id+"/edit", http.StatusSeeOther)
+		return
+	}
+	err = handler.catalogSrv.UpdateVariant(r.Context(), variantID, r.FormValue("sku"), image, price, currency, stock)
 	if err != nil {
 		handler.flash(w, r, err.Error(), "error")
 	} else {

--- a/backend/layout/http_auth.go
+++ b/backend/layout/http_auth.go
@@ -3,7 +3,6 @@ package layout
 import (
   "errors"
 	"html/template"
-	"log"
   "os"
   "io"
 	"net/http"
@@ -18,7 +17,7 @@ func (handler httpHandler) Login(w http.ResponseWriter, r *http.Request) {
 func (handler httpHandler) AuthMenuItem(w http.ResponseWriter, r *http.Request) {
   c, err := store.Get(r, "ecommerce")
 	if err != nil {
-		log.Print(err.Error())
+		handler.logger.WithError(err).Error("cannot get session store")
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
 	}
@@ -35,7 +34,7 @@ func (handler httpHandler) AuthMenuItem(w http.ResponseWriter, r *http.Request) 
 
   f, err := os.Open("./layout/tmpl/auth/menuItem.gohtml")
 	if err != nil {
-		log.Print(err.Error())
+		handler.logger.WithError(err).Error("cannot open menu item template")
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
 	}
@@ -43,14 +42,14 @@ func (handler httpHandler) AuthMenuItem(w http.ResponseWriter, r *http.Request) 
 
   body, err := io.ReadAll(f)
 	if err != nil {
-		log.Print(err.Error())
+		handler.logger.WithError(err).Error("cannot read menu item template")
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
 	}
 
   tmpl, err := template.New("").Parse(string(body))
 	if err != nil {
-		log.Print(err.Error())
+		handler.logger.WithError(err).Error("cannot parse menu item template")
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
 	}
@@ -59,7 +58,7 @@ func (handler httpHandler) AuthMenuItem(w http.ResponseWriter, r *http.Request) 
     "LoggedIn": loggedIn,
   })
 	if err != nil {
-		log.Print(err.Error())
+		handler.logger.WithError(err).Error("cannot execute menu item template")
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 	}
 }

--- a/backend/layout/http_cart.go
+++ b/backend/layout/http_cart.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"html/template"
-	"log"
 	"math/rand"
 	"net/http"
 	"time"
@@ -32,7 +31,7 @@ func (handler httpHandler) AddToCart(w http.ResponseWriter, r *http.Request) {
 
 	if err != nil {
 		https.InternalError(w, "internal-error", err.Error())
-		log.Print(err)
+		handler.logger.WithError(err).Error("cannot add item to cart")
 		return
 	}
 

--- a/backend/layout/http_product.go
+++ b/backend/layout/http_product.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"html/template"
-	"log"
 	"net/http"
 	"strconv"
 
@@ -32,7 +31,7 @@ func (handler httpHandler) AllProducts(w http.ResponseWriter, r *http.Request) {
 	// Use the facets for this scope to know which params are numeric vs enum.
 	facets, err := handler.catalogSrv.Facets(ctx, category)
 	if err != nil {
-		log.Printf("cannot get facets for %q: %s", category, err)
+		handler.logger.WithError(err).WithField("category", category).Warn("cannot get facets")
 		facets = nil
 	}
 
@@ -70,7 +69,7 @@ func (handler httpHandler) AllProducts(w http.ResponseWriter, r *http.Request) {
 	products, err := handler.catalogSrv.List(ctx, query)
 	if err != nil {
 		https.InternalError(w, "internal-error", "cannot get list of all products")
-		log.Printf("cannot get list of all products: %s", err)
+		handler.logger.WithError(err).Error("cannot get list of all products")
 		return
 	}
 

--- a/backend/layout/http_product.go
+++ b/backend/layout/http_product.go
@@ -6,6 +6,7 @@ import (
 	"html/template"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"github.com/bkielbasa/go-ecommerce/backend/cart/domain"
 	"github.com/bkielbasa/go-ecommerce/backend/internal/https"
@@ -21,11 +22,13 @@ func (handler httpHandler) AllProducts(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	q := r.URL.Query()
 	category := q.Get("category")
+	search := strings.TrimSpace(q.Get("q"))
 
 	query := pcapp.ProductQuery{
 		CategorySlug:   category,
 		NumericRanges:  map[string]pcapp.Range{},
 		EnumSelections: map[string][]string{},
+		Search:         search,
 	}
 
 	// Use the facets for this scope to know which params are numeric vs enum.
@@ -75,6 +78,7 @@ func (handler httpHandler) AllProducts(w http.ResponseWriter, r *http.Request) {
 
 	resp := map[string]any{
 		"Products": products,
+		"Search":   search,
 	}
 
 	files := []string{

--- a/backend/layout/http_search.go
+++ b/backend/layout/http_search.go
@@ -1,0 +1,37 @@
+package layout
+
+import (
+	"net/http"
+	"strings"
+)
+
+// SearchPage renders the storefront search results page. It reuses the catalog
+// template (filter rail + lazy grid) with no active category; the actual search
+// term is forwarded to the lazy /api/v1/products fetch via the ActiveCategory/
+// Search data the catalog template encodes into its hx-get URL.
+func (handler httpHandler) SearchPage(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	q := strings.TrimSpace(r.URL.Query().Get("q"))
+
+	categories, err := handler.catalogSrv.Categories(ctx)
+	if err != nil {
+		handler.logger.WithError(err).Warn("cannot get categories")
+		categories = nil
+	}
+
+	// Search shows the cross-catalog facets (no category scope). The user can
+	// still narrow with the rail; the hidden q input keeps the search active.
+	facets, err := handler.catalogSrv.Facets(ctx, "")
+	if err != nil {
+		handler.logger.WithError(err).Warn("cannot get facets")
+		facets = nil
+	}
+
+	handler.renderTemplate(w, r, "productCatalog/catalog", map[string]any{
+		"Categories":     categories,
+		"Facets":         facets,
+		"ActiveCategory": "",
+		"Search":         q,
+		"SearchQuery":    q,
+	})
+}

--- a/backend/layout/http_seo.go
+++ b/backend/layout/http_seo.go
@@ -1,0 +1,119 @@
+package layout
+
+import (
+	"encoding/xml"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// requestBaseURL derives the absolute base URL (scheme + host) for the current
+// request. It honors X-Forwarded-Proto first (typical for proxies/load
+// balancers), then falls back to inspecting r.TLS, and finally defaults to
+// http. The host comes from r.Host so it works for both real deployments and
+// localhost.
+func requestBaseURL(r *http.Request) string {
+	scheme := "http"
+	if proto := r.Header.Get("X-Forwarded-Proto"); proto != "" {
+		scheme = proto
+	} else if r.TLS != nil {
+		scheme = "https"
+	}
+	return scheme + "://" + r.Host
+}
+
+// Robots serves /robots.txt — an allow-all crawl directive plus a pointer to
+// the sitemap so search engines can find it without guessing.
+func (handler httpHandler) Robots(w http.ResponseWriter, r *http.Request) {
+	base := requestBaseURL(r)
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+
+	body := "User-agent: *\nAllow: /\n\nSitemap: " + base + "/sitemap.xml\n"
+	if _, err := w.Write([]byte(body)); err != nil {
+		handler.logger.WithError(err).Warn("cannot write robots.txt")
+	}
+}
+
+// sitemapURL is one <url> entry in the sitemap. Built via encoding/xml so
+// slugs/ids containing reserved characters are escaped automatically.
+type sitemapURL struct {
+	XMLName    xml.Name `xml:"url"`
+	Loc        string   `xml:"loc"`
+	ChangeFreq string   `xml:"changefreq"`
+}
+
+type sitemapURLSet struct {
+	XMLName xml.Name     `xml:"urlset"`
+	Xmlns   string       `xml:"xmlns,attr"`
+	URLs    []sitemapURL `xml:"url"`
+}
+
+// Sitemap serves /sitemap.xml — the storefront's URLs that should be
+// discoverable by crawlers: the landing page, the shop, every category, and
+// every product. We omit account/cart/checkout/order pages on purpose: they
+// are either per-user or transactional and have no value as crawl targets.
+func (handler httpHandler) Sitemap(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	base := requestBaseURL(r)
+
+	categories, err := handler.catalogSrv.Categories(ctx)
+	if err != nil {
+		handler.logger.WithError(err).Warn("sitemap: cannot get categories")
+		categories = nil
+	}
+
+	products, err := handler.catalogSrv.AllProducts(ctx)
+	if err != nil {
+		handler.logger.WithError(err).Warn("sitemap: cannot get products")
+		products = nil
+	}
+
+	urls := []sitemapURL{
+		{Loc: base + "/", ChangeFreq: "weekly"},
+		{Loc: base + "/products", ChangeFreq: "weekly"},
+	}
+	for _, c := range categories {
+		urls = append(urls, sitemapURL{
+			Loc:        base + "/category/" + c.Slug(),
+			ChangeFreq: "weekly",
+		})
+	}
+	for _, p := range products {
+		urls = append(urls, sitemapURL{
+			Loc:        base + "/product/" + string(p.ID()),
+			ChangeFreq: "weekly",
+		})
+	}
+
+	w.Header().Set("Content-Type", "text/xml; charset=utf-8")
+	if _, err := fmt.Fprint(w, xml.Header); err != nil {
+		handler.logger.WithError(err).Warn("cannot write sitemap header")
+		return
+	}
+
+	set := sitemapURLSet{
+		Xmlns: "http://www.sitemaps.org/schemas/sitemap/0.9",
+		URLs:  urls,
+	}
+	enc := xml.NewEncoder(w)
+	enc.Indent("", "  ")
+	if err := enc.Encode(set); err != nil {
+		handler.logger.WithError(err).Warn("cannot encode sitemap")
+	}
+}
+
+// truncateForMeta trims a string to a meta-description-friendly length
+// (~160 chars). It cuts at the previous word boundary when possible and
+// appends an ellipsis. Whitespace runs are normalized so a description
+// pulled from a multi-line product blurb still reads cleanly.
+func truncateForMeta(s string, max int) string {
+	s = strings.Join(strings.Fields(s), " ")
+	if len(s) <= max {
+		return s
+	}
+	cut := s[:max]
+	if i := strings.LastIndex(cut, " "); i > 0 {
+		cut = cut[:i]
+	}
+	return strings.TrimRight(cut, ".,;:!?-") + "…"
+}

--- a/backend/layout/static/main.css
+++ b/backend/layout/static/main.css
@@ -125,6 +125,51 @@ main {
 .nav a:hover { color: var(--fg); }
 .nav .cart-link__count { color: var(--fg); }
 
+/* ---------- header: search ---------- */
+.site-search {
+  flex: 1 1 14rem;
+  max-width: 22rem;
+  margin: 0;
+}
+.site-search input[type="search"] {
+  width: 100%;
+  border: 0;
+  border-bottom: 1px solid var(--rule);
+  background: transparent;
+  font: inherit;
+  color: var(--fg);
+  padding: var(--space-1) 0;
+  outline: none;
+  letter-spacing: .01em;
+}
+.site-search input[type="search"]::placeholder {
+  color: var(--fg-muted);
+  font-style: italic;
+}
+.site-search input[type="search"]:focus,
+.site-search input[type="search"]:focus-visible {
+  border-bottom-color: var(--fg);
+  outline: 0;
+}
+
+/* ---------- accessibility: visually-hidden ---------- */
+/*
+  Off-screen but still announced by screen readers. Use for labels that the
+  visual design omits (e.g. the search input next to a brand mark).
+*/
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border: 0;
+}
+
 /* ---------- footer ---------- */
 .site-footer {
   border-top: 1px solid var(--rule);

--- a/backend/layout/static/main.css
+++ b/backend/layout/static/main.css
@@ -2,7 +2,7 @@
 :root {
   --bg:        #FAFAF7;
   --fg:        #111;
-  --fg-muted:  #6B6B66;
+  --fg-muted:  #5F5F5A;
   --rule:      #E5E3DC;
   --accent:    #2B2B2B;
   --danger:    #8B2C2C;
@@ -797,3 +797,55 @@ main {
 /* ---------- utility ---------- */
 .muted { color: var(--fg-muted); }
 .sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0,0,0,0); border: 0; }
+
+/* ---------- accessibility: skip link ---------- */
+/*
+  Hidden off-screen by default; revealed when it receives keyboard focus so
+  keyboard-only / screen-reader users can bypass the header nav and jump
+  straight to the page content (#main).
+*/
+.skip-link {
+  position: absolute;
+  top: 0;
+  left: 0;
+  padding: var(--space-1) var(--space-2);
+  background: var(--accent);
+  color: var(--bg);
+  border: 0;
+  z-index: 1000;
+  transform: translateY(-150%);
+  transition: transform .15s ease;
+}
+.skip-link:focus,
+.skip-link:focus-visible {
+  transform: translateY(0);
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+/* ---------- accessibility: focus-visible ---------- */
+/*
+  Consistent, high-contrast focus ring on all interactive elements. We hide
+  the default outline only when the element is NOT keyboard-focused so mouse
+  clicks don't leave a lingering ring.
+*/
+a:focus-visible,
+button:focus-visible,
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible,
+.btn:focus-visible,
+.linkbtn:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+/* Static field label that mirrors .field label styling but is not a real
+   <label for=…>. Used where we render a read-only value below it. */
+.field__static-label {
+  font-size: 0.8rem;
+  color: var(--fg-muted);
+  text-transform: lowercase;
+  letter-spacing: .04em;
+  margin: 0;
+}

--- a/backend/layout/tmpl/account/address_edit.gohtml
+++ b/backend/layout/tmpl/account/address_edit.gohtml
@@ -1,3 +1,6 @@
+{{define "title"}}Edit address · {{.SiteName}}{{end}}
+{{define "description"}}Edit a saved shipping address.{{end}}
+
 {{define "main"}}
   <h1 class="page-title">account</h1>
   <div class="account">

--- a/backend/layout/tmpl/account/addresses.gohtml
+++ b/backend/layout/tmpl/account/addresses.gohtml
@@ -1,3 +1,6 @@
+{{define "title"}}Addresses · {{.SiteName}}{{end}}
+{{define "description"}}Manage your saved shipping addresses.{{end}}
+
 {{define "main"}}
   <h1 class="page-title">account</h1>
   <div class="account">

--- a/backend/layout/tmpl/account/details.gohtml
+++ b/backend/layout/tmpl/account/details.gohtml
@@ -1,3 +1,6 @@
+{{define "title"}}Account details · {{.SiteName}}{{end}}
+{{define "description"}}Your {{.SiteName}} account details and password.{{end}}
+
 {{define "main"}}
   <h1 class="page-title">account</h1>
   <div class="account">
@@ -6,7 +9,7 @@
       <h2 class="account-card__title">account details</h2>
 
       <div class="field">
-        <label>email</label>
+        <p class="field__static-label">email</p>
         <p>{{.Email}}</p>
       </div>
 

--- a/backend/layout/tmpl/account/orders.gohtml
+++ b/backend/layout/tmpl/account/orders.gohtml
@@ -1,3 +1,6 @@
+{{define "title"}}Orders · {{.SiteName}}{{end}}
+{{define "description"}}All your past orders.{{end}}
+
 {{define "main"}}
   <h1 class="page-title">account</h1>
   <div class="account">

--- a/backend/layout/tmpl/account/overview.gohtml
+++ b/backend/layout/tmpl/account/overview.gohtml
@@ -1,3 +1,6 @@
+{{define "title"}}Account · {{.SiteName}}{{end}}
+{{define "description"}}Your {{.SiteName}} account overview.{{end}}
+
 {{define "main"}}
   <h1 class="page-title">account</h1>
   <div class="account">

--- a/backend/layout/tmpl/admin/product_edit.gohtml
+++ b/backend/layout/tmpl/admin/product_edit.gohtml
@@ -11,12 +11,17 @@
   <div class="admin-tab" id="tab-details" data-tab="details" role="tabpanel">
     <section class="admin-section">
       <h3 class="admin-section__title">core fields</h3>
-      <form class="form" method="post" action="/admin/products/{{.Product.ID}}" data-tab="details">
+      <form class="form" method="post" action="/admin/products/{{.Product.ID}}" data-tab="details" enctype="multipart/form-data">
         <div class="field"><label for="p-name">name</label><input id="p-name" name="name" value="{{.Product.Name}}" required></div>
         <div class="field"><label for="p-description">description</label><textarea id="p-description" name="description" required>{{.Product.Description}}</textarea></div>
         <div class="field"><label for="p-price">price (major units, e.g. 9.00)</label><input id="p-price" name="price" value="{{.Product.Price.Display}}" required></div>
         <div class="field"><label for="p-currency">currency</label><input id="p-currency" name="currency" value="{{.Product.Price.Currency}}"></div>
-        <div class="field"><label for="p-thumbnail">thumbnail URL</label><input id="p-thumbnail" name="thumbnail" value="{{.Product.Thumbnail}}"></div>
+        <div class="field">
+          <label for="p-thumbnail-file">thumbnail</label>
+          <input id="p-thumbnail-file" type="file" name="thumbnail_file" accept="image/jpeg,image/png,image/webp,image/gif">
+          <input id="p-thumbnail" name="thumbnail" value="{{.Product.Thumbnail}}" placeholder="or paste a URL">
+          <p class="form__aside muted">Upload a new image to replace the current one, or paste a URL. If both are provided, the upload wins.</p>
+        </div>
         <button type="submit" class="btn">save core fields</button>
       </form>
     </section>
@@ -92,10 +97,11 @@
               <tr>
                 <td>{{with $v.Label $ots}}{{.}}{{else}}default{{end}}</td>
                 <td colspan="4">
-                  <form class="form form--inline" method="post" action="/admin/products/{{$.Product.ID}}/variants/{{$v.ID}}" data-tab="options-variants">
+                  <form class="form form--inline" method="post" action="/admin/products/{{$.Product.ID}}/variants/{{$v.ID}}" data-tab="options-variants" enctype="multipart/form-data">
                     <input name="sku" value="{{$v.SKU}}" placeholder="sku" aria-label="sku">
                     <input name="price" value="{{$v.Price.Display}}" placeholder="9.00" aria-label="price">
-                    <input name="image" value="{{$v.Image}}" placeholder="image URL" aria-label="image">
+                    <input type="file" name="image_file" accept="image/jpeg,image/png,image/webp,image/gif" aria-label="image upload">
+                    <input name="image" value="{{$v.Image}}" placeholder="or image URL" aria-label="image URL">
                     <input name="stock" type="number" min="0" value="{{$v.Stock}}" aria-label="stock">
                     <button type="submit" class="btn btn--small">save</button>
                   </form>
@@ -120,7 +126,7 @@
 
       {{if .Product.HasOptions}}
         <h4 class="admin-section__subtitle">add a variant</h4>
-        <form class="form" method="post" action="/admin/products/{{.Product.ID}}/variants" data-tab="options-variants">
+        <form class="form" method="post" action="/admin/products/{{.Product.ID}}/variants" data-tab="options-variants" enctype="multipart/form-data">
           {{range $ot := .Product.OptionTypes}}
             <div class="field">
               <label for="opt-{{$ot.Name}}">{{$ot.Name}}</label>
@@ -132,7 +138,12 @@
           <div class="field"><label for="nv-sku">sku</label><input id="nv-sku" name="sku"></div>
           <div class="field"><label for="nv-price">price (major units, e.g. 9.00)</label><input id="nv-price" name="price" required placeholder="9.00"></div>
           <div class="field"><label for="nv-stock">stock</label><input id="nv-stock" name="stock" type="number" min="0" value="0"></div>
-          <div class="field"><label for="nv-image">image URL</label><input id="nv-image" name="image"></div>
+          <div class="field">
+            <label for="nv-image-file">image</label>
+            <input id="nv-image-file" type="file" name="image_file" accept="image/jpeg,image/png,image/webp,image/gif">
+            <input id="nv-image" name="image" placeholder="or paste a URL">
+            <p class="form__aside muted">Upload an image, or paste a URL. If both are provided, the upload wins.</p>
+          </div>
           <button type="submit" class="btn">add variant</button>
         </form>
       {{end}}

--- a/backend/layout/tmpl/admin/product_new.gohtml
+++ b/backend/layout/tmpl/admin/product_new.gohtml
@@ -3,13 +3,18 @@
   <h2 class="account-card__title">add a product</h2>
 
   <section class="admin-section">
-    <form class="form" method="post" action="/admin/products">
+    <form class="form" method="post" action="/admin/products" enctype="multipart/form-data">
       <div class="field"><label for="p-id">id (slug)</label><input id="p-id" name="id" required placeholder="lowercase-with-hyphens"></div>
       <div class="field"><label for="p-name">name</label><input id="p-name" name="name" required></div>
       <div class="field"><label for="p-description">description</label><textarea id="p-description" name="description" required></textarea></div>
       <div class="field"><label for="p-price">price (major units, e.g. 9.00)</label><input id="p-price" name="price" required placeholder="9.00"></div>
       <div class="field"><label for="p-currency">currency</label><input id="p-currency" name="currency" value="USD"></div>
-      <div class="field"><label for="p-thumbnail">thumbnail URL</label><input id="p-thumbnail" name="thumbnail"></div>
+      <div class="field">
+        <label for="p-thumbnail-file">thumbnail</label>
+        <input id="p-thumbnail-file" type="file" name="thumbnail_file" accept="image/jpeg,image/png,image/webp,image/gif">
+        <input id="p-thumbnail" name="thumbnail" placeholder="or paste a URL">
+        <p class="form__aside muted">Upload an image, or paste a URL. If both are provided, the upload wins.</p>
+      </div>
       <div class="field">
         <label for="p-attribute-set">attribute set</label>
         <select id="p-attribute-set" name="attribute_set">

--- a/backend/layout/tmpl/admin/product_new_variant.gohtml
+++ b/backend/layout/tmpl/admin/product_new_variant.gohtml
@@ -2,14 +2,19 @@
   <p class="crumbs"><a href="/admin/products">products</a> / new variant product</p>
   <h2 class="account-card__title">create a variant product</h2>
 
-  <form class="form" method="post" action="/admin/products/new-variant">
+  <form class="form" method="post" action="/admin/products/new-variant" enctype="multipart/form-data">
     <section class="admin-section">
       <h3 class="admin-section__title">product</h3>
       <div class="field"><label for="p-id">id (slug)</label><input id="p-id" name="id" required placeholder="lowercase-with-hyphens"></div>
       <div class="field"><label for="p-name">name</label><input id="p-name" name="name" required></div>
       <div class="field"><label for="p-description">description</label><textarea id="p-description" name="description" required></textarea></div>
       <div class="field"><label for="p-currency">currency</label><input id="p-currency" name="currency" value="USD"></div>
-      <div class="field"><label for="p-thumbnail">thumbnail URL</label><input id="p-thumbnail" name="thumbnail"></div>
+      <div class="field">
+        <label for="p-thumbnail-file">thumbnail</label>
+        <input id="p-thumbnail-file" type="file" name="thumbnail_file" accept="image/jpeg,image/png,image/webp,image/gif">
+        <input id="p-thumbnail" name="thumbnail" placeholder="or paste a URL">
+        <p class="form__aside muted">Upload an image, or paste a URL. If both are provided, the upload wins.</p>
+      </div>
       <div class="field">
         <label for="p-attribute-set">attribute set</label>
         <select id="p-attribute-set" name="attribute_set">
@@ -40,13 +45,16 @@
       <h3 class="admin-section__title">variants</h3>
       <p class="form__aside muted">options formatted as "Name=Value, Name2=Value2" (must match the option type names above). price in major units (e.g. 9.00).</p>
       <table class="admin-table variant-table">
-        <thead><tr><th>sku</th><th>price</th><th>stock</th><th>image URL</th><th>options</th><th></th></tr></thead>
+        <thead><tr><th>sku</th><th>price</th><th>stock</th><th>image (upload or URL)</th><th>options</th><th></th></tr></thead>
         <tbody id="v-rows">
           <tr class="v-row">
             <td><input name="v_sku[]" placeholder="TSHIRT-RED-L"></td>
             <td><input name="v_price[]" placeholder="9.00"></td>
             <td><input name="v_stock[]" type="number" min="0" value="0"></td>
-            <td><input name="v_image[]"></td>
+            <td>
+              <input type="file" name="v_image_file[]" accept="image/jpeg,image/png,image/webp,image/gif">
+              <input name="v_image[]" placeholder="or URL">
+            </td>
             <td><input name="v_options[]" placeholder="Color=Red, Size=L"></td>
             <td><button type="button" class="linkbtn linkbtn--danger v-remove">remove</button></td>
           </tr>

--- a/backend/layout/tmpl/auth/login.gohtml
+++ b/backend/layout/tmpl/auth/login.gohtml
@@ -1,3 +1,6 @@
+{{define "title"}}Sign in · {{.SiteName}}{{end}}
+{{define "description"}}Sign in to your {{.SiteName}} account.{{end}}
+
 {{define "main"}}
   <h1 class="page-title">sign in</h1>
 

--- a/backend/layout/tmpl/auth/register.gohtml
+++ b/backend/layout/tmpl/auth/register.gohtml
@@ -1,3 +1,6 @@
+{{define "title"}}Register · {{.SiteName}}{{end}}
+{{define "description"}}Create a new {{.SiteName}} account.{{end}}
+
 {{define "main"}}
   <h1 class="page-title">register</h1>
 

--- a/backend/layout/tmpl/cart/show.gohtml
+++ b/backend/layout/tmpl/cart/show.gohtml
@@ -1,3 +1,6 @@
+{{define "title"}}Cart · {{.SiteName}}{{end}}
+{{define "description"}}Review the items in your shopping cart.{{end}}
+
 {{define "main"}}
   <h1 class="page-title">cart</h1>
 

--- a/backend/layout/tmpl/checkout/show.gohtml
+++ b/backend/layout/tmpl/checkout/show.gohtml
@@ -1,3 +1,6 @@
+{{define "title"}}Checkout · {{.SiteName}}{{end}}
+{{define "description"}}Complete your order — shipping, payment, and confirmation.{{end}}
+
 {{define "main"}}
   <h1 class="page-title">checkout</h1>
 

--- a/backend/layout/tmpl/home.gohtml
+++ b/backend/layout/tmpl/home.gohtml
@@ -1,3 +1,6 @@
+{{define "title"}}New arrivals · {{.SiteName}}{{end}}
+{{define "description"}}Newest products from our store.{{end}}
+
 {{define "main"}}
   <div class="home-hero">
     <h1 class="page-title">new arrivals</h1>

--- a/backend/layout/tmpl/layout.gohtml
+++ b/backend/layout/tmpl/layout.gohtml
@@ -33,6 +33,17 @@
     <header class="site-header">
       <div class="shell site-header__inner">
         <a href="/" class="brand">Ecommerce</a>
+        <form class="site-search" role="search" action="/search" method="get">
+          <label class="visually-hidden" for="site-search-q">Search</label>
+          <input id="site-search-q" type="search" name="q"
+                 placeholder="Search&hellip;"
+                 value="{{.SearchQuery}}"
+                 hx-get="/api/v1/products"
+                 hx-trigger="keyup changed delay:300ms"
+                 hx-target="#product-grid"
+                 hx-swap="innerHTML"
+                 hx-include="[name=category]">
+        </form>
         <nav aria-label="Primary">
           <ul class="nav">
             <li><a href="/products">shop</a></li>

--- a/backend/layout/tmpl/layout.gohtml
+++ b/backend/layout/tmpl/layout.gohtml
@@ -4,7 +4,21 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Ecommerce</title>
+
+    {{/*
+      Per-page SEO blocks. Each page template can {{define "title"}}…{{end}} to
+      override the storefront default. The og:* blocks fall back to the title
+      and description so a page only has to set one place.
+    */}}
+    <title>{{block "title" .}}{{.SiteName}}{{end}}</title>
+    <meta name="description" content="{{block "description" .}}A small Go + HTMX e-commerce demo store.{{end}}">
+    <link rel="canonical" href="{{block "canonical" .}}{{.CanonicalURL}}{{end}}">
+    <meta property="og:site_name" content="{{.SiteName}}">
+    <meta property="og:title" content="{{block "ogtitle" .}}{{template "title" .}}{{end}}">
+    <meta property="og:type" content="{{block "ogtype" .}}website{{end}}">
+    <meta property="og:url" content="{{block "ogurl" .}}{{template "canonical" .}}{{end}}">
+    <meta property="og:description" content="{{block "ogdescription" .}}{{template "description" .}}{{end}}">
+    <meta property="og:image" content="{{block "ogimage" .}}{{end}}">
 
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -14,18 +28,19 @@
     <script src="https://unpkg.com/htmx.org@1.9.5"></script>
   </head>
   <body>
+    <a class="skip-link" href="#main">Skip to main content</a>
 
     <header class="site-header">
       <div class="shell site-header__inner">
         <a href="/" class="brand">Ecommerce</a>
-        <nav>
+        <nav aria-label="Primary">
           <ul class="nav">
             <li><a href="/products">shop</a></li>
             {{range .NavCategories}}
               <li><a href="/category/{{.Slug}}">{{.Name}}</a></li>
             {{end}}
             <li>
-              <a href="/cart" class="cart-link">cart
+              <a href="/cart" class="cart-link" aria-label="Cart">cart
                 <span id="cartBudge"
                       hx-get="/cart/budge"
                       hx-trigger="load, cartBudge from:body"
@@ -45,7 +60,7 @@
       </div>
     </header>
 
-    <main>
+    <main id="main">
       <div class="shell">
         {{ range .FlashInfo }}
           <p class="flash flash--info">{{ . }}</p>

--- a/backend/layout/tmpl/order/show.gohtml
+++ b/backend/layout/tmpl/order/show.gohtml
@@ -1,3 +1,6 @@
+{{define "title"}}Order {{.Order.ID}} · {{.SiteName}}{{end}}
+{{define "description"}}Order details and status.{{end}}
+
 {{define "main"}}
   <p class="crumbs"><a href="/">products</a> / order</p>
 

--- a/backend/layout/tmpl/productCatalog/allProducts.gohtml
+++ b/backend/layout/tmpl/productCatalog/allProducts.gohtml
@@ -15,5 +15,9 @@
     {{end}}
   </div>
 {{else}}
-  <p class="muted">no products match these filters.</p>
+  {{if .Search}}
+    <p class="muted">no products match &ldquo;{{.Search}}&rdquo;.</p>
+  {{else}}
+    <p class="muted">no products match.</p>
+  {{end}}
 {{end}}

--- a/backend/layout/tmpl/productCatalog/catalog.gohtml
+++ b/backend/layout/tmpl/productCatalog/catalog.gohtml
@@ -1,3 +1,6 @@
+{{define "title"}}{{$name := ""}}{{range .Categories}}{{if eq .Slug $.ActiveCategory}}{{$name = .Name}}{{end}}{{end}}{{if $name}}{{$name}} · {{.SiteName}}{{else}}Shop · {{.SiteName}}{{end}}{{end}}
+{{define "description"}}{{$name := ""}}{{range .Categories}}{{if eq .Slug $.ActiveCategory}}{{$name = .Name}}{{end}}{{end}}{{if $name}}Browse {{$name}} products from our store.{{else}}Browse every product in our store.{{end}}{{end}}
+
 {{define "main"}}
   <h1 class="page-title">shop</h1>
 

--- a/backend/layout/tmpl/productCatalog/catalog.gohtml
+++ b/backend/layout/tmpl/productCatalog/catalog.gohtml
@@ -1,13 +1,13 @@
-{{define "title"}}{{$name := ""}}{{range .Categories}}{{if eq .Slug $.ActiveCategory}}{{$name = .Name}}{{end}}{{end}}{{if $name}}{{$name}} · {{.SiteName}}{{else}}Shop · {{.SiteName}}{{end}}{{end}}
-{{define "description"}}{{$name := ""}}{{range .Categories}}{{if eq .Slug $.ActiveCategory}}{{$name = .Name}}{{end}}{{end}}{{if $name}}Browse {{$name}} products from our store.{{else}}Browse every product in our store.{{end}}{{end}}
+{{define "title"}}{{$name := ""}}{{range .Categories}}{{if eq .Slug $.ActiveCategory}}{{$name = .Name}}{{end}}{{end}}{{if .Search}}Search &#34;{{.Search}}&#34; · {{.SiteName}}{{else if $name}}{{$name}} · {{.SiteName}}{{else}}Shop · {{.SiteName}}{{end}}{{end}}
+{{define "description"}}{{$name := ""}}{{range .Categories}}{{if eq .Slug $.ActiveCategory}}{{$name = .Name}}{{end}}{{end}}{{if .Search}}Search results for &#34;{{.Search}}&#34; in our store.{{else if $name}}Browse {{$name}} products from our store.{{else}}Browse every product in our store.{{end}}{{end}}
 
 {{define "main"}}
-  <h1 class="page-title">shop</h1>
+  <h1 class="page-title">{{if .Search}}search: {{.Search}}{{else}}shop{{end}}</h1>
 
   <div class="catalog">
     <aside class="filter-rail">
       <nav class="category-nav">
-        <a class="category-nav__link{{if eq .ActiveCategory ""}} is-active{{end}}" href="/products">all</a>
+        <a class="category-nav__link{{if and (eq .ActiveCategory "") (not .Search)}} is-active{{end}}" href="/products">all</a>
         {{range .Categories}}
           <a class="category-nav__link{{if eq $.ActiveCategory .Slug}} is-active{{end}}"
              href="/category/{{.Slug}}">{{.Name}}</a>
@@ -21,6 +21,7 @@
               hx-trigger="submit, change delay:300ms"
               hx-push-url="false">
           <input type="hidden" name="category" value="{{.ActiveCategory}}">
+          <input type="hidden" name="q" value="{{.Search}}">
 
           {{range .Facets}}
             <div class="facet">
@@ -51,14 +52,14 @@
 
           <div class="filter-form__actions">
             <button type="submit" class="btn btn--block">apply</button>
-            <a class="filter-form__clear" href="{{if .ActiveCategory}}/category/{{.ActiveCategory}}{{else}}/products{{end}}">clear</a>
+            <a class="filter-form__clear" href="{{if .Search}}/search?q={{.Search}}{{else if .ActiveCategory}}/category/{{.ActiveCategory}}{{else}}/products{{end}}">clear</a>
           </div>
         </form>
       {{end}}
     </aside>
 
     <div id="product-grid" class="catalog__grid"
-         hx-get="/api/v1/products?category={{.ActiveCategory}}"
+         hx-get="/api/v1/products?category={{.ActiveCategory}}&q={{.Search}}"
          hx-trigger="load"
          hx-swap="innerHTML">
       <p class="muted"><span class="loading"></span> loading&hellip;</p>

--- a/backend/layout/tmpl/productCatalog/show.gohtml
+++ b/backend/layout/tmpl/productCatalog/show.gohtml
@@ -1,3 +1,8 @@
+{{define "title"}}{{.Product.Name}} · {{.SiteName}}{{end}}
+{{define "description"}}{{truncate .Product.Description 160}}{{end}}
+{{define "ogtype"}}product{{end}}
+{{define "ogimage"}}{{.Product.Thumbnail}}{{end}}
+
 {{define "main"}}
   <p class="crumbs"><a href="/">products</a> / {{.Product.Name}}</p>
 

--- a/backend/productcatalog/adapter/inmemory.go
+++ b/backend/productcatalog/adapter/inmemory.go
@@ -3,6 +3,7 @@ package adapter
 import (
 	"context"
 	"sort"
+	"strings"
 
 	"github.com/bkielbasa/go-ecommerce/backend/productcatalog/app"
 	"github.com/bkielbasa/go-ecommerce/backend/productcatalog/domain"
@@ -473,6 +474,7 @@ func (im *inMemory) inCategory(productID, slug string) bool {
 }
 
 func (im *inMemory) ListProducts(ctx context.Context, q app.ProductQuery) ([]domain.Product, error) {
+	search := strings.ToLower(strings.TrimSpace(q.Search))
 	var out []domain.Product
 	for _, p := range im.products {
 		pid := string(p.ID())
@@ -483,6 +485,11 @@ func (im *inMemory) ListProducts(ctx context.Context, q app.ProductQuery) ([]dom
 			continue
 		}
 		if !im.matchesEnum(pid, q.EnumSelections) {
+			continue
+		}
+		if search != "" &&
+			!strings.Contains(strings.ToLower(p.Name()), search) &&
+			!strings.Contains(strings.ToLower(p.Description()), search) {
 			continue
 		}
 		out = append(out, im.hydrate(p))

--- a/backend/productcatalog/adapter/postgres.go
+++ b/backend/productcatalog/adapter/postgres.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"strings"
 
 	"github.com/bkielbasa/go-ecommerce/backend/productcatalog/app"
 	"github.com/bkielbasa/go-ecommerce/backend/productcatalog/domain"
@@ -985,6 +986,11 @@ func (db postgres) ListProducts(ctx context.Context, q app.ProductQuery) ([]doma
 		query += fmt.Sprintf(` AND EXISTS (
 			SELECT 1 FROM productcatalog_product_attribute pa
 			WHERE pa.product_id = p.id AND pa.attribute_type_id = %s AND pa.text_value = ANY(%s))`, idPH, valPH)
+	}
+
+	if s := strings.TrimSpace(q.Search); s != "" {
+		ph := set("%" + s + "%")
+		query += fmt.Sprintf(` AND (p.name ILIKE %s OR p.description ILIKE %s)`, ph, ph)
 	}
 
 	query += ` ORDER BY p.id`

--- a/backend/productcatalog/app/query.go
+++ b/backend/productcatalog/app/query.go
@@ -10,11 +10,13 @@ type Range struct {
 
 // ProductQuery describes a listing-page filter: an optional category (by slug),
 // numeric attribute ranges and enum attribute selections. The maps are keyed by
-// attribute-type id.
+// attribute-type id. Search, when non-empty, applies a case-insensitive
+// substring match across the product name and description.
 type ProductQuery struct {
 	CategorySlug   string
 	NumericRanges  map[string]Range
 	EnumSelections map[string][]string
+	Search         string
 }
 
 // AttributeAssignment is a single product attribute value to persist. Num is

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -14,6 +14,11 @@ services:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
       POSTGRES_HOST: postgres
+      UPLOADS_DIR: /uploads
+    volumes:
+      # User-uploaded admin images are persisted on the host. The Dockerfile
+      # creates /uploads owned by the app user (uid 10001).
+      - ./data/uploads:/uploads
   postgres:
     image: postgres
     restart: always


### PR DESCRIPTION
Four phases of polish.

- **structured logging**: replaced ad-hoc `log.Print`/`fmt.Print*` in handlers + panic middleware + cli with `logrus.FieldLogger.WithError(...)`; JSON log lines now carry `trace.id`, `path`, `status_code`, etc.
- **image uploads**: `internal/imagestore` (interface + local-disk impl with size cap, MIME allow-list, sha256 dedupe, sharded paths) served at `/uploads/*`; admin product/variant forms accept a file alongside the URL (upload wins). docker-compose mounts `./data/uploads`.
- **SEO + a11y**: `/robots.txt`, `/sitemap.xml` (24 URLs); per-page `<title>` / meta / canonical / Open Graph via block-define overrides on home / shop / category / product / cart / checkout / order / account / auth. Skip-link, semantic landmarks, `:focus-visible`, alt/label audit.
- **search**: `ProductQuery.Search` (ILIKE in postgres, substring in in-memory), `/search?q=…` page, header search form (submit + HTMX live-swap on grid pages), empty state quotes the query.

## Test plan
- [x] build (incl. -tags integration) / vet / tests / lint green
- [x] docker: structured JSON logs flowing; PNG upload persisted, served at `/uploads/...`; robots/sitemap correct content-type; per-page titles/og; search returns right products, combined with category, empty state, edge-case meta escape