### PR TITLE
chore: production-readiness pass (security, email, stock TTL, commerce)

### DIFF
--- a/backend/auth/adapter/auth_storage_inmemory.go
+++ b/backend/auth/adapter/auth_storage_inmemory.go
@@ -41,6 +41,18 @@ func (i *inMemory) UpdatePassword(ctx context.Context, email, hash string) error
 	return nil
 }
 
+// ClearMustChangePassword flips the must_change_password flag back to false
+// for the given customer; called after a successful ChangePassword.
+func (i *inMemory) ClearMustChangePassword(ctx context.Context, email string) error {
+	c, ok := i.customers[email]
+	if !ok {
+		return domain.ErrCustomerNotFound
+	}
+	c.MustChangePassword = false
+	i.customers[email] = c
+	return nil
+}
+
 func (i *inMemory) Find(ctx context.Context, email string) (Customer, error) {
 	customer, ok := i.customers[email]
 	if !ok {

--- a/backend/auth/adapter/auth_storage_postgres.go
+++ b/backend/auth/adapter/auth_storage_postgres.go
@@ -28,10 +28,18 @@ func (p authStoragePostgres) UpdatePassword(ctx context.Context, email, password
 	return err
 }
 
+// ClearMustChangePassword resets the must_change_password flag for the given
+// customer. Called after a successful ChangePassword so the gate at /auth/
+// change-password stops firing for them.
+func (p authStoragePostgres) ClearMustChangePassword(ctx context.Context, email string) error {
+	_, err := p.db.ExecContext(ctx, "UPDATE auth_customer SET must_change_password = false WHERE username = $1", email)
+	return err
+}
+
 func (p authStoragePostgres) Find(ctx context.Context, email string) (Customer, error) {
 	c := Customer{}
 
-	err := p.db.QueryRowContext(ctx, "SELECT username, password_hash, is_admin FROM auth_customer WHERE username = $1", email).Scan(&c.Username, &c.PasswordHash, &c.IsAdmin)
+	err := p.db.QueryRowContext(ctx, "SELECT username, password_hash, is_admin, must_change_password FROM auth_customer WHERE username = $1", email).Scan(&c.Username, &c.PasswordHash, &c.IsAdmin, &c.MustChangePassword)
 
 	if err == sql.ErrNoRows {
 		return Customer{}, domain.ErrCustomerNotFound

--- a/backend/auth/adapter/customer.go
+++ b/backend/auth/adapter/customer.go
@@ -8,4 +8,8 @@ type Customer struct {
 	Username     string
 	PasswordHash string
 	IsAdmin      bool
+	// MustChangePassword is true when the customer has to set a new password
+	// before they can use the site (the seeded admin starts true; the change
+	// is cleared after a successful ChangePassword).
+	MustChangePassword bool
 }

--- a/backend/auth/adapter/password_reset_inmemory.go
+++ b/backend/auth/adapter/password_reset_inmemory.go
@@ -1,0 +1,66 @@
+package adapter
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+// passwordResetInMemory is the in-memory PasswordResetStorage used by tests.
+// It mirrors the postgres semantics: rows are addressed by token hash, never
+// the raw token; consumed_at acts as the burn marker so a token cannot be
+// used twice.
+type passwordResetInMemory struct {
+	mu      sync.Mutex
+	entries map[string]resetEntry
+}
+
+type resetEntry struct {
+	CustomerID string
+	ExpiresAt  time.Time
+	Consumed   bool
+}
+
+func NewInMemoryPasswordResetStorage() *passwordResetInMemory {
+	return &passwordResetInMemory{entries: make(map[string]resetEntry)}
+}
+
+// BeginPasswordReset mints a token (mirroring the postgres impl), stores its
+// hash with the TTL, and hands the raw value back to the caller.
+func (p *passwordResetInMemory) BeginPasswordReset(ctx context.Context, customerID string, ttl time.Duration) (string, error) {
+	raw, err := newResetToken()
+	if err != nil {
+		return "", err
+	}
+	hash := hashResetToken(raw)
+
+	p.mu.Lock()
+	p.entries[hash] = resetEntry{
+		CustomerID: customerID,
+		ExpiresAt:  time.Now().Add(ttl),
+	}
+	p.mu.Unlock()
+	return raw, nil
+}
+
+// ConsumePasswordReset validates and burns the token in a single critical
+// section. Returns ErrInvalidResetToken for unknown / expired / already-used
+// tokens — same vague error as the postgres impl so the handler layer can
+// treat them uniformly.
+func (p *passwordResetInMemory) ConsumePasswordReset(ctx context.Context, rawToken string) (string, error) {
+	if rawToken == "" {
+		return "", ErrInvalidResetToken
+	}
+	hash := hashResetToken(rawToken)
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	entry, ok := p.entries[hash]
+	if !ok || entry.Consumed || time.Now().After(entry.ExpiresAt) {
+		return "", ErrInvalidResetToken
+	}
+	entry.Consumed = true
+	p.entries[hash] = entry
+	return entry.CustomerID, nil
+}

--- a/backend/auth/adapter/password_reset_inmemory_test.go
+++ b/backend/auth/adapter/password_reset_inmemory_test.go
@@ -1,0 +1,66 @@
+package adapter_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/bkielbasa/go-ecommerce/backend/auth/adapter"
+)
+
+// TestPasswordResetRoundtrip exercises the happy path: a token freshly
+// minted by Begin is consumable exactly once and returns the same
+// customerID that was supplied.
+func TestPasswordResetRoundtrip(t *testing.T) {
+	ctx := context.Background()
+	store := adapter.NewInMemoryPasswordResetStorage()
+
+	raw, err := store.BeginPasswordReset(ctx, "alice@example.com", time.Minute)
+	if err != nil {
+		t.Fatalf("Begin: %v", err)
+	}
+	if raw == "" {
+		t.Fatalf("expected raw token, got empty")
+	}
+
+	got, err := store.ConsumePasswordReset(ctx, raw)
+	if err != nil {
+		t.Fatalf("Consume: %v", err)
+	}
+	if got != "alice@example.com" {
+		t.Fatalf("Consume returned %q, want alice@example.com", got)
+	}
+
+	// Second consume must fail — tokens are one-shot.
+	if _, err := store.ConsumePasswordReset(ctx, raw); !errors.Is(err, adapter.ErrInvalidResetToken) {
+		t.Fatalf("second Consume err = %v, want ErrInvalidResetToken", err)
+	}
+}
+
+func TestPasswordResetUnknownToken(t *testing.T) {
+	store := adapter.NewInMemoryPasswordResetStorage()
+	if _, err := store.ConsumePasswordReset(context.Background(), "nope"); !errors.Is(err, adapter.ErrInvalidResetToken) {
+		t.Fatalf("err = %v, want ErrInvalidResetToken", err)
+	}
+}
+
+func TestPasswordResetExpired(t *testing.T) {
+	ctx := context.Background()
+	store := adapter.NewInMemoryPasswordResetStorage()
+
+	raw, err := store.BeginPasswordReset(ctx, "alice@example.com", -1*time.Second)
+	if err != nil {
+		t.Fatalf("Begin: %v", err)
+	}
+	if _, err := store.ConsumePasswordReset(ctx, raw); !errors.Is(err, adapter.ErrInvalidResetToken) {
+		t.Fatalf("expired Consume err = %v, want ErrInvalidResetToken", err)
+	}
+}
+
+func TestPasswordResetEmptyToken(t *testing.T) {
+	store := adapter.NewInMemoryPasswordResetStorage()
+	if _, err := store.ConsumePasswordReset(context.Background(), ""); !errors.Is(err, adapter.ErrInvalidResetToken) {
+		t.Fatalf("err = %v, want ErrInvalidResetToken", err)
+	}
+}

--- a/backend/auth/adapter/password_reset_postgres.go
+++ b/backend/auth/adapter/password_reset_postgres.go
@@ -1,0 +1,116 @@
+package adapter
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/base64"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"time"
+
+	_ "github.com/lib/pq"
+)
+
+// ErrInvalidResetToken is returned by ConsumePasswordReset when the supplied
+// token does not match any unused, unexpired row. It is intentionally vague:
+// callers MUST NOT leak whether the token was wrong, expired, or already
+// consumed (each variant is useful intelligence to an attacker).
+var ErrInvalidResetToken = errors.New("invalid or expired password reset token")
+
+// passwordResetPostgres is the postgres-backed implementation of
+// PasswordResetStorage. The token row stores a sha256 of the raw token so a
+// database read leak cannot itself be used to impersonate a reset request;
+// the raw token only ever lives on the wire (in the email link) and in the
+// browser tab the user opened.
+type passwordResetPostgres struct {
+	db *sql.DB
+}
+
+func NewPostgresPasswordResetStorage(db *sql.DB) passwordResetPostgres {
+	return passwordResetPostgres{db: db}
+}
+
+// BeginPasswordReset mints a fresh token, persists its hash with the chosen
+// TTL, and returns the RAW token to the caller. The caller is responsible
+// for emailing it; the raw token is never written to the DB.
+func (p passwordResetPostgres) BeginPasswordReset(ctx context.Context, customerID string, ttl time.Duration) (string, error) {
+	raw, err := newResetToken()
+	if err != nil {
+		return "", fmt.Errorf("could not generate reset token: %w", err)
+	}
+	hash := hashResetToken(raw)
+	expires := time.Now().Add(ttl)
+
+	_, err = p.db.ExecContext(ctx,
+		"INSERT INTO auth_password_reset (token_hash, customer_id, expires_at) VALUES ($1, $2, $3)",
+		hash, customerID, expires)
+	if err != nil {
+		return "", fmt.Errorf("could not store reset token: %w", err)
+	}
+	return raw, nil
+}
+
+// ConsumePasswordReset validates and atomically burns a reset token. The
+// SELECT … FOR UPDATE inside the same tx ensures two concurrent consumers
+// cannot both succeed; the second one sees consumed_at IS NOT NULL and is
+// rejected with ErrInvalidResetToken (we never tell the caller which of
+// "wrong / expired / already used" applied).
+func (p passwordResetPostgres) ConsumePasswordReset(ctx context.Context, rawToken string) (string, error) {
+	if rawToken == "" {
+		return "", ErrInvalidResetToken
+	}
+	hash := hashResetToken(rawToken)
+
+	tx, err := p.db.BeginTx(ctx, nil)
+	if err != nil {
+		return "", fmt.Errorf("could not begin tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	var customerID string
+	err = tx.QueryRowContext(ctx,
+		`SELECT customer_id FROM auth_password_reset
+		   WHERE token_hash = $1 AND consumed_at IS NULL AND expires_at > now()
+		   FOR UPDATE`,
+		hash).Scan(&customerID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", ErrInvalidResetToken
+	}
+	if err != nil {
+		return "", fmt.Errorf("could not lookup reset token: %w", err)
+	}
+
+	if _, err := tx.ExecContext(ctx,
+		"UPDATE auth_password_reset SET consumed_at = now() WHERE token_hash = $1",
+		hash); err != nil {
+		return "", fmt.Errorf("could not consume reset token: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return "", fmt.Errorf("could not commit consume tx: %w", err)
+	}
+	return customerID, nil
+}
+
+// newResetToken returns a fresh 32-byte (256-bit) random token, base64-url
+// encoded. The encoding produces ~43 URL-safe characters — short enough to
+// paste comfortably and far too long to brute-force.
+func newResetToken() (string, error) {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(b), nil
+}
+
+// hashResetToken applies sha256 and returns the hex digest. We avoid bcrypt
+// here on purpose: reset tokens are already high-entropy random strings, and
+// the storage layer needs deterministic lookups by hash (a bcrypt salt
+// rotates every call, defeating the WHERE clause).
+func hashResetToken(raw string) string {
+	sum := sha256.Sum256([]byte(raw))
+	return hex.EncodeToString(sum[:])
+}

--- a/backend/auth/app/auth.go
+++ b/backend/auth/app/auth.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"regexp"
 	"time"
@@ -15,6 +16,13 @@ var (
 	ErrInvalidEmail  = fmt.Errorf("invalid email")
 	ErrWrongPassword = fmt.Errorf("current password is incorrect")
 )
+
+// passwordResetTTL is the lifetime of a freshly-minted reset token. Thirty
+// minutes is the OWASP-recommended ceiling for self-service password-reset
+// links — long enough that the email arriving a few minutes late still works,
+// short enough that a token leaked into history/logs is useless within an
+// hour.
+const passwordResetTTL = 30 * time.Minute
 
 var emailRegexp = regexp.MustCompile("^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$")
 
@@ -33,15 +41,33 @@ type SessStorage interface {
 	Find(ctx context.Context, token string) (*domain.Session, error)
 }
 
+// PasswordResetStorage is the persistence boundary for the password-reset
+// flow. Begin mints a raw token (and stores only its hash); Consume validates
+// and atomically burns it. Implementations live in auth/adapter alongside the
+// customer/session stores.
+type PasswordResetStorage interface {
+	BeginPasswordReset(ctx context.Context, customerID string, ttl time.Duration) (string, error)
+	ConsumePasswordReset(ctx context.Context, rawToken string) (string, error)
+}
+
 type auth struct {
 	authStorage  CustomerStorage
 	sessStorage  SessStorage
+	resetStorage PasswordResetStorage
 	passPolicies []domain.PasswordPolicy
 }
 
-func NewAuth(authStorage CustomerStorage, sessStorage SessStorage) auth {
+// NewAuth wires the auth application service. The PasswordResetStorage is
+// optional — pass nil from call sites that don't need the forgot-password
+// flow yet and the service degrades gracefully (RequestPasswordReset returns
+// nil silently, ResetPassword returns ErrInvalidResetToken).
+func NewAuth(authStorage CustomerStorage, sessStorage SessStorage, resetStorage ...PasswordResetStorage) auth {
+	var rs PasswordResetStorage
+	if len(resetStorage) > 0 {
+		rs = resetStorage[0]
+	}
 	return auth{
-		authStorage: authStorage, sessStorage: sessStorage,
+		authStorage: authStorage, sessStorage: sessStorage, resetStorage: rs,
 		passPolicies: []domain.PasswordPolicy{
 
 			// those values are recommended by OWASP https://cheatsheetseries.owasp.org/cheatsheets/Authentication_Cheat_Sheet.html#implement-proper-password-strength-controls
@@ -206,4 +232,67 @@ func (a auth) MustChangePassword(ctx context.Context, email string) (bool, error
 func hashPassword(password string) (string, error) {
 	bytes, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
 	return string(bytes), err
+}
+
+// RequestPasswordReset mints a fresh password-reset token for the customer
+// identified by email. The returned token is the RAW value the caller must
+// embed in the reset link sent over email; the storage layer only ever
+// persists its sha256 hash.
+//
+// To prevent account-enumeration, RequestPasswordReset returns ("", nil) when
+// no customer matches — the caller renders the same "if an account exists,
+// an email is on its way" confirmation regardless. Any OTHER lookup error is
+// returned verbatim so a transient DB outage still produces a 5xx rather
+// than a silent success that leaks no information.
+func (a auth) RequestPasswordReset(ctx context.Context, email string) (string, error) {
+	if a.resetStorage == nil {
+		return "", nil
+	}
+	if !emailRegexp.MatchString(email) {
+		// Treat malformed input as a non-existent account — same
+		// enumeration-prevention rationale as the not-found path.
+		return "", nil
+	}
+	_, err := a.authStorage.Find(ctx, email)
+	if errors.Is(err, domain.ErrCustomerNotFound) {
+		return "", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("could not lookup customer: %w", err)
+	}
+	return a.resetStorage.BeginPasswordReset(ctx, email, passwordResetTTL)
+}
+
+// ResetPassword burns a reset token and replaces the customer's password
+// with newPassword (after enforcing the same policy as ChangePassword).
+// The token is consumed BEFORE the policy check on purpose: a policy
+// failure should not let a leaked token stay reusable.
+func (a auth) ResetPassword(ctx context.Context, rawToken, newPassword string) error {
+	if a.resetStorage == nil {
+		return adapter.ErrInvalidResetToken
+	}
+	customerID, err := a.resetStorage.ConsumePasswordReset(ctx, rawToken)
+	if err != nil {
+		return err
+	}
+
+	for _, policy := range a.passPolicies {
+		if err := policy(newPassword); err != nil {
+			return fmt.Errorf("cannot reset password: %w", err)
+		}
+	}
+
+	newHash, err := hashPassword(newPassword)
+	if err != nil {
+		return fmt.Errorf("could not hash password: %w", err)
+	}
+	if err := a.authStorage.UpdatePassword(ctx, customerID, newHash); err != nil {
+		return fmt.Errorf("could not update password: %w", err)
+	}
+	// A successful password reset clears any forced-change flag the same
+	// way ChangePassword does — the user just proved they own the inbox.
+	if err := a.authStorage.ClearMustChangePassword(ctx, customerID); err != nil {
+		return fmt.Errorf("could not clear must-change-password flag: %w", err)
+	}
+	return nil
 }

--- a/backend/auth/app/auth.go
+++ b/backend/auth/app/auth.go
@@ -22,6 +22,10 @@ type CustomerStorage interface {
 	Create(ctx context.Context, email, passwordHash string) error
 	Find(ctx context.Context, email string) (adapter.Customer, error)
 	UpdatePassword(ctx context.Context, email, passwordHash string) error
+	// ClearMustChangePassword resets the must_change_password flag for the
+	// given customer. Called by ChangePassword after a successful update so
+	// the change-password gate stops firing on subsequent logins.
+	ClearMustChangePassword(ctx context.Context, email string) error
 }
 
 type SessStorage interface {
@@ -156,7 +160,17 @@ func (a auth) ChangePassword(ctx context.Context, email, oldPassword, newPasswor
 		return fmt.Errorf("could not hash password: %w", err)
 	}
 
-	return a.authStorage.UpdatePassword(ctx, email, newHash)
+	if err := a.authStorage.UpdatePassword(ctx, email, newHash); err != nil {
+		return fmt.Errorf("could not update password: %w", err)
+	}
+
+	// A successful password change always clears the must-change-password
+	// gate (no-op for users who weren't flagged in the first place).
+	if err := a.authStorage.ClearMustChangePassword(ctx, email); err != nil {
+		return fmt.Errorf("could not clear must-change-password flag: %w", err)
+	}
+
+	return nil
 }
 
 // IsAdmin reports whether the customer identified by email has the admin
@@ -172,6 +186,21 @@ func (a auth) IsAdmin(ctx context.Context, email string) (bool, error) {
 	}
 
 	return customer.IsAdmin, nil
+}
+
+// MustChangePassword reports whether the given customer is currently flagged
+// for a forced password change. A missing customer is treated as false so
+// anonymous lookups don't trip the gate; any other lookup error is returned.
+func (a auth) MustChangePassword(ctx context.Context, email string) (bool, error) {
+	customer, err := a.authStorage.Find(ctx, email)
+	if err == domain.ErrCustomerNotFound {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("could not find customer: %w", err)
+	}
+
+	return customer.MustChangePassword, nil
 }
 
 func hashPassword(password string) (string, error) {

--- a/backend/auth/bounded_context.go
+++ b/backend/auth/bounded_context.go
@@ -21,12 +21,15 @@ type appService interface {
 	ChangePassword(ctx context.Context, email, oldPassword, newPassword string) error
 	IsAdmin(ctx context.Context, email string) (bool, error)
 	MustChangePassword(ctx context.Context, email string) (bool, error)
+	RequestPasswordReset(ctx context.Context, email string) (string, error)
+	ResetPassword(ctx context.Context, rawToken, newPassword string) error
 }
 
 func New(db *sql.DB) (application.BoundedContext, appService) {
 	authStorage := adapter.NewPostgresAuthStorage(db)
 	sessStorage := adapter.NewPostgresSessionStorage(db)
-	appServ := app.NewAuth(authStorage, sessStorage)
+	resetStorage := adapter.NewPostgresPasswordResetStorage(db)
+	appServ := app.NewAuth(authStorage, sessStorage, resetStorage)
 
 	return &boundedContext{
 		httpHandler: port.NewHTTP(appServ),

--- a/backend/auth/bounded_context.go
+++ b/backend/auth/bounded_context.go
@@ -20,6 +20,7 @@ type appService interface {
 	FindByToken(ctx context.Context, sessToken string) (*domain.Session, error)
 	ChangePassword(ctx context.Context, email, oldPassword, newPassword string) error
 	IsAdmin(ctx context.Context, email string) (bool, error)
+	MustChangePassword(ctx context.Context, email string) (bool, error)
 }
 
 func New(db *sql.DB) (application.BoundedContext, appService) {

--- a/backend/checkout/adapter/events_codec.go
+++ b/backend/checkout/adapter/events_codec.go
@@ -42,14 +42,16 @@ type lineDTO struct {
 }
 
 type orderPlacedDTO struct {
-	OrderID    string            `json:"order_id"`
-	UserID     string            `json:"user_id"`
-	CustomerID string            `json:"customer_id"`
-	ShipTo     addressDTO        `json:"ship_to"`
-	ShipMethod shippingMethodDTO `json:"ship_method"`
-	PayMethod  paymentMethodDTO  `json:"pay_method"`
-	Lines      []lineDTO         `json:"lines"`
-	At         time.Time         `json:"at"`
+	OrderID      string            `json:"order_id"`
+	UserID       string            `json:"user_id"`
+	CustomerID   string            `json:"customer_id"`
+	ShipTo       addressDTO        `json:"ship_to"`
+	ShipMethod   shippingMethodDTO `json:"ship_method"`
+	PayMethod    paymentMethodDTO  `json:"pay_method"`
+	Lines        []lineDTO         `json:"lines"`
+	Tax          int64             `json:"tax,omitempty"`
+	ShippingCost int64             `json:"shipping_cost,omitempty"`
+	At           time.Time         `json:"at"`
 }
 
 type paymentSucceededDTO struct {
@@ -64,6 +66,24 @@ type paymentFailedDTO struct {
 }
 
 type orderCancelledDTO struct {
+	OrderID string    `json:"order_id"`
+	Reason  string    `json:"reason"`
+	At      time.Time `json:"at"`
+}
+
+type orderShippedDTO struct {
+	OrderID      string    `json:"order_id"`
+	Carrier      string    `json:"carrier,omitempty"`
+	TrackingCode string    `json:"tracking_code,omitempty"`
+	At           time.Time `json:"at"`
+}
+
+type orderDeliveredDTO struct {
+	OrderID string    `json:"order_id"`
+	At      time.Time `json:"at"`
+}
+
+type orderRefundedDTO struct {
 	OrderID string    `json:"order_id"`
 	Reason  string    `json:"reason"`
 	At      time.Time `json:"at"`
@@ -85,14 +105,16 @@ func marshalEvent(e domain.Event) (string, []byte, error) {
 			})
 		}
 		payload = orderPlacedDTO{
-			OrderID:    ev.OrderID,
-			UserID:     ev.UserID,
-			CustomerID: ev.CustomerID,
-			ShipTo:     toAddressDTO(ev.ShipTo),
-			ShipMethod: shippingMethodDTO{Code: ev.ShipMethod.Code(), Label: ev.ShipMethod.Label(), Cost: ev.ShipMethod.Cost()},
-			PayMethod:  paymentMethodDTO{Code: ev.PayMethod.Code(), Label: ev.PayMethod.Label()},
-			Lines:      lines,
-			At:         ev.At,
+			OrderID:      ev.OrderID,
+			UserID:       ev.UserID,
+			CustomerID:   ev.CustomerID,
+			ShipTo:       toAddressDTO(ev.ShipTo),
+			ShipMethod:   shippingMethodDTO{Code: ev.ShipMethod.Code(), Label: ev.ShipMethod.Label(), Cost: ev.ShipMethod.Cost()},
+			PayMethod:    paymentMethodDTO{Code: ev.PayMethod.Code(), Label: ev.PayMethod.Label()},
+			Lines:        lines,
+			Tax:          ev.Tax,
+			ShippingCost: ev.ShippingCost,
+			At:           ev.At,
 		}
 	case domain.PaymentSucceeded:
 		payload = paymentSucceededDTO{OrderID: ev.OrderID, At: ev.At}
@@ -100,6 +122,12 @@ func marshalEvent(e domain.Event) (string, []byte, error) {
 		payload = paymentFailedDTO{OrderID: ev.OrderID, Reason: ev.Reason, At: ev.At}
 	case domain.OrderCancelled:
 		payload = orderCancelledDTO{OrderID: ev.OrderID, Reason: ev.Reason, At: ev.At}
+	case domain.OrderShipped:
+		payload = orderShippedDTO{OrderID: ev.OrderID, Carrier: ev.Carrier, TrackingCode: ev.TrackingCode, At: ev.At}
+	case domain.OrderDelivered:
+		payload = orderDeliveredDTO{OrderID: ev.OrderID, At: ev.At}
+	case domain.OrderRefunded:
+		payload = orderRefundedDTO{OrderID: ev.OrderID, Reason: ev.Reason, At: ev.At}
 	default:
 		return "", nil, fmt.Errorf("no codec for event %s", e.EventType())
 	}
@@ -124,14 +152,16 @@ func unmarshalEvent(eventType string, payload []byte) (domain.Event, error) {
 			lines = append(lines, domain.NewLine(l.ProductID, l.ProductName, l.Qty, l.PriceAmount, l.PriceCurrency))
 		}
 		return domain.OrderPlaced{
-			OrderID:    dto.OrderID,
-			UserID:     dto.UserID,
-			CustomerID: dto.CustomerID,
-			ShipTo:     domain.RebuildAddress(dto.ShipTo.Name, dto.ShipTo.Street1, dto.ShipTo.Street2, dto.ShipTo.City, dto.ShipTo.Zip, dto.ShipTo.Country),
-			ShipMethod: domain.RebuildShippingMethod(dto.ShipMethod.Code, dto.ShipMethod.Label, dto.ShipMethod.Cost),
-			PayMethod:  domain.RebuildPaymentMethod(dto.PayMethod.Code, dto.PayMethod.Label),
-			Lines:      lines,
-			At:         dto.At,
+			OrderID:      dto.OrderID,
+			UserID:       dto.UserID,
+			CustomerID:   dto.CustomerID,
+			ShipTo:       domain.RebuildAddress(dto.ShipTo.Name, dto.ShipTo.Street1, dto.ShipTo.Street2, dto.ShipTo.City, dto.ShipTo.Zip, dto.ShipTo.Country),
+			ShipMethod:   domain.RebuildShippingMethod(dto.ShipMethod.Code, dto.ShipMethod.Label, dto.ShipMethod.Cost),
+			PayMethod:   domain.RebuildPaymentMethod(dto.PayMethod.Code, dto.PayMethod.Label),
+			Lines:        lines,
+			Tax:          dto.Tax,
+			ShippingCost: dto.ShippingCost,
+			At:           dto.At,
 		}, nil
 	case "PaymentSucceeded":
 		var dto paymentSucceededDTO
@@ -151,6 +181,24 @@ func unmarshalEvent(eventType string, payload []byte) (domain.Event, error) {
 			return nil, fmt.Errorf("unmarshal OrderCancelled: %w", err)
 		}
 		return domain.OrderCancelled{OrderID: dto.OrderID, Reason: dto.Reason, At: dto.At}, nil
+	case "OrderShipped":
+		var dto orderShippedDTO
+		if err := json.Unmarshal(payload, &dto); err != nil {
+			return nil, fmt.Errorf("unmarshal OrderShipped: %w", err)
+		}
+		return domain.OrderShipped{OrderID: dto.OrderID, Carrier: dto.Carrier, TrackingCode: dto.TrackingCode, At: dto.At}, nil
+	case "OrderDelivered":
+		var dto orderDeliveredDTO
+		if err := json.Unmarshal(payload, &dto); err != nil {
+			return nil, fmt.Errorf("unmarshal OrderDelivered: %w", err)
+		}
+		return domain.OrderDelivered{OrderID: dto.OrderID, At: dto.At}, nil
+	case "OrderRefunded":
+		var dto orderRefundedDTO
+		if err := json.Unmarshal(payload, &dto); err != nil {
+			return nil, fmt.Errorf("unmarshal OrderRefunded: %w", err)
+		}
+		return domain.OrderRefunded{OrderID: dto.OrderID, Reason: dto.Reason, At: dto.At}, nil
 	default:
 		return nil, fmt.Errorf("unknown event type %q", eventType)
 	}

--- a/backend/checkout/adapter/events_codec_test.go
+++ b/backend/checkout/adapter/events_codec_test.go
@@ -19,7 +19,9 @@ func TestEventCodecRoundTrip_OrderPlaced(t *testing.T) {
 		Lines: []domain.Line{
 			domain.NewLine("ceramic-mug-cream", "Ceramic Mug — Cream", 2, 2400, "USD"),
 		},
-		At: at,
+		Tax:          426,
+		ShippingCost: 0,
+		At:           at,
 	}
 
 	typ, payload, err := marshalEvent(original)
@@ -56,6 +58,40 @@ func TestEventCodecRoundTrip_OrderPlaced(t *testing.T) {
 	}
 	if len(op.Lines) != 1 || op.Lines[0].ProductName() != "Ceramic Mug — Cream" || op.Lines[0].Quantity() != 2 || op.Lines[0].PriceAmount() != 2400 {
 		t.Errorf("line round-trip mismatch: %+v", op.Lines)
+	}
+	if op.Tax != 426 || op.ShippingCost != 0 {
+		t.Errorf("tax/shipping round-trip mismatch: tax=%d shipping=%d", op.Tax, op.ShippingCost)
+	}
+}
+
+func TestEventCodecRoundTrip_Fulfillment(t *testing.T) {
+	at := time.Date(2026, 5, 27, 12, 0, 0, 0, time.UTC)
+	cases := []domain.Event{
+		domain.OrderShipped{OrderID: "ord-1", Carrier: "UPS", TrackingCode: "1Z-XYZ", At: at},
+		domain.OrderDelivered{OrderID: "ord-1", At: at},
+		domain.OrderRefunded{OrderID: "ord-1", Reason: "customer return", At: at},
+	}
+	for _, e := range cases {
+		typ, payload, err := marshalEvent(e)
+		if err != nil {
+			t.Fatalf("marshal %s: %v", e.EventType(), err)
+		}
+		got, err := unmarshalEvent(typ, payload)
+		if err != nil {
+			t.Fatalf("unmarshal %s: %v", typ, err)
+		}
+		if got.EventType() != e.EventType() {
+			t.Errorf("type mismatch: got %s want %s", got.EventType(), e.EventType())
+		}
+		if !got.OccurredAt().Equal(at) {
+			t.Errorf("occurred-at mismatch for %s", typ)
+		}
+	}
+
+	// Carrier/tracking specifically need to survive the round-trip on OrderShipped.
+	round := mustUnmarshal(t, domain.OrderShipped{OrderID: "ord-1", Carrier: "DHL", TrackingCode: "JJD", At: at})
+	if os, ok := round.(domain.OrderShipped); !ok || os.Carrier != "DHL" || os.TrackingCode != "JJD" {
+		t.Errorf("OrderShipped carrier/tracking lost: %+v", round)
 	}
 }
 

--- a/backend/checkout/adapter/events_postgres.go
+++ b/backend/checkout/adapter/events_postgres.go
@@ -85,13 +85,33 @@ func projectEventTx(ctx context.Context, tx *sql.Tx, e domain.Event) error {
 		return setOrderStatus(ctx, tx, ev.OrderID, string(domain.StatusFailed))
 	case domain.OrderCancelled:
 		return setOrderStatus(ctx, tx, ev.OrderID, string(domain.StatusCancelled))
+	case domain.OrderShipped:
+		return projectOrderShipped(ctx, tx, ev)
+	case domain.OrderDelivered:
+		return setOrderStatus(ctx, tx, ev.OrderID, string(domain.StatusDelivered))
+	case domain.OrderRefunded:
+		return setOrderStatus(ctx, tx, ev.OrderID, string(domain.StatusRefunded))
 	default:
 		return fmt.Errorf("no projection for event %s", e.EventType())
 	}
 }
 
+// projectOrderShipped updates the order status and stores the optional
+// carrier/tracking metadata on the read model row.
+func projectOrderShipped(ctx context.Context, tx *sql.Tx, ev domain.OrderShipped) error {
+	if _, err := tx.ExecContext(ctx, `
+		UPDATE checkout_order
+		SET status = $2, carrier = $3, tracking_code = $4
+		WHERE id = $1
+	`, ev.OrderID, string(domain.StatusShipped), ev.Carrier, ev.TrackingCode); err != nil {
+		return fmt.Errorf("project shipped: %w", err)
+	}
+	return nil
+}
+
 func projectOrderPlaced(ctx context.Context, tx *sql.Tx, ev domain.OrderPlaced) error {
-	// Fold the single event into an Order so we can reuse its derived totals.
+	// Fold the single event into an Order so we can reuse its derived totals
+	// (the aggregate already applies the threshold-aware shipping/tax math).
 	o := domain.RehydrateOrder([]domain.Event{ev})
 
 	var customerID sql.NullString
@@ -107,8 +127,8 @@ func projectOrderPlaced(ctx context.Context, tx *sql.Tx, ev domain.OrderPlaced) 
 			(id, user_id, customer_id, total_amount, total_currency, status, placed_at,
 			 ship_name, ship_street1, ship_street2, ship_city, ship_zip, ship_country,
 			 ship_method_code, ship_method_label, ship_cost,
-			 payment_method_code, payment_method_label)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18)
+			 payment_method_code, payment_method_label, tax_amount)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19)
 		ON CONFLICT (id) DO UPDATE SET
 			user_id = EXCLUDED.user_id,
 			customer_id = EXCLUDED.customer_id,
@@ -125,13 +145,14 @@ func projectOrderPlaced(ctx context.Context, tx *sql.Tx, ev domain.OrderPlaced) 
 			ship_method_label = EXCLUDED.ship_method_label,
 			ship_cost = EXCLUDED.ship_cost,
 			payment_method_code = EXCLUDED.payment_method_code,
-			payment_method_label = EXCLUDED.payment_method_label
+			payment_method_label = EXCLUDED.payment_method_label,
+			tax_amount = EXCLUDED.tax_amount
 	`,
 		o.ID(), o.UserID(), customerID, o.TotalAmount(), o.TotalCurrency(),
 		string(o.Status()), o.PlacedAt(),
 		ship.Name(), ship.Street1(), ship.Street2(), ship.City(), ship.Zip(), ship.Country(),
-		method.Code(), method.Label(), method.Cost(),
-		pay.Code(), pay.Label(),
+		method.Code(), method.Label(), o.ShippingCost(),
+		pay.Code(), pay.Label(), o.TaxAmount(),
 	)
 	if err != nil {
 		return fmt.Errorf("project order: %w", err)

--- a/backend/checkout/adapter/postgres.go
+++ b/backend/checkout/adapter/postgres.go
@@ -160,6 +160,35 @@ func (p Postgres) ListByCustomer(ctx context.Context, customerID string) ([]quer
 	return summaries, nil
 }
 
+// ListExpiredPending returns the ids of orders still in the pending status
+// whose placed_at is strictly older than olderThan. The reservation TTL
+// sweeper uses this list to release orphaned stock reservations.
+func (p Postgres) ListExpiredPending(ctx context.Context, olderThan time.Time) ([]string, error) {
+	rows, err := p.db.QueryContext(ctx, `
+		SELECT id
+		FROM checkout_order
+		WHERE status = $1 AND placed_at < $2
+		ORDER BY placed_at
+	`, string(domain.StatusPending), olderThan)
+	if err != nil {
+		return nil, fmt.Errorf("query expired pending: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("scan expired pending: %w", err)
+		}
+		ids = append(ids, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("rows: %w", err)
+	}
+	return ids, nil
+}
+
 // ListAll returns every order newest-first as list summaries, regardless of
 // customer (including anonymous orders with a NULL customer_id). It powers the
 // admin order list and uses the same grouped query as ListByCustomer without

--- a/backend/checkout/adapter/postgres.go
+++ b/backend/checkout/adapter/postgres.go
@@ -63,7 +63,8 @@ func (p Postgres) Find(ctx context.Context, id string) (query.OrderView, error) 
 	var shipName, shipStreet1, shipStreet2, shipCity, shipZip, shipCountry sql.NullString
 	var shipMethodCode, shipMethodLabel sql.NullString
 	var payMethodCode, payMethodLabel sql.NullString
-	var shipCost int64
+	var shipCost, taxAmt int64
+	var carrier, trackingCode string
 	var totalAmt int64
 	var placedAt time.Time
 
@@ -71,12 +72,14 @@ func (p Postgres) Find(ctx context.Context, id string) (query.OrderView, error) 
 		SELECT user_id, customer_id, total_amount, total_currency, status, placed_at,
 		       ship_name, ship_street1, ship_street2, ship_city, ship_zip, ship_country,
 		       ship_method_code, ship_method_label, ship_cost,
-		       payment_method_code, payment_method_label
+		       payment_method_code, payment_method_label,
+		       tax_amount, carrier, tracking_code
 		FROM checkout_order WHERE id = $1
 	`, id).Scan(&userID, &customerID, &totalAmt, &currency, &status, &placedAt,
 		&shipName, &shipStreet1, &shipStreet2, &shipCity, &shipZip, &shipCountry,
 		&shipMethodCode, &shipMethodLabel, &shipCost,
-		&payMethodCode, &payMethodLabel)
+		&payMethodCode, &payMethodLabel,
+		&taxAmt, &carrier, &trackingCode)
 	if errors.Is(err, sql.ErrNoRows) {
 		return query.OrderView{}, domain.ErrOrderNotFound
 	}
@@ -115,10 +118,12 @@ func (p Postgres) Find(ctx context.Context, id string) (query.OrderView, error) 
 	shipMethod := domain.RebuildShippingMethod(shipMethodCode.String, shipMethodLabel.String, shipCost)
 	payMethod := domain.RebuildPaymentMethod(payMethodCode.String, payMethodLabel.String)
 
+	subtotal := totalAmt - shipCost - taxAmt
 	return query.NewOrderView(
 		id, customerID.String, domain.Status(status), placedAt,
 		lines, shipTo, shipMethod, payMethod,
-		totalAmt-shipCost, totalAmt, currency,
+		subtotal, taxAmt, shipCost, totalAmt, currency,
+		carrier, trackingCode,
 	), nil
 }
 

--- a/backend/checkout/app/checkout.go
+++ b/backend/checkout/app/checkout.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"time"
 
 	cartDomain "github.com/bkielbasa/go-ecommerce/backend/cart/domain"
@@ -50,18 +51,66 @@ type StockReserver interface {
 	Release(ctx context.Context, quantities map[string]int) error
 }
 
+// StockMovements is the audit-log seam: every reservation/release/refund the
+// checkout context drives also records a row in the catalogue's stock
+// movement log. It is intentionally separate from StockReserver so we don't
+// have to widen the existing Reserve/Release signatures (which other
+// contexts call). A no-op implementation (nopStockMovements) is used when no
+// recorder is wired so existing tests stay unchanged.
+type StockMovements interface {
+	Record(ctx context.Context, variantID string, delta int, reason, refOrderID string) error
+}
+
+// nopStockMovements is the default StockMovements when none is supplied. It
+// keeps the audit trail strictly additive: contexts that don't care simply
+// see no log rows.
+type nopStockMovements struct{}
+
+func (nopStockMovements) Record(context.Context, string, int, string, string) error { return nil }
+
+// PricingPolicy tells the checkout service how to derive tax and the
+// effective shipping cost from the order's subtotal and chosen shipping
+// method. Both fields default to zero/disabled so existing wiring stays
+// arithmetic-identical to before the change.
+type PricingPolicy struct {
+	// TaxRatePercent is the flat tax rate applied to the subtotal, e.g.
+	// 8.875 for 8.875%. 0 disables tax.
+	TaxRatePercent float64
+	// FreeShippingThreshold is the minimum subtotal (in minor units) at or
+	// above which the chosen method's shipping cost is overridden to 0.
+	// 0 disables the override.
+	FreeShippingThreshold int64
+}
+
+// computeTaxAndShipping applies the policy to a given subtotal + method,
+// returning the tax amount and the effective shipping cost (both in minor
+// units).
+func (p PricingPolicy) computeTaxAndShipping(subtotal int64, method domain.ShippingMethod) (int64, int64) {
+	var tax int64
+	if p.TaxRatePercent > 0 && subtotal > 0 {
+		tax = int64(math.Round(float64(subtotal) * p.TaxRatePercent / 100.0))
+	}
+	shipping := method.Cost()
+	if p.FreeShippingThreshold > 0 && subtotal >= p.FreeShippingThreshold {
+		shipping = 0
+	}
+	return tax, shipping
+}
+
 // IDGenerator returns a fresh order ID. Injected so tests can substitute a
 // deterministic generator.
 type IDGenerator func() string
 
 type CheckoutService struct {
-	cart    CartReader
-	storage OrderStorage
-	payment PaymentProcessor
-	stock   StockReserver
-	events  EventPublisher
-	newID   IDGenerator
-	now     func() time.Time
+	cart      CartReader
+	storage   OrderStorage
+	payment   PaymentProcessor
+	stock     StockReserver
+	movements StockMovements
+	events    EventPublisher
+	newID     IDGenerator
+	now       func() time.Time
+	pricing   PricingPolicy
 }
 
 func NewCheckoutService(
@@ -69,17 +118,24 @@ func NewCheckoutService(
 	storage OrderStorage,
 	payment PaymentProcessor,
 	stock StockReserver,
+	movements StockMovements,
 	events EventPublisher,
 	newID IDGenerator,
+	pricing PricingPolicy,
 ) CheckoutService {
+	if movements == nil {
+		movements = nopStockMovements{}
+	}
 	return CheckoutService{
-		cart:    cart,
-		storage: storage,
-		payment: payment,
-		stock:   stock,
-		events:  events,
-		newID:   newID,
-		now:     func() time.Time { return time.Now().UTC() },
+		cart:      cart,
+		storage:   storage,
+		payment:   payment,
+		stock:     stock,
+		movements: movements,
+		events:    events,
+		newID:     newID,
+		now:       func() time.Time { return time.Now().UTC() },
+		pricing:   pricing,
 	}
 }
 
@@ -123,9 +179,28 @@ func (s CheckoutService) Place(ctx context.Context, sessID, customerID, cardNumb
 		return domain.Order{}, fmt.Errorf("reserve stock: %w", err)
 	}
 
-	order, err := domain.PlaceOrder(s.newID(), sessID, customerID, shipTo, shipMethod, payMethod, lines, s.now())
+	orderID := s.newID()
+	// Record reservation movements (best-effort: a failure here must not
+	// undo the reservation itself).
+	for vid, qty := range quantities {
+		_ = s.movements.Record(ctx, vid, -qty, "reserve", orderID)
+	}
+
+	// Apply the configured tax + free-shipping threshold to derive what the
+	// customer is actually charged. Both default to 0 so an unconfigured
+	// app behaves exactly like before this change.
+	var subtotal int64
+	for _, ln := range lines {
+		subtotal += ln.LineTotal()
+	}
+	tax, effectiveShipping := s.pricing.computeTaxAndShipping(subtotal, shipMethod)
+
+	order, err := domain.PlaceOrder(orderID, sessID, customerID, shipTo, shipMethod, payMethod, lines, tax, effectiveShipping, s.now())
 	if err != nil {
 		_ = s.stock.Release(ctx, quantities)
+		for vid, qty := range quantities {
+			_ = s.movements.Record(ctx, vid, qty, "release-place-failed", orderID)
+		}
 		return domain.Order{}, err
 	}
 
@@ -133,6 +208,9 @@ func (s CheckoutService) Place(ctx context.Context, sessID, customerID, cardNumb
 		// Payment failed after reserving — give the stock back, record the
 		// failed attempt, and report the decline.
 		_ = s.stock.Release(ctx, quantities)
+		for vid, qty := range quantities {
+			_ = s.movements.Record(ctx, vid, qty, "release-failed-payment", orderID)
+		}
 		order.MarkFailed(chargeErr.Error(), s.now())
 		if err := s.storage.Save(ctx, order); err != nil {
 			return domain.Order{}, fmt.Errorf("save order: %w", err)
@@ -144,6 +222,9 @@ func (s CheckoutService) Place(ctx context.Context, sessID, customerID, cardNumb
 	if err := s.storage.Save(ctx, order); err != nil {
 		// Order couldn't be persisted; return the reservation.
 		_ = s.stock.Release(ctx, quantities)
+		for vid, qty := range quantities {
+			_ = s.movements.Record(ctx, vid, qty, "release-save-failed", orderID)
+		}
 		return domain.Order{}, fmt.Errorf("save order: %w", err)
 	}
 
@@ -199,14 +280,14 @@ func (s CheckoutService) cancel(ctx context.Context, order *domain.Order, reason
 		return fmt.Errorf("save cancellation: %w", err)
 	}
 
-	s.releaseStock(ctx, order)
+	s.releaseStock(ctx, order, "release-cancel")
 	return nil
 }
 
-// releaseStock returns every line's quantity to the catalogue (best-effort).
-// Used by the cancel path and by the reservation TTL sweeper when failing
-// orphaned pending orders.
-func (s CheckoutService) releaseStock(ctx context.Context, order *domain.Order) {
+// releaseStock returns every line's quantity to the catalogue (best-effort)
+// and records a movement per variant for the audit trail. reason describes
+// why the release happened (e.g. "release", "release-refund").
+func (s CheckoutService) releaseStock(ctx context.Context, order *domain.Order, reason string) {
 	quantities := map[string]int{}
 	for _, ln := range order.Items() {
 		quantities[ln.ProductID()] += ln.Quantity()
@@ -215,6 +296,9 @@ func (s CheckoutService) releaseStock(ctx context.Context, order *domain.Order) 
 		return
 	}
 	_ = s.stock.Release(ctx, quantities)
+	for vid, qty := range quantities {
+		_ = s.movements.Record(ctx, vid, qty, reason, order.ID())
+	}
 }
 
 // ExpirePending fails a pending order whose reservation TTL has elapsed: it
@@ -235,6 +319,55 @@ func (s CheckoutService) ExpirePending(ctx context.Context, orderID string) erro
 	if err := s.storage.Save(ctx, order); err != nil {
 		return fmt.Errorf("save expired order: %w", err)
 	}
-	s.releaseStock(ctx, order)
+	s.releaseStock(ctx, order, "release-expired")
+	return nil
+}
+
+// MarkShipped transitions a paid order to shipped, optionally recording the
+// carrier and tracking code. Admin-only — never wired into the customer
+// surface.
+func (s CheckoutService) MarkShipped(ctx context.Context, orderID, carrier, trackingCode string) error {
+	order, err := s.storage.Load(ctx, orderID)
+	if err != nil {
+		return err
+	}
+	if err := order.MarkShipped(carrier, trackingCode, s.now()); err != nil {
+		return err
+	}
+	if err := s.storage.Save(ctx, order); err != nil {
+		return fmt.Errorf("save shipped: %w", err)
+	}
+	return nil
+}
+
+// MarkDelivered transitions a shipped order to delivered. Admin-only.
+func (s CheckoutService) MarkDelivered(ctx context.Context, orderID string) error {
+	order, err := s.storage.Load(ctx, orderID)
+	if err != nil {
+		return err
+	}
+	if err := order.MarkDelivered(s.now()); err != nil {
+		return err
+	}
+	if err := s.storage.Save(ctx, order); err != nil {
+		return fmt.Errorf("save delivered: %w", err)
+	}
+	return nil
+}
+
+// Refund refunds a paid/shipped/delivered order and returns its stock to the
+// catalogue (refunds bring the goods back). Admin-only.
+func (s CheckoutService) Refund(ctx context.Context, orderID, reason string) error {
+	order, err := s.storage.Load(ctx, orderID)
+	if err != nil {
+		return err
+	}
+	if err := order.Refund(reason, s.now()); err != nil {
+		return err
+	}
+	if err := s.storage.Save(ctx, order); err != nil {
+		return fmt.Errorf("save refund: %w", err)
+	}
+	s.releaseStock(ctx, order, "release-refund")
 	return nil
 }

--- a/backend/checkout/app/checkout.go
+++ b/backend/checkout/app/checkout.go
@@ -199,12 +199,42 @@ func (s CheckoutService) cancel(ctx context.Context, order *domain.Order, reason
 		return fmt.Errorf("save cancellation: %w", err)
 	}
 
-	// Return the reserved stock to the catalogue (best-effort).
+	s.releaseStock(ctx, order)
+	return nil
+}
+
+// releaseStock returns every line's quantity to the catalogue (best-effort).
+// Used by the cancel path and by the reservation TTL sweeper when failing
+// orphaned pending orders.
+func (s CheckoutService) releaseStock(ctx context.Context, order *domain.Order) {
 	quantities := map[string]int{}
 	for _, ln := range order.Items() {
 		quantities[ln.ProductID()] += ln.Quantity()
 	}
+	if len(quantities) == 0 {
+		return
+	}
 	_ = s.stock.Release(ctx, quantities)
+}
 
+// ExpirePending fails a pending order whose reservation TTL has elapsed: it
+// rehydrates the aggregate, marks it failed with a "reservation expired"
+// reason, persists the event, and releases the reserved stock. It is
+// idempotent — if the order is no longer pending (another worker raced us, or
+// the customer's payment finally landed) it returns nil without touching the
+// aggregate. Used by the reservation TTL sweeper.
+func (s CheckoutService) ExpirePending(ctx context.Context, orderID string) error {
+	order, err := s.storage.Load(ctx, orderID)
+	if err != nil {
+		return err
+	}
+	if order.Status() != domain.StatusPending {
+		return nil
+	}
+	order.MarkFailed("reservation expired", s.now())
+	if err := s.storage.Save(ctx, order); err != nil {
+		return fmt.Errorf("save expired order: %w", err)
+	}
+	s.releaseStock(ctx, order)
 	return nil
 }

--- a/backend/checkout/bounded_context.go
+++ b/backend/checkout/bounded_context.go
@@ -28,15 +28,27 @@ type StockReserver interface {
 	Release(ctx context.Context, quantities map[string]int) error
 }
 
+// StockMovements is the audit-log seam: every reservation/release/refund the
+// checkout context drives is also recorded in the catalogue's stock movement
+// log. Implemented by productcatalog/app.ProductService.
+type StockMovements interface {
+	Record(ctx context.Context, variantID string, delta int, reason, refOrderID string) error
+}
+
 // New wires the checkout context and returns its command service (write side,
 // event-sourced) and query service (read side, projection-backed) separately,
 // keeping the CQRS split explicit at the composition root. Cross-context side
 // effects (e.g. clearing the cart) are driven by integration events published
 // on bus, not by direct calls.
-func New(db *sql.DB, cart CartReader, bus *eventbus.Bus, stock StockReserver) (application.BoundedContext, app.CheckoutService, query.Service) {
+//
+// movements may be nil — checkout then runs without writing audit rows, which
+// is the historical behaviour. pricing carries tax + free-shipping config; a
+// zero-value PricingPolicy disables both, again matching the historical
+// behaviour.
+func New(db *sql.DB, cart CartReader, bus *eventbus.Bus, stock StockReserver, movements StockMovements, pricing app.PricingPolicy) (application.BoundedContext, app.CheckoutService, query.Service) {
 	storage := adapter.NewPostgres(db)
 	payment := adapter.NewFakePayment()
-	cmd := app.NewCheckoutService(cart, storage, payment, stock, bus, newOrderID)
+	cmd := app.NewCheckoutService(cart, storage, payment, stock, movements, bus, newOrderID, pricing)
 	queries := query.NewService(storage)
 	return &boundedContext{}, cmd, queries
 }

--- a/backend/checkout/domain/events.go
+++ b/backend/checkout/domain/events.go
@@ -14,15 +14,22 @@ type Event interface {
 
 // OrderPlaced is emitted when a customer places an order. It carries the full
 // snapshot of what was ordered so the order is self-contained.
+//
+// Tax is the tax amount in minor units computed at place time from the
+// configured tax rate; ShippingCost is the EFFECTIVE shipping price at place
+// time (which may be 0 if the configured free-shipping threshold was met,
+// overriding the catalogue method's Cost()).
 type OrderPlaced struct {
-	OrderID    string
-	UserID     string
-	CustomerID string
-	ShipTo     Address
-	ShipMethod ShippingMethod
-	PayMethod  PaymentMethod
-	Lines      []Line
-	At         time.Time
+	OrderID      string
+	UserID       string
+	CustomerID   string
+	ShipTo       Address
+	ShipMethod   ShippingMethod
+	PayMethod    PaymentMethod
+	Lines        []Line
+	Tax          int64
+	ShippingCost int64
+	At           time.Time
 }
 
 func (e OrderPlaced) EventType() string     { return "OrderPlaced" }
@@ -56,3 +63,36 @@ type OrderCancelled struct {
 
 func (e OrderCancelled) EventType() string     { return "OrderCancelled" }
 func (e OrderCancelled) OccurredAt() time.Time { return e.At }
+
+// OrderShipped is emitted when an admin marks a paid order as dispatched.
+// Carrier and TrackingCode are optional (empty strings when not supplied).
+type OrderShipped struct {
+	OrderID      string
+	Carrier      string
+	TrackingCode string
+	At           time.Time
+}
+
+func (e OrderShipped) EventType() string     { return "OrderShipped" }
+func (e OrderShipped) OccurredAt() time.Time { return e.At }
+
+// OrderDelivered is emitted when an admin marks a shipped order as delivered.
+type OrderDelivered struct {
+	OrderID string
+	At      time.Time
+}
+
+func (e OrderDelivered) EventType() string     { return "OrderDelivered" }
+func (e OrderDelivered) OccurredAt() time.Time { return e.At }
+
+// OrderRefunded is emitted when an admin refunds a paid/shipped/delivered
+// order. Refund returns the goods so reserved/sold stock is added back to
+// the catalogue.
+type OrderRefunded struct {
+	OrderID string
+	Reason  string
+	At      time.Time
+}
+
+func (e OrderRefunded) EventType() string     { return "OrderRefunded" }
+func (e OrderRefunded) OccurredAt() time.Time { return e.At }

--- a/backend/checkout/domain/order.go
+++ b/backend/checkout/domain/order.go
@@ -13,12 +13,18 @@ const (
 	StatusPaid      Status = "paid"
 	StatusFailed    Status = "failed"
 	StatusCancelled Status = "cancelled"
+	StatusShipped   Status = "shipped"
+	StatusDelivered Status = "delivered"
+	StatusRefunded  Status = "refunded"
 )
 
 var (
 	ErrOrderNotFound       = errors.New("order not found")
 	ErrCartEmpty           = errors.New("cannot place order from an empty cart")
 	ErrOrderNotCancellable = errors.New("order cannot be cancelled")
+	ErrOrderNotShippable   = errors.New("order cannot be shipped")
+	ErrOrderNotDeliverable = errors.New("order cannot be delivered")
+	ErrOrderNotRefundable  = errors.New("order cannot be refunded")
 )
 
 // Order is a placed (or attempted) checkout. Once created, line items are a
@@ -30,18 +36,22 @@ var (
 // orders placed without logging in. Only orders with a non-empty
 // customerID show up in the per-user order history.
 type Order struct {
-	id          string
-	userID      string
-	customerID  string
-	shipTo      Address
-	shipMethod  ShippingMethod
-	payMethod   PaymentMethod
-	items       []Line
-	subtotalAmt int64
-	totalAmt    int64
-	totalCcy    string
-	status      Status
-	placedAt    time.Time
+	id           string
+	userID       string
+	customerID   string
+	shipTo       Address
+	shipMethod   ShippingMethod
+	payMethod    PaymentMethod
+	items        []Line
+	subtotalAmt  int64
+	taxAmt       int64
+	shipCostAmt  int64
+	totalAmt     int64
+	totalCcy     string
+	status       Status
+	placedAt     time.Time
+	carrier      string
+	trackingCode string
 
 	version       int
 	pendingEvents []Event
@@ -99,6 +109,7 @@ func NewOrder(id, userID, customerID string, shipTo Address, shipMethod Shipping
 		payMethod:   payMethod,
 		items:       items,
 		subtotalAmt: subtotal,
+		shipCostAmt: shipMethod.Cost(),
 		totalAmt:    subtotal + shipMethod.Cost(),
 		totalCcy:    ccy,
 		status:      status,
@@ -114,33 +125,44 @@ func (o Order) ShippingMethod() ShippingMethod { return o.shipMethod }
 func (o Order) PaymentMethod() PaymentMethod   { return o.payMethod }
 func (o Order) Subtotal() int64                { return o.subtotalAmt }
 func (o Order) SubtotalDisplay() string        { return money(o.subtotalAmt) }
-func (o Order) ShippingCost() int64            { return o.shipMethod.Cost() }
-func (o Order) ShippingCostDisplay() string    { return money(o.shipMethod.Cost()) }
+func (o Order) ShippingCost() int64            { return o.shipCostAmt }
+func (o Order) ShippingCostDisplay() string    { return money(o.shipCostAmt) }
+func (o Order) TaxAmount() int64               { return o.taxAmt }
+func (o Order) TaxDisplay() string             { return money(o.taxAmt) }
 func (o Order) Items() []Line         { return o.items }
 func (o Order) Status() Status        { return o.status }
 func (o Order) PlacedAt() time.Time   { return o.placedAt }
 func (o Order) TotalAmount() int64    { return o.totalAmt }
 func (o Order) TotalCurrency() string { return o.totalCcy }
 func (o Order) TotalDisplay() string  { return money(o.totalAmt) }
+func (o Order) Carrier() string       { return o.carrier }
+func (o Order) TrackingCode() string  { return o.trackingCode }
 
 // --- event-sourced write side ---
 
 // PlaceOrder is the command that creates a new order from a cart snapshot
 // and the customer's checkout choices. It emits an OrderPlaced event.
-func PlaceOrder(id, userID, customerID string, shipTo Address, shipMethod ShippingMethod, payMethod PaymentMethod, lines []Line, at time.Time) (*Order, error) {
+//
+// tax is the tax amount in minor units already computed by the caller
+// (CheckoutService) from the configured rate. effectiveShipping is the
+// shipping price actually charged — equal to shipMethod.Cost() in the normal
+// case, but 0 when a configured free-shipping threshold knocked it down.
+func PlaceOrder(id, userID, customerID string, shipTo Address, shipMethod ShippingMethod, payMethod PaymentMethod, lines []Line, tax, effectiveShipping int64, at time.Time) (*Order, error) {
 	if len(lines) == 0 {
 		return nil, ErrCartEmpty
 	}
 	o := &Order{}
 	o.raise(OrderPlaced{
-		OrderID:    id,
-		UserID:     userID,
-		CustomerID: customerID,
-		ShipTo:     shipTo,
-		ShipMethod: shipMethod,
-		PayMethod:  payMethod,
-		Lines:      lines,
-		At:         at,
+		OrderID:      id,
+		UserID:       userID,
+		CustomerID:   customerID,
+		ShipTo:       shipTo,
+		ShipMethod:   shipMethod,
+		PayMethod:    payMethod,
+		Lines:        lines,
+		Tax:          tax,
+		ShippingCost: effectiveShipping,
+		At:           at,
 	})
 	return o, nil
 }
@@ -180,7 +202,16 @@ func (o *Order) apply(e Event) {
 			}
 		}
 		o.subtotalAmt = subtotal
-		o.totalAmt = subtotal + ev.ShipMethod.Cost()
+		o.taxAmt = ev.Tax
+		// Historical events written before the tax/shipping fields existed
+		// will have ShippingCost == 0 and Tax == 0; fall back to the method
+		// cost so those orders still display their original total.
+		if ev.ShippingCost == 0 && ev.Tax == 0 {
+			o.shipCostAmt = ev.ShipMethod.Cost()
+		} else {
+			o.shipCostAmt = ev.ShippingCost
+		}
+		o.totalAmt = subtotal + o.taxAmt + o.shipCostAmt
 		o.totalCcy = ccy
 		o.status = StatusPending
 		o.placedAt = ev.At
@@ -190,6 +221,14 @@ func (o *Order) apply(e Event) {
 		o.status = StatusFailed
 	case OrderCancelled:
 		o.status = StatusCancelled
+	case OrderShipped:
+		o.status = StatusShipped
+		o.carrier = ev.Carrier
+		o.trackingCode = ev.TrackingCode
+	case OrderDelivered:
+		o.status = StatusDelivered
+	case OrderRefunded:
+		o.status = StatusRefunded
 	}
 	o.version++
 }
@@ -201,6 +240,41 @@ func (o *Order) Cancel(reason string, at time.Time) error {
 		return ErrOrderNotCancellable
 	}
 	o.raise(OrderCancelled{OrderID: o.id, Reason: reason, At: at})
+	return nil
+}
+
+// MarkShipped records that the warehouse dispatched a paid order. Carrier
+// and trackingCode are optional metadata (empty strings are allowed). The
+// transition is only permitted from StatusPaid.
+func (o *Order) MarkShipped(carrier, trackingCode string, at time.Time) error {
+	if o.status != StatusPaid {
+		return ErrOrderNotShippable
+	}
+	o.raise(OrderShipped{OrderID: o.id, Carrier: carrier, TrackingCode: trackingCode, At: at})
+	return nil
+}
+
+// MarkDelivered records that a shipped order reached the customer. Only
+// shipped orders can be marked delivered.
+func (o *Order) MarkDelivered(at time.Time) error {
+	if o.status != StatusShipped {
+		return ErrOrderNotDeliverable
+	}
+	o.raise(OrderDelivered{OrderID: o.id, At: at})
+	return nil
+}
+
+// Refund records that an admin reversed the charge on the order; refunds are
+// allowed for paid, shipped or delivered orders (returning customers get
+// their money back regardless of where the shipment is).
+func (o *Order) Refund(reason string, at time.Time) error {
+	switch o.status {
+	case StatusPaid, StatusShipped, StatusDelivered:
+		// allowed
+	default:
+		return ErrOrderNotRefundable
+	}
+	o.raise(OrderRefunded{OrderID: o.id, Reason: reason, At: at})
 	return nil
 }
 

--- a/backend/checkout/domain/order_test.go
+++ b/backend/checkout/domain/order_test.go
@@ -87,3 +87,84 @@ func TestCancel_FailedOrderNotCancellable(t *testing.T) {
 		t.Errorf("cancel of failed order err = %v, want ErrOrderNotCancellable", err)
 	}
 }
+
+// TestPlaceOrder_AppliesTaxAndEffectiveShipping locks in the tax/shipping
+// math driven by the new PricingPolicy: the OrderPlaced event carries the
+// derived numbers and the rehydrated order's total reflects them.
+func TestPlaceOrder_AppliesTaxAndEffectiveShipping(t *testing.T) {
+	at := time.Date(2026, 5, 27, 9, 0, 0, 0, time.UTC)
+	lines := []domain.Line{domain.NewLine("v1", "Mug", 4, 1000, "USD")}
+	method := domain.RebuildShippingMethod("courier", "Courier", 1500)
+
+	// Caller computed an 8.875% tax on 4000 = 355 and free shipping (threshold met).
+	o, err := domain.PlaceOrder("ord-3", "cart-1", "jane@example.com", domain.Address{}, method,
+		domain.RebuildPaymentMethod("card", "Card"), lines, 355, 0, at)
+	if err != nil {
+		t.Fatalf("PlaceOrder: %v", err)
+	}
+	if o.TaxAmount() != 355 {
+		t.Errorf("tax = %d, want 355", o.TaxAmount())
+	}
+	if o.ShippingCost() != 0 {
+		t.Errorf("shipping = %d, want 0 (free)", o.ShippingCost())
+	}
+	// subtotal 4000 + tax 355 + shipping 0.
+	if o.TotalAmount() != 4355 {
+		t.Errorf("total = %d, want 4355", o.TotalAmount())
+	}
+}
+
+// TestFulfillmentTransitions exercises the paid → shipped → delivered
+// happy path plus the guards: shipping a pending order fails, delivering a
+// paid order fails, refunding a delivered order succeeds, and refunding a
+// cancelled order fails.
+func TestFulfillmentTransitions(t *testing.T) {
+	at := time.Date(2026, 5, 27, 9, 0, 0, 0, time.UTC)
+
+	// Paid order: ship/deliver/refund all valid.
+	paid := domain.RehydrateOrder(paidOrderEvents())
+	if err := paid.MarkShipped("UPS", "1Z-XYZ", at); err != nil {
+		t.Fatalf("MarkShipped: %v", err)
+	}
+	if paid.Status() != domain.StatusShipped {
+		t.Errorf("after MarkShipped: status = %q, want shipped", paid.Status())
+	}
+	if paid.Carrier() != "UPS" || paid.TrackingCode() != "1Z-XYZ" {
+		t.Errorf("carrier/tracking not stored: %q / %q", paid.Carrier(), paid.TrackingCode())
+	}
+	if err := paid.MarkDelivered(at); err != nil {
+		t.Fatalf("MarkDelivered: %v", err)
+	}
+	if paid.Status() != domain.StatusDelivered {
+		t.Errorf("after MarkDelivered: status = %q, want delivered", paid.Status())
+	}
+	if err := paid.Refund("customer return", at); err != nil {
+		t.Fatalf("Refund on delivered: %v", err)
+	}
+	if paid.Status() != domain.StatusRefunded {
+		t.Errorf("after Refund: status = %q, want refunded", paid.Status())
+	}
+
+	// Pending order: not shippable.
+	pending := domain.RehydrateOrder([]domain.Event{
+		domain.OrderPlaced{OrderID: "ord-p", Lines: []domain.Line{domain.NewLine("v", "X", 1, 100, "USD")}, ShipMethod: domain.RebuildShippingMethod("pickup", "Pickup", 0), At: at},
+	})
+	if err := pending.MarkShipped("UPS", "", at); !errors.Is(err, domain.ErrOrderNotShippable) {
+		t.Errorf("MarkShipped on pending = %v, want ErrOrderNotShippable", err)
+	}
+
+	// Paid (not shipped) order: cannot be delivered yet.
+	paid2 := domain.RehydrateOrder(paidOrderEvents())
+	if err := paid2.MarkDelivered(at); !errors.Is(err, domain.ErrOrderNotDeliverable) {
+		t.Errorf("MarkDelivered on paid = %v, want ErrOrderNotDeliverable", err)
+	}
+
+	// Cancelled order: not refundable.
+	cancelled := domain.RehydrateOrder(paidOrderEvents())
+	if err := cancelled.Cancel("changed mind", at); err != nil {
+		t.Fatalf("Cancel: %v", err)
+	}
+	if err := cancelled.Refund("late", at); !errors.Is(err, domain.ErrOrderNotRefundable) {
+		t.Errorf("Refund on cancelled = %v, want ErrOrderNotRefundable", err)
+	}
+}

--- a/backend/checkout/domain/place_test.go
+++ b/backend/checkout/domain/place_test.go
@@ -12,7 +12,7 @@ func TestPlaceOrder_EmptyCartRejected(t *testing.T) {
 	_, err := domain.PlaceOrder("ord-1", "cart-1", "", domain.Address{},
 		domain.RebuildShippingMethod("pickup", "Personal pickup", 0),
 		domain.RebuildPaymentMethod("cod", "Cash on delivery"),
-		nil, time.Now())
+		nil, 0, 0, time.Now())
 	if !errors.Is(err, domain.ErrCartEmpty) {
 		t.Errorf("err = %v, want ErrCartEmpty", err)
 	}
@@ -24,10 +24,11 @@ func TestPlaceOrder_EmitsPendingOrderPlaced(t *testing.T) {
 		domain.NewLine("v1", "Mug", 2, 1500, "USD"),
 		domain.NewLine("v2", "Plate", 1, 2000, "USD"),
 	}
+	method := domain.RebuildShippingMethod("courier", "Courier", 1500)
 	o, err := domain.PlaceOrder("ord-1", "cart-1", "jane@example.com", domain.Address{},
-		domain.RebuildShippingMethod("courier", "Courier", 1500),
+		method,
 		domain.RebuildPaymentMethod("card", "Credit / debit card"),
-		lines, at)
+		lines, 0, method.Cost(), at)
 	if err != nil {
 		t.Fatalf("PlaceOrder: %v", err)
 	}

--- a/backend/checkout/query/service.go
+++ b/backend/checkout/query/service.go
@@ -1,6 +1,9 @@
 package query
 
-import "context"
+import (
+	"context"
+	"time"
+)
 
 // Repository is the read side's data source — it reads the projection tables
 // and returns read models, never the write aggregate.
@@ -8,6 +11,11 @@ type Repository interface {
 	Find(ctx context.Context, id string) (OrderView, error)
 	ListByCustomer(ctx context.Context, customerID string) ([]OrderSummary, error)
 	ListAll(ctx context.Context) ([]OrderSummary, error)
+	// ListExpiredPending returns the ids of orders still in the pending
+	// status whose placed_at is strictly older than olderThan. The
+	// reservation TTL sweeper uses this to find orphaned reservations to
+	// release.
+	ListExpiredPending(ctx context.Context, olderThan time.Time) ([]string, error)
 }
 
 // Service is the checkout query side. It is intentionally separate from the
@@ -38,4 +46,11 @@ func (s Service) ListByCustomer(ctx context.Context, customerID string) ([]Order
 // customer. Intended for the admin order list.
 func (s Service) ListAll(ctx context.Context) ([]OrderSummary, error) {
 	return s.repo.ListAll(ctx)
+}
+
+// ListExpiredPending returns the ids of pending orders placed before
+// olderThan — i.e. reservations whose TTL has elapsed without the order
+// being confirmed or explicitly failed. Used by the reservation sweeper.
+func (s Service) ListExpiredPending(ctx context.Context, olderThan time.Time) ([]string, error) {
+	return s.repo.ListExpiredPending(ctx, olderThan)
 }

--- a/backend/checkout/query/views.go
+++ b/backend/checkout/query/views.go
@@ -41,17 +41,21 @@ func (s OrderSummary) TotalCurrency() string { return s.currency }
 
 // OrderView is the read model for the order detail page.
 type OrderView struct {
-	id         string
-	customerID string
-	status     domain.Status
-	placedAt   time.Time
-	items      []domain.Line
-	shipTo     domain.Address
-	shipMethod domain.ShippingMethod
-	payMethod  domain.PaymentMethod
-	subtotal   int64
-	total      int64
-	currency   string
+	id           string
+	customerID   string
+	status       domain.Status
+	placedAt     time.Time
+	items        []domain.Line
+	shipTo       domain.Address
+	shipMethod   domain.ShippingMethod
+	payMethod    domain.PaymentMethod
+	subtotal     int64
+	tax          int64
+	shipCost     int64
+	total        int64
+	currency     string
+	carrier      string
+	trackingCode string
 }
 
 func NewOrderView(
@@ -62,13 +66,15 @@ func NewOrderView(
 	shipTo domain.Address,
 	shipMethod domain.ShippingMethod,
 	payMethod domain.PaymentMethod,
-	subtotal, total int64,
+	subtotal, tax, shipCost, total int64,
 	currency string,
+	carrier, trackingCode string,
 ) OrderView {
 	return OrderView{
 		id: id, customerID: customerID, status: status, placedAt: placedAt,
 		items: items, shipTo: shipTo, shipMethod: shipMethod, payMethod: payMethod,
-		subtotal: subtotal, total: total, currency: currency,
+		subtotal: subtotal, tax: tax, shipCost: shipCost, total: total, currency: currency,
+		carrier: carrier, trackingCode: trackingCode,
 	}
 }
 
@@ -81,6 +87,11 @@ func (v OrderView) ShipTo() domain.Address                { return v.shipTo }
 func (v OrderView) ShippingMethod() domain.ShippingMethod { return v.shipMethod }
 func (v OrderView) PaymentMethod() domain.PaymentMethod   { return v.payMethod }
 func (v OrderView) SubtotalDisplay() string               { return money(v.subtotal) }
-func (v OrderView) ShippingCostDisplay() string           { return money(v.shipMethod.Cost()) }
+func (v OrderView) ShippingCost() int64                   { return v.shipCost }
+func (v OrderView) ShippingCostDisplay() string           { return money(v.shipCost) }
+func (v OrderView) TaxAmount() int64                      { return v.tax }
+func (v OrderView) TaxDisplay() string                    { return money(v.tax) }
 func (v OrderView) TotalDisplay() string                  { return money(v.total) }
 func (v OrderView) TotalCurrency() string                 { return v.currency }
+func (v OrderView) Carrier() string                       { return v.carrier }
+func (v OrderView) TrackingCode() string                  { return v.trackingCode }

--- a/backend/checkout/sweeper/sweeper.go
+++ b/backend/checkout/sweeper/sweeper.go
@@ -1,0 +1,128 @@
+// Package sweeper runs a periodic background worker that releases stock
+// reservations held by orders stuck in the pending state past their TTL.
+//
+// Checkout reserves stock up front when an order is placed and either marks
+// the order paid on a successful charge or releases the stock on an explicit
+// failure. If neither path completes (process crash, a hung async payment
+// confirmation, an abandoned cart after stock was reserved) the order stays
+// pending and the reservation is held forever. The sweeper closes that gap:
+// every interval it lists pending orders whose placed_at is older than a
+// configurable TTL and fails each one, which runs through the existing
+// release-the-reservation path. Processing is sequential — concurrency
+// across multiple replicas would need a DB lease, which is out of scope.
+package sweeper
+
+import (
+	"context"
+	"time"
+
+	"github.com/bkielbasa/go-ecommerce/backend/checkout/query"
+	"github.com/sirupsen/logrus"
+)
+
+// ExpireCommand is the subset of the checkout write side the sweeper needs.
+// Satisfied by app.CheckoutService.ExpirePending; the indirection keeps the
+// sweeper trivially fakeable in tests.
+type ExpireCommand interface {
+	ExpirePending(ctx context.Context, orderID string) error
+}
+
+// expiredPendingLister is the narrow read-side seam the sweeper needs.
+// query.Service satisfies it structurally; tests can pass a fake.
+type expiredPendingLister interface {
+	ListExpiredPending(ctx context.Context, olderThan time.Time) ([]string, error)
+}
+
+// Sweeper periodically expires pending orders past their reservation TTL.
+type Sweeper struct {
+	queries  expiredPendingLister
+	commands ExpireCommand
+	ttl      time.Duration
+	interval time.Duration
+	logger   logrus.FieldLogger
+	now      func() time.Time
+}
+
+// New builds a Sweeper. ttl is how old a pending order must be before it is
+// expired; interval is how often the sweep runs. Both should be positive —
+// non-positive values disable the sweeper at Run time so a misconfigured
+// deployment can't crash or spin.
+func New(queries query.Service, commands ExpireCommand, ttl, interval time.Duration, logger logrus.FieldLogger) *Sweeper {
+	return newSweeper(queries, commands, ttl, interval, logger)
+}
+
+// newSweeper builds a Sweeper from the narrow read-side seam. The exported
+// New pins the dependency to the concrete query.Service to keep the
+// composition root explicit; tests use this constructor with a fake.
+func newSweeper(queries expiredPendingLister, commands ExpireCommand, ttl, interval time.Duration, logger logrus.FieldLogger) *Sweeper {
+	return &Sweeper{
+		queries:  queries,
+		commands: commands,
+		ttl:      ttl,
+		interval: interval,
+		logger:   logger,
+		now:      func() time.Time { return time.Now().UTC() },
+	}
+}
+
+// Run blocks until ctx is cancelled, sweeping every interval. The first
+// sweep happens after one tick — never immediately — so that bootstrapping
+// the storage layer can't be raced. If ttl or interval is non-positive the
+// sweeper logs a warning and returns without scheduling anything.
+func (s *Sweeper) Run(ctx context.Context) {
+	if s.interval <= 0 || s.ttl <= 0 {
+		s.logger.WithFields(logrus.Fields{
+			"interval": s.interval.String(),
+			"ttl":      s.ttl.String(),
+		}).Warn("reservation sweeper disabled: non-positive interval or ttl")
+		return
+	}
+
+	s.logger.WithFields(logrus.Fields{
+		"interval": s.interval.String(),
+		"ttl":      s.ttl.String(),
+	}).Info("reservation sweeper started")
+
+	ticker := time.NewTicker(s.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			s.logger.Info("reservation sweeper stopped")
+			return
+		case <-ticker.C:
+			s.sweep(ctx, s.now())
+		}
+	}
+}
+
+// sweep performs a single sweep pass against the given "now". Split out so
+// tests can drive it deterministically without a ticker.
+func (s *Sweeper) sweep(ctx context.Context, now time.Time) {
+	cutoff := now.Add(-s.ttl)
+	ids, err := s.queries.ListExpiredPending(ctx, cutoff)
+	if err != nil {
+		s.logger.WithError(err).WithField("cutoff", cutoff).Warn("reservation sweeper: list expired pending failed")
+		return
+	}
+	if len(ids) == 0 {
+		return
+	}
+
+	s.logger.WithFields(logrus.Fields{
+		"count":  len(ids),
+		"cutoff": cutoff,
+	}).Info("reservation sweeper: expiring pending orders")
+
+	for _, id := range ids {
+		if err := ctx.Err(); err != nil {
+			return
+		}
+		if err := s.commands.ExpirePending(ctx, id); err != nil {
+			s.logger.WithError(err).WithField("order_id", id).Warn("reservation sweeper: expire pending failed")
+			continue
+		}
+		s.logger.WithField("order_id", id).Info("reservation sweeper: pending order expired, reservation released")
+	}
+}

--- a/backend/checkout/sweeper/sweeper_test.go
+++ b/backend/checkout/sweeper/sweeper_test.go
@@ -1,0 +1,154 @@
+package sweeper
+
+import (
+	"context"
+	"errors"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/matryer/is"
+	"github.com/sirupsen/logrus"
+)
+
+type fakeQueries struct {
+	ids        []string
+	err        error
+	lastCutoff time.Time
+	calls      int
+}
+
+func (f *fakeQueries) ListExpiredPending(_ context.Context, olderThan time.Time) ([]string, error) {
+	f.calls++
+	f.lastCutoff = olderThan
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.ids, nil
+}
+
+type fakeCommand struct {
+	expired []string
+	errs    map[string]error
+}
+
+func (f *fakeCommand) ExpirePending(_ context.Context, orderID string) error {
+	if err, ok := f.errs[orderID]; ok {
+		return err
+	}
+	f.expired = append(f.expired, orderID)
+	return nil
+}
+
+func discardLogger() logrus.FieldLogger {
+	l := logrus.New()
+	l.SetOutput(io.Discard)
+	return l
+}
+
+func TestSweep_ExpiresEveryReturnedID(t *testing.T) {
+	is := is.New(t)
+	q := &fakeQueries{ids: []string{"ord-1", "ord-2", "ord-3"}}
+	c := &fakeCommand{}
+
+	s := newSweeper(q, c, 30*time.Minute, 5*time.Minute, discardLogger())
+	now := time.Date(2026, 1, 2, 12, 0, 0, 0, time.UTC)
+	s.sweep(context.Background(), now)
+
+	is.Equal(c.expired, []string{"ord-1", "ord-2", "ord-3"})
+	is.Equal(q.lastCutoff, now.Add(-30*time.Minute))
+	is.Equal(q.calls, 1)
+}
+
+func TestSweep_NoExpired_NoCommands(t *testing.T) {
+	is := is.New(t)
+	q := &fakeQueries{ids: nil}
+	c := &fakeCommand{}
+
+	s := newSweeper(q, c, 30*time.Minute, 5*time.Minute, discardLogger())
+	s.sweep(context.Background(), time.Now())
+
+	is.Equal(len(c.expired), 0)
+}
+
+func TestSweep_ListErrorDoesNotPanicAndSkipsExpiry(t *testing.T) {
+	is := is.New(t)
+	q := &fakeQueries{err: errors.New("db down")}
+	c := &fakeCommand{}
+
+	s := newSweeper(q, c, 30*time.Minute, 5*time.Minute, discardLogger())
+	s.sweep(context.Background(), time.Now())
+
+	is.Equal(len(c.expired), 0)
+}
+
+func TestSweep_ContinuesOnPerOrderError(t *testing.T) {
+	is := is.New(t)
+	q := &fakeQueries{ids: []string{"ord-1", "ord-2", "ord-3"}}
+	c := &fakeCommand{errs: map[string]error{"ord-2": errors.New("boom")}}
+
+	s := newSweeper(q, c, 30*time.Minute, 5*time.Minute, discardLogger())
+	s.sweep(context.Background(), time.Now())
+
+	is.Equal(c.expired, []string{"ord-1", "ord-3"})
+}
+
+func TestSweep_StopsWhenContextCancelled(t *testing.T) {
+	is := is.New(t)
+	q := &fakeQueries{ids: []string{"ord-1", "ord-2"}}
+	c := &fakeCommand{}
+
+	s := newSweeper(q, c, 30*time.Minute, 5*time.Minute, discardLogger())
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	s.sweep(ctx, time.Now())
+
+	is.Equal(len(c.expired), 0)
+}
+
+func TestRun_DisabledOnNonPositiveInterval(t *testing.T) {
+	is := is.New(t)
+	q := &fakeQueries{ids: []string{"ord-1"}}
+	c := &fakeCommand{}
+
+	s := newSweeper(q, c, 30*time.Minute, 0, discardLogger())
+	// Run returns immediately when disabled — no goroutine, no ticker, no panic.
+	s.Run(context.Background())
+
+	is.Equal(q.calls, 0)
+	is.Equal(len(c.expired), 0)
+}
+
+func TestRun_DisabledOnNonPositiveTTL(t *testing.T) {
+	is := is.New(t)
+	q := &fakeQueries{ids: []string{"ord-1"}}
+	c := &fakeCommand{}
+
+	s := newSweeper(q, c, 0, time.Minute, discardLogger())
+	s.Run(context.Background())
+
+	is.Equal(q.calls, 0)
+	is.Equal(len(c.expired), 0)
+}
+
+func TestRun_StopsOnContextCancel(t *testing.T) {
+	q := &fakeQueries{}
+	c := &fakeCommand{}
+
+	s := newSweeper(q, c, time.Minute, 50*time.Millisecond, discardLogger())
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan struct{})
+	go func() {
+		s.Run(ctx)
+		close(done)
+	}()
+
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Run did not return after context cancel")
+	}
+}

--- a/backend/cmd/cli/seeds.go
+++ b/backend/cmd/cli/seeds.go
@@ -18,9 +18,13 @@ const (
 	seedAdminPassword = "Admin123!"
 )
 
-const upsertAdmin = `INSERT INTO auth_customer (username, password_hash, is_admin)
-	VALUES ($1, $2, true)
-	ON CONFLICT (username) DO UPDATE SET is_admin = true`
+// upsertAdmin idempotently inserts the demo admin account or, on conflict,
+// re-asserts is_admin = true and forces must_change_password = true. Always
+// resetting must_change_password on re-seed makes the "change password on
+// first login" gate reliably testable when developers re-run `seeds`.
+const upsertAdmin = `INSERT INTO auth_customer (username, password_hash, is_admin, must_change_password)
+	VALUES ($1, $2, true, true)
+	ON CONFLICT (username) DO UPDATE SET is_admin = true, must_change_password = true`
 
 // seedAdminUser idempotently creates (or promotes) the demo admin account.
 func seedAdminUser(ctx context.Context, db *sql.DB) error {
@@ -456,9 +460,9 @@ func newSeedsCmd(pc productCatalog, db *sql.DB) *cobra.Command {
 				return err
 			}
 
-			fmt.Printf("seeded %d simple + %d variant products, %d attribute types, %d categories, %d category assignments, %d attribute values, admin user %s (password %s)\n",
+			fmt.Printf("seeded %d simple + %d variant products, %d attribute types, %d categories, %d category assignments, %d attribute values, admin user %s (password reset required on first login)\n",
 				len(seedProducts), len(variantSeeds), len(attributeTypeSeeds), len(categorySeeds),
-				countCategoryAssignments(), len(productAttributeSeeds), seedAdminEmail, seedAdminPassword)
+				countCategoryAssignments(), len(productAttributeSeeds), seedAdminEmail)
 			return nil
 		},
 	}

--- a/backend/cmd/web/config.go
+++ b/backend/cmd/web/config.go
@@ -1,6 +1,9 @@
 package main
 
-import "fmt"
+import (
+	"fmt"
+	"time"
+)
 
 type config struct {
 	ServerPort int `conf:"default:8080,SERVER_PORT"`
@@ -48,6 +51,16 @@ type config struct {
 	// reset link). Defaulting to localhost:8080 keeps `docker compose up`
 	// working out of the box; production deployments MUST override.
 	BaseURL string `conf:"default:http://localhost:8080"`
+	// ReservationTTL is how long a pending order may hold its stock
+	// reservation before the sweeper expires it. Tune to match the longest
+	// legitimate payment confirmation window for your processor; orders
+	// abandoned past this point have their stock released back to the
+	// catalogue. 30 minutes is a safe default for synchronous card flows.
+	ReservationTTL time.Duration `conf:"default:30m"`
+	// ReservationSweepInterval is how often the reservation TTL sweeper
+	// runs. Set to 0 (or any non-positive value) to disable the sweeper
+	// entirely. Default keeps lag low without hammering the read side.
+	ReservationSweepInterval time.Duration `conf:"default:5m"`
 }
 
 // defaultSessionSecret is the placeholder value SessionSecret must NOT keep

--- a/backend/cmd/web/config.go
+++ b/backend/cmd/web/config.go
@@ -61,6 +61,15 @@ type config struct {
 	// runs. Set to 0 (or any non-positive value) to disable the sweeper
 	// entirely. Default keeps lag low without hammering the read side.
 	ReservationSweepInterval time.Duration `conf:"default:5m"`
+	// TaxRatePercent is the flat tax rate applied to every order's subtotal
+	// at checkout time, expressed as a percentage (e.g. 8.875 for 8.875%).
+	// Defaults to 0, i.e. tax-free; tax is applied to the subtotal and is
+	// part of the historical order via OrderPlaced.Tax.
+	TaxRatePercent float64 `conf:"default:0"`
+	// FreeShippingThreshold is the minimum order subtotal (in minor units —
+	// e.g. cents) at or above which the chosen shipping method's cost is
+	// overridden to 0 at place time. 0 disables the threshold.
+	FreeShippingThreshold int64 `conf:"default:0"`
 }
 
 // defaultSessionSecret is the placeholder value SessionSecret must NOT keep

--- a/backend/cmd/web/config.go
+++ b/backend/cmd/web/config.go
@@ -10,7 +10,24 @@ type config struct {
 	// It is also the directory the /uploads/* HTTP route serves from. The
 	// container default lines up with the docker-compose bind mount.
 	UploadsDir string `conf:"default:/uploads"`
+	// SessionSecret is the symmetric key gorilla/sessions uses to authenticate
+	// cookies. It MUST be set to a strong random value (32+ bytes from a CSPRNG)
+	// in production via the SESSION_SECRET env var. The default below is a
+	// placeholder that allows the app to start in dev but emits a loud WARN on
+	// every boot; in production (Env == "prod" / "production") the app refuses
+	// to start with the default value.
+	SessionSecret string `conf:"default:dev-only-do-not-use-in-production"`
+	// CookieSecure controls the Secure flag on every session cookie. Set
+	// COOKIE_SECURE=true when serving over HTTPS (production); leave false for
+	// plain-HTTP local/docker-compose development so the browser still accepts
+	// the cookie.
+	CookieSecure bool `conf:"default:false"`
 }
+
+// defaultSessionSecret is the placeholder value SessionSecret must NOT keep
+// in production. Exported via a constant so main.go can compare against it
+// without re-typing the literal.
+const defaultSessionSecret = "dev-only-do-not-use-in-production"
 
 type postgresConfig struct {
 	User     string `conf:"default:postgres"`

--- a/backend/cmd/web/config.go
+++ b/backend/cmd/web/config.go
@@ -22,6 +22,12 @@ type config struct {
 	// plain-HTTP local/docker-compose development so the browser still accepts
 	// the cookie.
 	CookieSecure bool `conf:"default:false"`
+	// CSRFEnabled toggles the request-level CSRF check. It defaults to true
+	// — production never wants this off. The only legitimate reason to set
+	// CSRF_ENABLED=false is a short-lived local debugging session where you
+	// want to curl/wget unsafe endpoints without minting a token first; do
+	// NOT ship a deployment with this disabled.
+	CSRFEnabled bool `conf:"default:true"`
 }
 
 // defaultSessionSecret is the placeholder value SessionSecret must NOT keep

--- a/backend/cmd/web/config.go
+++ b/backend/cmd/web/config.go
@@ -28,6 +28,26 @@ type config struct {
 	// want to curl/wget unsafe endpoints without minting a token first; do
 	// NOT ship a deployment with this disabled.
 	CSRFEnabled bool `conf:"default:true"`
+	// SMTPHost is the host:port of the outbound SMTP relay (e.g. mailhog:1025
+	// in dev, an SES/SendGrid SMTP endpoint in production). Leave blank to
+	// disable real delivery — the app then falls back to a LogMailer that
+	// writes the rendered email to the structured log. The fallback emits a
+	// loud WARN at boot so a forgotten SMTP_HOST in staging cannot go
+	// unnoticed.
+	SMTPHost string
+	// SMTPUsername / SMTPPassword authenticate against the relay. When
+	// Username is empty, no auth is sent (MailHog accepts unauthenticated
+	// SMTP). The password is masked in `conf` usage output.
+	SMTPUsername string
+	SMTPPassword string `conf:"mask"`
+	// MailFrom is the default From: header on outbound mail. Caller-supplied
+	// Message.From overrides it; otherwise every email is sent as MailFrom.
+	MailFrom string `conf:"default:no-reply@gocommerce.local"`
+	// BaseURL is the absolute base URL of the storefront, used to render
+	// absolute links inside emails (the order detail link, the password
+	// reset link). Defaulting to localhost:8080 keeps `docker compose up`
+	// working out of the box; production deployments MUST override.
+	BaseURL string `conf:"default:http://localhost:8080"`
 }
 
 // defaultSessionSecret is the placeholder value SessionSecret must NOT keep

--- a/backend/cmd/web/main.go
+++ b/backend/cmd/web/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/bkielbasa/go-ecommerce/backend/auth"
 	"github.com/bkielbasa/go-ecommerce/backend/cart"
 	"github.com/bkielbasa/go-ecommerce/backend/checkout"
+	checkoutapp "github.com/bkielbasa/go-ecommerce/backend/checkout/app"
 	checkoutintegration "github.com/bkielbasa/go-ecommerce/backend/checkout/integration"
 	"github.com/bkielbasa/go-ecommerce/backend/checkout/sweeper"
 	"github.com/bkielbasa/go-ecommerce/backend/shippinginfo"
@@ -97,7 +98,11 @@ func main() {
 	pcBD, catalogService := productcatalog.New(db)
 	cartBD, cartSrv := cart.New(db, logger, catalogService)
 	authBD, authService := auth.New(db)
-	checkoutBD, checkoutSrv, checkoutQry := checkout.New(db, cartSrv, bus, catalogService)
+	pricing := checkoutapp.PricingPolicy{
+		TaxRatePercent:        cfg.TaxRatePercent,
+		FreeShippingThreshold: cfg.FreeShippingThreshold,
+	}
+	checkoutBD, checkoutSrv, checkoutQry := checkout.New(db, cartSrv, bus, catalogService, catalogService, pricing)
 	shipSrv := shippinginfo.New(db)
 
 	// Mailer is the outbound-email abstraction. When SMTP_HOST is empty

--- a/backend/cmd/web/main.go
+++ b/backend/cmd/web/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/bkielbasa/go-ecommerce/backend/cart"
 	"github.com/bkielbasa/go-ecommerce/backend/checkout"
 	checkoutintegration "github.com/bkielbasa/go-ecommerce/backend/checkout/integration"
+	"github.com/bkielbasa/go-ecommerce/backend/checkout/sweeper"
 	"github.com/bkielbasa/go-ecommerce/backend/shippinginfo"
 	"github.com/bkielbasa/go-ecommerce/backend/internal"
 	"github.com/bkielbasa/go-ecommerce/backend/internal/application"
@@ -157,6 +158,13 @@ func main() {
 	app.AddBoundedContext(pcBD)
 	app.AddBoundedContext(authBD)
 	app.AddBoundedContext(checkoutBD)
+
+	// Reservation TTL sweeper: releases stock held by pending orders whose
+	// confirmation never arrived (process crash, abandoned cart after stock
+	// reserve, hung async payment). Bound to the application's lifecycle
+	// context; cancel triggers a clean exit.
+	reservationSweeper := sweeper.New(checkoutQry, checkoutSrv, cfg.ReservationTTL, cfg.ReservationSweepInterval, logger)
+	go reservationSweeper.Run(ctx)
 
 	go func() {
 		_ = app.Run()

--- a/backend/cmd/web/main.go
+++ b/backend/cmd/web/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/bkielbasa/go-ecommerce/backend/internal/dependency"
 	"github.com/bkielbasa/go-ecommerce/backend/internal/eventbus"
 	"github.com/bkielbasa/go-ecommerce/backend/internal/imagestore"
+	"github.com/bkielbasa/go-ecommerce/backend/internal/mailer"
 	"github.com/bkielbasa/go-ecommerce/backend/internal/observability"
 	"github.com/bkielbasa/go-ecommerce/backend/layout"
 	"github.com/bkielbasa/go-ecommerce/backend/productcatalog"
@@ -98,17 +99,57 @@ func main() {
 	checkoutBD, checkoutSrv, checkoutQry := checkout.New(db, cartSrv, bus, catalogService)
 	shipSrv := shippinginfo.New(db)
 
+	// Mailer is the outbound-email abstraction. When SMTP_HOST is empty
+	// (the dev default), New() returns a LogMailer that writes each email
+	// to the structured log instead of dialling — keeping the app bootable
+	// with no MailHog/SMTP relay running. Production always sets SMTP_HOST.
+	mailerSrv := mailer.New(mailer.Config{
+		Host:     cfg.SMTPHost,
+		Username: cfg.SMTPUsername,
+		Password: cfg.SMTPPassword,
+		From:     cfg.MailFrom,
+	}, logger)
+
 	// Cross-context integration: when checkout reports an order paid, the cart
 	// context empties the basket it was placed from.
 	bus.Subscribe(checkoutintegration.OrderPaid{}.EventName(), func(ctx context.Context, e eventbus.Event) error {
 		return cartSrv.Clear(ctx, e.(checkoutintegration.OrderPaid).SessionID)
 	})
 
+	// Second OrderPaid subscriber: render and dispatch the order
+	// confirmation email. Anonymous orders (CustomerID == "") are
+	// skipped — there is no inbox to mail. Any failure inside the
+	// subscriber is returned (and logged by the bus) but never aborts
+	// the publisher's own transaction; the cart-clearing subscriber
+	// above is unaffected.
+	bus.Subscribe(checkoutintegration.OrderPaid{}.EventName(), func(ctx context.Context, e eventbus.Event) error {
+		paid := e.(checkoutintegration.OrderPaid)
+		if paid.CustomerID == "" {
+			return nil
+		}
+		view, err := checkoutQry.Find(ctx, paid.OrderID)
+		if err != nil {
+			return fmt.Errorf("order confirmation: load view: %w", err)
+		}
+		msg, err := layout.RenderOrderConfirmation(view, cfg.BaseURL)
+		if err != nil {
+			return fmt.Errorf("order confirmation: render: %w", err)
+		}
+		// Make sure the recipient is the actual customer email even
+		// if RenderOrderConfirmation derived it from the view; the
+		// integration event is the authoritative source.
+		msg.To = paid.CustomerID
+		if err := mailerSrv.Send(ctx, msg); err != nil {
+			return fmt.Errorf("order confirmation: send: %w", err)
+		}
+		return nil
+	})
+
 	app.AddBoundedContext(cartBD)
 
 	imgStore := imagestore.NewDisk(cfg.UploadsDir, "/uploads")
 
-	app.AddBoundedContext(layout.New(logger, cartSrv, catalogService, authService, checkoutSrv, checkoutQry, shipSrv, imgStore, cfg.UploadsDir, []byte(cfg.SessionSecret), cfg.CookieSecure, cfg.CSRFEnabled))
+	app.AddBoundedContext(layout.New(logger, cartSrv, catalogService, authService, checkoutSrv, checkoutQry, shipSrv, imgStore, cfg.UploadsDir, []byte(cfg.SessionSecret), cfg.CookieSecure, cfg.CSRFEnabled, mailerSrv, cfg.BaseURL))
 	// CSRF protection wraps every route on the application router. It must be
 	// installed after layout.New has set up the session store (which the
 	// middleware reads from) but before app.Run() begins serving.

--- a/backend/cmd/web/main.go
+++ b/backend/cmd/web/main.go
@@ -108,7 +108,11 @@ func main() {
 
 	imgStore := imagestore.NewDisk(cfg.UploadsDir, "/uploads")
 
-	app.AddBoundedContext(layout.New(logger, cartSrv, catalogService, authService, checkoutSrv, checkoutQry, shipSrv, imgStore, cfg.UploadsDir, []byte(cfg.SessionSecret), cfg.CookieSecure))
+	app.AddBoundedContext(layout.New(logger, cartSrv, catalogService, authService, checkoutSrv, checkoutQry, shipSrv, imgStore, cfg.UploadsDir, []byte(cfg.SessionSecret), cfg.CookieSecure, cfg.CSRFEnabled))
+	// CSRF protection wraps every route on the application router. It must be
+	// installed after layout.New has set up the session store (which the
+	// middleware reads from) but before app.Run() begins serving.
+	app.Use(layout.CSRFMiddleware)
 	app.AddBoundedContext(pcBD)
 	app.AddBoundedContext(authBD)
 	app.AddBoundedContext(checkoutBD)

--- a/backend/cmd/web/main.go
+++ b/backend/cmd/web/main.go
@@ -49,6 +49,18 @@ func main() {
 
 	logger := newLogger(logrus.DebugLevel, appName)
 
+	// Session secret hygiene: in production the operator MUST override the
+	// default. In any other env we still log a loud WARN so a forgotten
+	// SESSION_SECRET in staging/dev is impossible to miss.
+	if cfg.SessionSecret == defaultSessionSecret {
+		switch cfg.Env {
+		case "prod", "production":
+			logger.Fatal("SESSION_SECRET is set to the insecure default; refusing to start in production. Set SESSION_SECRET to a strong random value.")
+		default:
+			logger.Warn("SESSION_SECRET is set to the insecure default; this is acceptable only for local development. Set SESSION_SECRET to a strong random value before deploying.")
+		}
+	}
+
 	ctx, cancel := internal.Context()
 	defer cancel()
 
@@ -96,7 +108,7 @@ func main() {
 
 	imgStore := imagestore.NewDisk(cfg.UploadsDir, "/uploads")
 
-	app.AddBoundedContext(layout.New(logger, cartSrv, catalogService, authService, checkoutSrv, checkoutQry, shipSrv, imgStore, cfg.UploadsDir))
+	app.AddBoundedContext(layout.New(logger, cartSrv, catalogService, authService, checkoutSrv, checkoutQry, shipSrv, imgStore, cfg.UploadsDir, []byte(cfg.SessionSecret), cfg.CookieSecure))
 	app.AddBoundedContext(pcBD)
 	app.AddBoundedContext(authBD)
 	app.AddBoundedContext(checkoutBD)

--- a/backend/internal/application/appplication.go
+++ b/backend/internal/application/appplication.go
@@ -83,6 +83,16 @@ type MuxRegister interface {
 	MuxRegister(*mux.Router)
 }
 
+// Use registers a request-level middleware on the underlying gorilla/mux
+// router. Middlewares are applied in registration order and run for every
+// route, including the /healthyz and /readyz endpoints registered at New().
+// The /static and /uploads handlers also run through them, which is
+// harmless for the middlewares we use (CSRF only enforces unsafe methods,
+// otelmux is pure observation).
+func (app *App) Use(mw mux.MiddlewareFunc) {
+	app.router.Use(mw)
+}
+
 func (app *App) AddDependency(dep dependency.Dependency) {
 	app.deps.Add(dep)
 }

--- a/backend/internal/mailer/mailer.go
+++ b/backend/internal/mailer/mailer.go
@@ -1,0 +1,235 @@
+// Package mailer is the outbound-email abstraction: the rest of the app talks
+// to a Mailer interface and never reaches for net/smtp itself. Two concrete
+// implementations live here:
+//
+//   - SMTPMailer dials a real SMTP relay (e.g. MailHog in dev, SES/SendGrid
+//     SMTP in production) and is selected when Config.Host is set.
+//   - LogMailer writes the rendered message to the structured log; it is the
+//     dev/no-SMTP fallback so the app still boots when SMTP isn't configured.
+//
+// Adding a new provider later (SES native API, SendGrid HTTP) is a matter of
+// implementing the Mailer interface — no caller code needs to change.
+package mailer
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"net/smtp"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+)
+
+// Message is one outbound email. From is optional: when blank, the Mailer
+// fills in its configured default sender. HTMLBody and TextBody are both
+// optional but at least one MUST be set; when both are populated the message
+// is built as multipart/alternative so clients pick the variant they render
+// best.
+type Message struct {
+	To       string
+	From     string
+	Subject  string
+	HTMLBody string
+	TextBody string
+}
+
+// Mailer is the abstraction every caller in the codebase depends on. The
+// concrete implementation is chosen at composition-root time via New(); call
+// sites never type-assert to a specific implementation.
+type Mailer interface {
+	Send(ctx context.Context, msg Message) error
+}
+
+// Config drives New(). When Host is empty we return a LogMailer instead of
+// trying to dial — this is the local-development default so the app still
+// boots without MailHog running. Username/Password are optional; when
+// Username is "" we pass nil auth (MailHog accepts unauthenticated SMTP).
+type Config struct {
+	Host     string
+	Username string
+	Password string
+	From     string
+}
+
+// New returns the Mailer implementation matching cfg: SMTPMailer when Host is
+// set, LogMailer otherwise. The LogMailer fallback emits a single WARN at
+// startup so an operator forgetting to wire SMTP in staging cannot miss it.
+func New(cfg Config, logger logrus.FieldLogger) Mailer {
+	if cfg.Host == "" {
+		if logger != nil {
+			logger.Warn("mailer: SMTP_HOST is empty; using LogMailer (emails will be logged, not sent)")
+		}
+		return &LogMailer{Logger: logger, From: cfg.From}
+	}
+	return &SMTPMailer{
+		Host:     cfg.Host,
+		Username: cfg.Username,
+		Password: cfg.Password,
+		From:     cfg.From,
+	}
+}
+
+// SMTPMailer delivers via plain net/smtp. The zero value is NOT usable: at a
+// minimum Host and From must be set. Username/Password are optional.
+type SMTPMailer struct {
+	Host     string
+	Username string
+	Password string
+	From     string
+}
+
+// ErrEmptyMessage is returned by Send when the supplied Message has no body
+// at all. We refuse to dispatch a blank email rather than send something the
+// recipient will ignore.
+var ErrEmptyMessage = errors.New("mailer: message has no body")
+
+// Send dispatches msg over SMTP. The MIME body is built locally so the
+// implementation can produce a true multipart/alternative when both bodies
+// are present without dragging in net/mail or net/textproto.
+func (m *SMTPMailer) Send(ctx context.Context, msg Message) error {
+	if msg.HTMLBody == "" && msg.TextBody == "" {
+		return ErrEmptyMessage
+	}
+	if msg.To == "" {
+		return errors.New("mailer: To is required")
+	}
+
+	from := msg.From
+	if from == "" {
+		from = m.From
+	}
+
+	body, err := buildMIME(from, msg)
+	if err != nil {
+		return fmt.Errorf("mailer: build MIME: %w", err)
+	}
+
+	// host is the SMTP host portion (without port) used by smtp.PlainAuth.
+	// The full host:port string is what smtp.SendMail dials.
+	host := m.Host
+	if i := strings.IndexByte(host, ':'); i > 0 {
+		host = host[:i]
+	}
+
+	var auth smtp.Auth
+	if m.Username != "" {
+		auth = smtp.PlainAuth("", m.Username, m.Password, host)
+	}
+
+	// net/smtp does not honor ctx natively, but we still respect a
+	// pre-cancelled context so a Publish that fires during shutdown does
+	// not block on the SMTP dial.
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	return smtp.SendMail(m.Host, auth, from, []string{msg.To}, body)
+}
+
+// buildMIME constructs the raw RFC822 bytes net/smtp expects. For
+// HTML+text we emit a multipart/alternative; for text-only we emit a
+// straight text/plain; for HTML-only we emit text/html.
+func buildMIME(from string, msg Message) ([]byte, error) {
+	var buf bytes.Buffer
+
+	headers := func(extra map[string]string) {
+		buf.WriteString("From: " + from + "\r\n")
+		buf.WriteString("To: " + msg.To + "\r\n")
+		buf.WriteString("Subject: " + msg.Subject + "\r\n")
+		buf.WriteString("MIME-Version: 1.0\r\n")
+		for k, v := range extra {
+			buf.WriteString(k + ": " + v + "\r\n")
+		}
+	}
+
+	switch {
+	case msg.HTMLBody != "" && msg.TextBody != "":
+		boundary, err := mimeBoundary()
+		if err != nil {
+			return nil, err
+		}
+		headers(map[string]string{
+			"Content-Type": `multipart/alternative; boundary="` + boundary + `"`,
+		})
+		buf.WriteString("\r\n")
+		// text part first — clients pick the LAST part they can
+		// render, so HTML naturally wins when supported.
+		buf.WriteString("--" + boundary + "\r\n")
+		buf.WriteString("Content-Type: text/plain; charset=\"utf-8\"\r\n\r\n")
+		buf.WriteString(msg.TextBody)
+		buf.WriteString("\r\n")
+		buf.WriteString("--" + boundary + "\r\n")
+		buf.WriteString("Content-Type: text/html; charset=\"utf-8\"\r\n\r\n")
+		buf.WriteString(msg.HTMLBody)
+		buf.WriteString("\r\n")
+		buf.WriteString("--" + boundary + "--\r\n")
+	case msg.HTMLBody != "":
+		headers(map[string]string{
+			"Content-Type": `text/html; charset="utf-8"`,
+		})
+		buf.WriteString("\r\n")
+		buf.WriteString(msg.HTMLBody)
+	default:
+		headers(map[string]string{
+			"Content-Type": `text/plain; charset="utf-8"`,
+		})
+		buf.WriteString("\r\n")
+		buf.WriteString(msg.TextBody)
+	}
+
+	return buf.Bytes(), nil
+}
+
+// mimeBoundary returns a fresh, RFC 2046-safe boundary string. Sixteen
+// random bytes hex-encoded yields a 32-char ASCII token, easily unique
+// within one process and well under the 70-char limit.
+func mimeBoundary() (string, error) {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return "gocommerce-" + hex.EncodeToString(b), nil
+}
+
+// LogMailer writes a structured log line for every send instead of
+// delivering. Useful for local development and for any deployment that has
+// not (yet) wired up an SMTP relay.
+type LogMailer struct {
+	Logger logrus.FieldLogger
+	From   string
+}
+
+// Send writes the message metadata to the structured logger at info level.
+// The body itself is intentionally NOT logged in full (passwords / reset
+// tokens can show up inside it); a truncated preview is enough for a
+// developer to confirm the right email was triggered.
+func (m *LogMailer) Send(ctx context.Context, msg Message) error {
+	if msg.To == "" {
+		return errors.New("mailer: To is required")
+	}
+	from := msg.From
+	if from == "" {
+		from = m.From
+	}
+	preview := msg.TextBody
+	if preview == "" {
+		preview = msg.HTMLBody
+	}
+	if len(preview) > 200 {
+		preview = preview[:200] + "..."
+	}
+	if m.Logger != nil {
+		m.Logger.WithFields(logrus.Fields{
+			"mailer":  "log",
+			"from":    from,
+			"to":      msg.To,
+			"subject": msg.Subject,
+			"preview": preview,
+		}).Info("email (not actually sent)")
+	}
+	return nil
+}

--- a/backend/internal/mailer/mailer_test.go
+++ b/backend/internal/mailer/mailer_test.go
@@ -1,0 +1,70 @@
+package mailer_test
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/bkielbasa/go-ecommerce/backend/internal/mailer"
+	"github.com/sirupsen/logrus"
+)
+
+func TestLogMailerSendDoesNotError(t *testing.T) {
+	logger := logrus.New()
+	logger.SetLevel(logrus.InfoLevel)
+	var buf bytes.Buffer
+	logger.SetOutput(&buf)
+
+	m := &mailer.LogMailer{Logger: logger, From: "no-reply@example.com"}
+	err := m.Send(context.Background(), mailer.Message{
+		To:       "alice@example.com",
+		Subject:  "hello",
+		TextBody: "world",
+	})
+	if err != nil {
+		t.Fatalf("LogMailer.Send: %v", err)
+	}
+	if !strings.Contains(buf.String(), "alice@example.com") {
+		t.Fatalf("log output missing recipient: %q", buf.String())
+	}
+	if !strings.Contains(buf.String(), "hello") {
+		t.Fatalf("log output missing subject: %q", buf.String())
+	}
+}
+
+func TestLogMailerRejectsEmptyTo(t *testing.T) {
+	m := &mailer.LogMailer{Logger: logrus.New()}
+	err := m.Send(context.Background(), mailer.Message{Subject: "x", TextBody: "y"})
+	if err == nil {
+		t.Fatalf("expected error for empty To")
+	}
+}
+
+func TestNewSelectsLogMailerWhenHostEmpty(t *testing.T) {
+	logger := logrus.New()
+	logger.SetOutput(new(bytes.Buffer))
+	m := mailer.New(mailer.Config{Host: "", From: "x@example.com"}, logger)
+	if _, ok := m.(*mailer.LogMailer); !ok {
+		t.Fatalf("expected LogMailer, got %T", m)
+	}
+}
+
+func TestNewSelectsSMTPMailerWhenHostSet(t *testing.T) {
+	logger := logrus.New()
+	logger.SetOutput(new(bytes.Buffer))
+	m := mailer.New(mailer.Config{Host: "mailhog:1025", From: "x@example.com"}, logger)
+	if _, ok := m.(*mailer.SMTPMailer); !ok {
+		t.Fatalf("expected SMTPMailer, got %T", m)
+	}
+}
+
+func TestSMTPMailerRejectsEmptyMessage(t *testing.T) {
+	// Construction-only check; we don't actually dial. With both bodies
+	// blank, Send must short-circuit BEFORE attempting any network IO.
+	m := &mailer.SMTPMailer{Host: "127.0.0.1:0", From: "x@example.com"}
+	err := m.Send(context.Background(), mailer.Message{To: "y@example.com"})
+	if err == nil {
+		t.Fatalf("expected ErrEmptyMessage")
+	}
+}

--- a/backend/internal/ratelimit/ratelimit.go
+++ b/backend/internal/ratelimit/ratelimit.go
@@ -1,0 +1,107 @@
+// Package ratelimit provides a small, dependency-free token-bucket rate
+// limiter keyed by an arbitrary string (typically a client IP). It is
+// intentionally tiny — one mutex, a map of buckets, a fractional token
+// counter per bucket — so the whole package can live entirely in-memory in
+// a single process without pulling in golang.org/x/time/rate.
+//
+// Each bucket refills at `rate` tokens/second up to `burst` tokens. A bucket
+// allows a request iff its current token count is >= 1, in which case one
+// token is consumed. Buckets are created lazily on the first call for a key
+// and capped at maxKeys; once full, a random eviction round drops a
+// stale-looking entry to keep memory bounded under abusive traffic.
+package ratelimit
+
+import (
+	"sync"
+	"time"
+)
+
+// maxKeys caps the bucket map size. The number is generous enough for the
+// real workloads we throttle (login/register/cart-add per source IP) and
+// small enough that the map stays well under a megabyte even fully populated.
+const maxKeys = 4096
+
+// bucket is the per-key state. tokens is fractional so a sub-per-second
+// rate (e.g. 3/hour) is representable; lastRefill anchors the next refill
+// calculation.
+type bucket struct {
+	tokens     float64
+	lastRefill time.Time
+}
+
+// Limiter is a token-bucket rate limiter keyed by string. The zero value is
+// not usable; construct one with New.
+type Limiter struct {
+	mu      sync.Mutex
+	buckets map[string]*bucket
+	rate    float64
+	burst   float64
+	now     func() time.Time
+}
+
+// New returns a Limiter that refills each bucket at rate tokens/second up
+// to a maximum of burst tokens. burst doubles as the bucket's starting
+// capacity so the first burst requests for a fresh key always succeed.
+func New(rate float64, burst int) *Limiter {
+	if rate < 0 {
+		rate = 0
+	}
+	if burst < 1 {
+		burst = 1
+	}
+	return &Limiter{
+		buckets: make(map[string]*bucket),
+		rate:    rate,
+		burst:   float64(burst),
+		now:     time.Now,
+	}
+}
+
+// Allow reports whether a request for key is permitted right now. On true,
+// one token is consumed from the bucket; on false, the bucket is untouched.
+func (l *Limiter) Allow(key string) bool {
+	now := l.now()
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	b, ok := l.buckets[key]
+	if !ok {
+		// Cap the working set. We don't track usage timestamps so a
+		// random victim is the cheapest defensible eviction; under
+		// real load the surviving buckets refill to full within
+		// seconds, so a wrongly-evicted entry is self-healing.
+		if len(l.buckets) >= maxKeys {
+			l.evictOneLocked()
+		}
+		b = &bucket{tokens: l.burst, lastRefill: now}
+		l.buckets[key] = b
+	} else {
+		elapsed := now.Sub(b.lastRefill).Seconds()
+		if elapsed > 0 {
+			b.tokens += elapsed * l.rate
+			if b.tokens > l.burst {
+				b.tokens = l.burst
+			}
+			b.lastRefill = now
+		}
+	}
+
+	if b.tokens >= 1 {
+		b.tokens--
+		return true
+	}
+	return false
+}
+
+// evictOneLocked drops a single arbitrary entry from the bucket map. The
+// caller must hold l.mu. Go's map iteration is randomized so the chosen
+// victim is effectively uniform without us tracking insertion order.
+func (l *Limiter) evictOneLocked() {
+	// We only need to drop one entry; break out of the iteration on the
+	// first key we see.
+	for k := range l.buckets {
+		delete(l.buckets, k)
+		return
+	}
+}

--- a/backend/internal/ratelimit/ratelimit_test.go
+++ b/backend/internal/ratelimit/ratelimit_test.go
@@ -1,0 +1,66 @@
+package ratelimit
+
+import (
+	"testing"
+	"time"
+
+	"github.com/matryer/is"
+)
+
+// TestAllowBurstThenDeny exercises the documented contract: a fresh key is
+// allowed up to `burst` times in a tight loop with no refill, then refused.
+func TestAllowBurstThenDeny(t *testing.T) {
+	is := is.New(t)
+
+	// 1 token per second, burst of 3 — using a frozen clock so refill is
+	// strictly opt-in via the helper below.
+	l := New(1, 3)
+	frozen := time.Unix(1_700_000_000, 0)
+	l.now = func() time.Time { return frozen }
+
+	is.True(l.Allow("ip-a"))  // 1/3
+	is.True(l.Allow("ip-a"))  // 2/3
+	is.True(l.Allow("ip-a"))  // 3/3
+	is.True(!l.Allow("ip-a")) // bucket drained, must refuse
+}
+
+// TestAllowRefillsAfterTime confirms that after enough wall-clock has elapsed
+// the bucket refills and Allow returns true again.
+func TestAllowRefillsAfterTime(t *testing.T) {
+	is := is.New(t)
+
+	// 5 tokens per second, burst of 2 — drain, then advance 1 s which
+	// must add 5 tokens (capped to burst=2).
+	l := New(5, 2)
+	frozen := time.Unix(1_700_000_000, 0)
+	l.now = func() time.Time { return frozen }
+
+	is.True(l.Allow("ip-b"))  // 1/2
+	is.True(l.Allow("ip-b"))  // 2/2
+	is.True(!l.Allow("ip-b")) // drained
+
+	// Advance one second; bucket should be back to full.
+	frozen = frozen.Add(time.Second)
+	is.True(l.Allow("ip-b"))
+	is.True(l.Allow("ip-b"))
+	is.True(!l.Allow("ip-b"))
+}
+
+// TestPerKeyIsolation makes sure one noisy key does not poison another's
+// bucket.
+func TestPerKeyIsolation(t *testing.T) {
+	is := is.New(t)
+
+	l := New(1, 2)
+	frozen := time.Unix(1_700_000_000, 0)
+	l.now = func() time.Time { return frozen }
+
+	is.True(l.Allow("noisy"))
+	is.True(l.Allow("noisy"))
+	is.True(!l.Allow("noisy"))
+
+	// A different key has its own untouched bucket.
+	is.True(l.Allow("quiet"))
+	is.True(l.Allow("quiet"))
+	is.True(!l.Allow("quiet"))
+}

--- a/backend/layout/bounded_context.go
+++ b/backend/layout/bounded_context.go
@@ -10,6 +10,7 @@ import (
 	checkoutQuery "github.com/bkielbasa/go-ecommerce/backend/checkout/query"
 	"github.com/bkielbasa/go-ecommerce/backend/internal/application"
 	"github.com/bkielbasa/go-ecommerce/backend/internal/imagestore"
+	"github.com/bkielbasa/go-ecommerce/backend/internal/mailer"
 	pcapp "github.com/bkielbasa/go-ecommerce/backend/productcatalog/app"
 	pcdomain "github.com/bkielbasa/go-ecommerce/backend/productcatalog/domain"
 	shipDomain "github.com/bkielbasa/go-ecommerce/backend/shippinginfo/domain"
@@ -70,6 +71,8 @@ type authService interface {
 	ChangePassword(ctx context.Context, email, oldPassword, newPassword string) error
 	IsAdmin(ctx context.Context, email string) (bool, error)
 	MustChangePassword(ctx context.Context, email string) (bool, error)
+	RequestPasswordReset(ctx context.Context, email string) (string, error)
+	ResetPassword(ctx context.Context, rawToken, newPassword string) error
 }
 
 type shippingService interface {
@@ -105,7 +108,7 @@ type checkoutQueries interface {
 // csrfEnabled toggles the request-level CSRF check; production always wants
 // true, and only local debugging should ever flip it to false (see
 // cmd/web/config.go CSRFEnabled for the operator-facing knob).
-func New(logger logrus.FieldLogger, cartSrv cartService, catalogSrv catalogService, authSrv authService, checkoutSrv checkoutCommands, checkoutQry checkoutQueries, shipSrv shippingService, imageStore imagestore.Store, uploadsDir string, sessionSecret []byte, cookieSecure, csrfEnabled bool) application.BoundedContext {
+func New(logger logrus.FieldLogger, cartSrv cartService, catalogSrv catalogService, authSrv authService, checkoutSrv checkoutCommands, checkoutQry checkoutQueries, shipSrv shippingService, imageStore imagestore.Store, uploadsDir string, sessionSecret []byte, cookieSecure, csrfEnabled bool, mailerSrv mailer.Mailer, baseURL string) application.BoundedContext {
 	store = newCookieStore(sessionSecret, cookieSecure)
 	setCSRFEnabled(csrfEnabled)
 	return &boundedContext{
@@ -117,6 +120,8 @@ func New(logger logrus.FieldLogger, cartSrv cartService, catalogSrv catalogServi
 			checkoutQry: checkoutQry,
 			shipSrv:     shipSrv,
 			imageStore:  imageStore,
+			mailer:      mailerSrv,
+			baseURL:     baseURL,
 			logger:      logger,
 		},
 		uploadsDir: uploadsDir,

--- a/backend/layout/bounded_context.go
+++ b/backend/layout/bounded_context.go
@@ -56,6 +56,8 @@ type catalogService interface {
 	CreateAttributeSet(ctx context.Context, name string, attributeTypeIDs []string) error
 	UpdateAttributeSet(ctx context.Context, id, name string, attributeTypeIDs []string) error
 	DeleteAttributeSet(ctx context.Context, id string) error
+
+	ListStockMovements(ctx context.Context, variantID string, limit int) ([]pcdomain.StockMovement, error)
 }
 
 type cartService interface {
@@ -90,6 +92,9 @@ type checkoutCommands interface {
 	Place(ctx context.Context, sessID, customerID, cardNumber string, shipTo checkoutDomain.Address, shipMethod checkoutDomain.ShippingMethod, payMethod checkoutDomain.PaymentMethod) (checkoutDomain.Order, error)
 	Cancel(ctx context.Context, orderID, customerID string) error
 	AdminCancel(ctx context.Context, orderID string) error
+	MarkShipped(ctx context.Context, orderID, carrier, trackingCode string) error
+	MarkDelivered(ctx context.Context, orderID string) error
+	Refund(ctx context.Context, orderID, reason string) error
 }
 
 // checkoutQueries is the read side of the checkout context (CQRS); it returns

--- a/backend/layout/bounded_context.go
+++ b/backend/layout/bounded_context.go
@@ -101,8 +101,13 @@ type checkoutQueries interface {
 // session cookie store from the supplied secret and Secure flag. Callers must
 // supply a non-empty sessionSecret; main.go enforces the production-vs-default
 // policy before calling here.
-func New(logger logrus.FieldLogger, cartSrv cartService, catalogSrv catalogService, authSrv authService, checkoutSrv checkoutCommands, checkoutQry checkoutQueries, shipSrv shippingService, imageStore imagestore.Store, uploadsDir string, sessionSecret []byte, cookieSecure bool) application.BoundedContext {
+//
+// csrfEnabled toggles the request-level CSRF check; production always wants
+// true, and only local debugging should ever flip it to false (see
+// cmd/web/config.go CSRFEnabled for the operator-facing knob).
+func New(logger logrus.FieldLogger, cartSrv cartService, catalogSrv catalogService, authSrv authService, checkoutSrv checkoutCommands, checkoutQry checkoutQueries, shipSrv shippingService, imageStore imagestore.Store, uploadsDir string, sessionSecret []byte, cookieSecure, csrfEnabled bool) application.BoundedContext {
 	store = newCookieStore(sessionSecret, cookieSecure)
+	setCSRFEnabled(csrfEnabled)
 	return &boundedContext{
 		handler: httpHandler{
 			cartSrv:     cartSrv,

--- a/backend/layout/bounded_context.go
+++ b/backend/layout/bounded_context.go
@@ -69,6 +69,7 @@ type authService interface {
 	FindByToken(ctx context.Context, sessToken string) (*authDomain.Session, error)
 	ChangePassword(ctx context.Context, email, oldPassword, newPassword string) error
 	IsAdmin(ctx context.Context, email string) (bool, error)
+	MustChangePassword(ctx context.Context, email string) (bool, error)
 }
 
 type shippingService interface {
@@ -96,7 +97,12 @@ type checkoutQueries interface {
 	ListAll(ctx context.Context) ([]checkoutQuery.OrderSummary, error)
 }
 
-func New(logger logrus.FieldLogger, cartSrv cartService, catalogSrv catalogService, authSrv authService, checkoutSrv checkoutCommands, checkoutQry checkoutQueries, shipSrv shippingService, imageStore imagestore.Store, uploadsDir string) application.BoundedContext {
+// New wires the layout bounded context. It also initialises the process-wide
+// session cookie store from the supplied secret and Secure flag. Callers must
+// supply a non-empty sessionSecret; main.go enforces the production-vs-default
+// policy before calling here.
+func New(logger logrus.FieldLogger, cartSrv cartService, catalogSrv catalogService, authSrv authService, checkoutSrv checkoutCommands, checkoutQry checkoutQueries, shipSrv shippingService, imageStore imagestore.Store, uploadsDir string, sessionSecret []byte, cookieSecure bool) application.BoundedContext {
+	store = newCookieStore(sessionSecret, cookieSecure)
 	return &boundedContext{
 		handler: httpHandler{
 			cartSrv:     cartSrv,

--- a/backend/layout/csrf.go
+++ b/backend/layout/csrf.go
@@ -1,0 +1,152 @@
+package layout
+
+import (
+	"crypto/rand"
+	"crypto/subtle"
+	"encoding/base64"
+	"net/http"
+	"strings"
+)
+
+// csrfTokenKey is the session-values key under which the per-session CSRF
+// token is stored. Using the gorilla/sessions store keeps the token bound
+// to the same authenticated cookie the rest of the app already trusts.
+const csrfTokenKey = "csrf_token"
+
+// csrfHeader is the request header HTMX clients (and any JS caller) send
+// the CSRF token in. Form posts may instead include a hidden input named
+// csrfFormField; the middleware accepts whichever arrives.
+const csrfHeader = "X-CSRF-Token"
+
+// csrfFormField is the hidden-input name every server-rendered <form
+// method="post"> embeds. Standard browser form submits do not have a way
+// to set arbitrary headers, so the form value is the fallback channel.
+const csrfFormField = "csrf_token"
+
+// csrfTokenBytes is the size, in raw bytes, of a freshly minted CSRF
+// token. 32 bytes (256 bits) is generous overkill for a random token whose
+// only adversary is an attacker guessing it in a single request.
+const csrfTokenBytes = 32
+
+// csrfEnabled is the package-level switch that lets the dev config disable
+// CSRF for low-friction local hacking. Production defaults true via the
+// CSRFEnabled conf knob. The middleware checks this once per request.
+var csrfEnabled = true
+
+// setCSRFEnabled is called from layout.New() to wire the config knob into
+// the package-level switch. Keeping it package-scoped (rather than passing
+// it down through every handler) matches the existing `store` pattern.
+func setCSRFEnabled(enabled bool) {
+	csrfEnabled = enabled
+}
+
+// issueCSRFToken returns the CSRF token for the current session, minting a
+// new one (and persisting it back via Save) when the session does not yet
+// carry one. Callers must invoke it before the response body has been
+// committed, since session.Save sets a Set-Cookie header.
+func issueCSRFToken(r *http.Request, w http.ResponseWriter) (string, error) {
+	session, err := store.Get(r, "ecommerce")
+	if err != nil {
+		// gorilla returns a usable (new) session even on cookie-decode
+		// errors, so we keep going rather than failing the render.
+		session, _ = store.New(r, "ecommerce")
+	}
+
+	if existing, ok := session.Values[csrfTokenKey].(string); ok && existing != "" {
+		return existing, nil
+	}
+
+	buf := make([]byte, csrfTokenBytes)
+	if _, err := rand.Read(buf); err != nil {
+		return "", err
+	}
+	tok := base64.RawURLEncoding.EncodeToString(buf)
+	session.Values[csrfTokenKey] = tok
+	if err := session.Save(r, w); err != nil {
+		return "", err
+	}
+	return tok, nil
+}
+
+// sessionCSRFToken reads the current CSRF token off the session without
+// minting a new one. It returns "" when the session has no token yet, in
+// which case the request is rejected (the form was rendered without a
+// token, which should be impossible for any legitimate client).
+func sessionCSRFToken(r *http.Request) string {
+	session, err := store.Get(r, "ecommerce")
+	if err != nil {
+		return ""
+	}
+	tok, _ := session.Values[csrfTokenKey].(string)
+	return tok
+}
+
+// CSRFMiddleware is the exported entry point main.go uses to install the
+// CSRF check on the application-wide router. It is a thin wrapper around
+// the package-internal middleware so callers outside the package do not
+// have to know about the implementation symbol.
+func CSRFMiddleware(next http.Handler) http.Handler {
+	return csrfMiddleware(next)
+}
+
+// csrfMiddleware enforces the double-submit check on every unsafe request
+// (POST/PUT/PATCH/DELETE). Safe methods are forwarded unchanged so the
+// template-rendering path that mints the token is itself never blocked.
+//
+// The token may arrive via the X-CSRF-Token header (used by HTMX, set
+// uniformly by the configRequest script in the base layout) or via the
+// csrf_token hidden form field (used by standard browser form posts). We
+// prefer the header to avoid consuming the request body when the handler
+// downstream wants raw access to it; only if the header is empty do we
+// fall back to ParseForm/ParseMultipartForm, both of which are documented
+// as idempotent on net/http so a downstream re-parse is safe.
+func csrfMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !csrfEnabled || isSafeMethod(r.Method) {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		expected := sessionCSRFToken(r)
+		if expected == "" {
+			http.Error(w, "invalid CSRF token", http.StatusForbidden)
+			return
+		}
+
+		got := r.Header.Get(csrfHeader)
+		if got == "" {
+			// Parse the body so the handler downstream sees the
+			// same parsed form. ParseForm / ParseMultipartForm are
+			// both idempotent on a *http.Request.
+			ct := r.Header.Get("Content-Type")
+			if strings.HasPrefix(ct, "multipart/form-data") {
+				// 32 MiB matches net/http's default. The
+				// disk-image handlers downstream call
+				// ParseMultipartForm themselves with the
+				// same default, so we don't shrink it here.
+				_ = r.ParseMultipartForm(32 << 20)
+			} else {
+				_ = r.ParseForm()
+			}
+			got = r.FormValue(csrfFormField)
+		}
+
+		if got == "" || subtle.ConstantTimeCompare([]byte(expected), []byte(got)) != 1 {
+			http.Error(w, "invalid CSRF token", http.StatusForbidden)
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}
+
+// isSafeMethod returns true for HTTP methods that are spec-defined as
+// state-changing-free and therefore exempt from CSRF enforcement.
+func isSafeMethod(method string) bool {
+	switch method {
+	case http.MethodGet, http.MethodHead, http.MethodOptions:
+		return true
+	default:
+		return false
+	}
+}

--- a/backend/layout/emails.go
+++ b/backend/layout/emails.go
@@ -1,0 +1,150 @@
+package layout
+
+import (
+	"bytes"
+	"embed"
+	htmltmpl "html/template"
+	"strings"
+	"sync"
+	texttmpl "text/template"
+
+	checkoutQuery "github.com/bkielbasa/go-ecommerce/backend/checkout/query"
+	"github.com/bkielbasa/go-ecommerce/backend/internal/mailer"
+)
+
+// emailTemplates holds the embedded HTML/text bodies for every transactional
+// email this app sends. Embedding them keeps the alpine runtime image working
+// without bind-mounting tmpl/ — the static.go embed precedent already in this
+// package solves the same problem for /static.
+//
+//go:embed tmpl/emails/*
+var emailTemplates embed.FS
+
+// siteName is repeated in several email bodies; centralising it here keeps
+// the strings consistent and the templates short.
+const emailSiteName = "GoCommerce"
+
+// Parsed templates are lazy-loaded via sync.Once so the first send pays the
+// parse cost and every subsequent one is a cheap Execute. Falling back to a
+// startup-time parse would also work, but the Once form keeps the template
+// graph next to the renderer that uses it and avoids touching layout.New's
+// already-busy signature.
+var (
+	orderConfHTMLOnce sync.Once
+	orderConfHTML     *htmltmpl.Template
+	orderConfHTMLErr  error
+
+	orderConfTextOnce sync.Once
+	orderConfText     *texttmpl.Template
+	orderConfTextErr  error
+
+	resetHTMLOnce sync.Once
+	resetHTML     *htmltmpl.Template
+	resetHTMLErr  error
+
+	resetTextOnce sync.Once
+	resetText     *texttmpl.Template
+	resetTextErr  error
+)
+
+func loadOrderConfHTML() (*htmltmpl.Template, error) {
+	orderConfHTMLOnce.Do(func() {
+		orderConfHTML, orderConfHTMLErr = htmltmpl.ParseFS(emailTemplates, "tmpl/emails/order_confirmation.html.tmpl")
+	})
+	return orderConfHTML, orderConfHTMLErr
+}
+
+func loadOrderConfText() (*texttmpl.Template, error) {
+	orderConfTextOnce.Do(func() {
+		orderConfText, orderConfTextErr = texttmpl.ParseFS(emailTemplates, "tmpl/emails/order_confirmation.txt.tmpl")
+	})
+	return orderConfText, orderConfTextErr
+}
+
+func loadResetHTML() (*htmltmpl.Template, error) {
+	resetHTMLOnce.Do(func() {
+		resetHTML, resetHTMLErr = htmltmpl.ParseFS(emailTemplates, "tmpl/emails/password_reset.html.tmpl")
+	})
+	return resetHTML, resetHTMLErr
+}
+
+func loadResetText() (*texttmpl.Template, error) {
+	resetTextOnce.Do(func() {
+		resetText, resetTextErr = texttmpl.ParseFS(emailTemplates, "tmpl/emails/password_reset.txt.tmpl")
+	})
+	return resetText, resetTextErr
+}
+
+// RenderOrderConfirmation builds a Message for the order-paid email. The
+// caller (the OrderPaid subscriber in cmd/web/main.go) supplies the order
+// detail view and the storefront baseURL; this helper renders the two
+// bodies and hands back a ready-to-send Message — it does NOT call mailer
+// itself, keeping rendering and delivery cleanly separable.
+func RenderOrderConfirmation(view checkoutQuery.OrderView, baseURL string) (mailer.Message, error) {
+	htmlT, err := loadOrderConfHTML()
+	if err != nil {
+		return mailer.Message{}, err
+	}
+	textT, err := loadOrderConfText()
+	if err != nil {
+		return mailer.Message{}, err
+	}
+
+	data := map[string]any{
+		"Order":    view,
+		"SiteName": emailSiteName,
+		"OrderURL": strings.TrimRight(baseURL, "/") + "/order/" + view.ID(),
+	}
+
+	var htmlBuf, textBuf bytes.Buffer
+	if err := htmlT.Execute(&htmlBuf, data); err != nil {
+		return mailer.Message{}, err
+	}
+	if err := textT.Execute(&textBuf, data); err != nil {
+		return mailer.Message{}, err
+	}
+
+	return mailer.Message{
+		To:       view.CustomerID(),
+		Subject:  "Your order " + view.ID() + " is confirmed",
+		HTMLBody: htmlBuf.String(),
+		TextBody: textBuf.String(),
+	}, nil
+}
+
+// RenderPasswordReset builds a Message for the forgot-password flow. The
+// raw token (NOT its hash) is embedded into the reset URL the recipient
+// clicks; ttlMinutes is rendered into the body so the user knows how long
+// they have.
+func RenderPasswordReset(toEmail, rawToken, baseURL string, ttlMinutes int) (mailer.Message, error) {
+	htmlT, err := loadResetHTML()
+	if err != nil {
+		return mailer.Message{}, err
+	}
+	textT, err := loadResetText()
+	if err != nil {
+		return mailer.Message{}, err
+	}
+
+	resetURL := strings.TrimRight(baseURL, "/") + "/auth/reset?token=" + rawToken
+	data := map[string]any{
+		"SiteName":   emailSiteName,
+		"ResetURL":   resetURL,
+		"TTLMinutes": ttlMinutes,
+	}
+
+	var htmlBuf, textBuf bytes.Buffer
+	if err := htmlT.Execute(&htmlBuf, data); err != nil {
+		return mailer.Message{}, err
+	}
+	if err := textT.Execute(&textBuf, data); err != nil {
+		return mailer.Message{}, err
+	}
+
+	return mailer.Message{
+		To:       toEmail,
+		Subject:  "Reset your " + emailSiteName + " password",
+		HTMLBody: htmlBuf.String(),
+		TextBody: textBuf.String(),
+	}, nil
+}

--- a/backend/layout/emails_test.go
+++ b/backend/layout/emails_test.go
@@ -1,0 +1,71 @@
+package layout
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/bkielbasa/go-ecommerce/backend/checkout/domain"
+	checkoutQuery "github.com/bkielbasa/go-ecommerce/backend/checkout/query"
+)
+
+// TestRenderOrderConfirmation locks in that the embedded templates parse
+// AND execute against a representative OrderView. A regression in either
+// the template syntax or a renamed accessor on OrderView is caught here
+// without spinning up a full integration test.
+func TestRenderOrderConfirmation(t *testing.T) {
+	view := checkoutQuery.NewOrderView(
+		"ord-123",
+		"alice@example.com",
+		domain.Status("paid"),
+		time.Date(2026, 1, 2, 15, 4, 5, 0, time.UTC),
+		[]domain.Line{
+			domain.NewLine("p-1", "Widget", 2, 999, "USD"),
+		},
+		domain.Address{},
+		domain.RebuildShippingMethod("pickup", "Pickup", 0),
+		domain.RebuildPaymentMethod("card", "Card"),
+		1998,
+		1998,
+		"USD",
+	)
+
+	msg, err := RenderOrderConfirmation(view, "http://localhost:8080")
+	if err != nil {
+		t.Fatalf("RenderOrderConfirmation: %v", err)
+	}
+	if msg.To != "alice@example.com" {
+		t.Fatalf("To = %q, want alice@example.com", msg.To)
+	}
+	if !strings.Contains(msg.Subject, "ord-123") {
+		t.Fatalf("Subject does not include order id: %q", msg.Subject)
+	}
+	if !strings.Contains(msg.HTMLBody, "Widget") {
+		t.Fatalf("HTMLBody missing item name: %q", msg.HTMLBody)
+	}
+	if !strings.Contains(msg.HTMLBody, "/order/ord-123") {
+		t.Fatalf("HTMLBody missing OrderURL: %q", msg.HTMLBody)
+	}
+	if !strings.Contains(msg.TextBody, "Widget") {
+		t.Fatalf("TextBody missing item name: %q", msg.TextBody)
+	}
+}
+
+func TestRenderPasswordReset(t *testing.T) {
+	msg, err := RenderPasswordReset("bob@example.com", "raw-token-abc", "http://localhost:8080/", 30)
+	if err != nil {
+		t.Fatalf("RenderPasswordReset: %v", err)
+	}
+	if msg.To != "bob@example.com" {
+		t.Fatalf("To = %q, want bob@example.com", msg.To)
+	}
+	if !strings.Contains(msg.HTMLBody, "raw-token-abc") {
+		t.Fatalf("HTMLBody missing token: %q", msg.HTMLBody)
+	}
+	if !strings.Contains(msg.HTMLBody, "/auth/reset?token=raw-token-abc") {
+		t.Fatalf("HTMLBody missing ResetURL: %q", msg.HTMLBody)
+	}
+	if !strings.Contains(msg.TextBody, "30") {
+		t.Fatalf("TextBody missing TTL: %q", msg.TextBody)
+	}
+}

--- a/backend/layout/emails_test.go
+++ b/backend/layout/emails_test.go
@@ -26,8 +26,12 @@ func TestRenderOrderConfirmation(t *testing.T) {
 		domain.RebuildShippingMethod("pickup", "Pickup", 0),
 		domain.RebuildPaymentMethod("card", "Card"),
 		1998,
+		0,
+		0,
 		1998,
 		"USD",
+		"",
+		"",
 	)
 
 	msg, err := RenderOrderConfirmation(view, "http://localhost:8080")

--- a/backend/layout/http.go
+++ b/backend/layout/http.go
@@ -15,23 +15,24 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-var (
-	key   = []byte("go-ecommerce")
-	store = newCookieStore(key)
-)
+// store is the process-wide session cookie store. It is initialised once by
+// layout.New() (which reads SESSION_SECRET and COOKIE_SECURE from config) and
+// reused by every handler in this package. Keeping it package-level keeps the
+// existing `store.Get(r, "ecommerce")` call-sites unchanged; there is only
+// one layout boundedContext per process so a single shared store is fine.
+var store *sessions.CookieStore
 
 // newCookieStore returns a CookieStore whose Options work over plain HTTP
-// (localhost / docker compose) so the demo runs without TLS. gorilla
-// sessions defaults to Secure + SameSite=None which makes the cookie
-// invisible to non-HTTPS clients. Flip Secure to true when serving over
-// HTTPS for real.
-func newCookieStore(key []byte) *sessions.CookieStore {
+// (localhost / docker compose) when secure=false; flip secure=true for
+// HTTPS deployments (COOKIE_SECURE=true). HttpOnly and SameSite=Lax are
+// always on.
+func newCookieStore(key []byte, secure bool) *sessions.CookieStore {
 	s := sessions.NewCookieStore(key)
 	s.Options = &sessions.Options{
 		Path:     "/",
 		MaxAge:   86400 * 30,
 		HttpOnly: true,
-		Secure:   false,
+		Secure:   secure,
 		SameSite: http.SameSiteLaxMode,
 	}
 	return s
@@ -126,6 +127,8 @@ func (m boundedContext) MuxRegister(r *mux.Router) {
 	r.HandleFunc("/auth/logout", observability.HTTPWrap(m.handler.HandleLogout, m.logger)).Methods("GET")
 	r.HandleFunc("/auth/register", observability.HTTPWrap(m.handler.Register, m.logger)).Methods("GET")
 	r.HandleFunc("/auth/register", observability.HTTPWrap(m.handler.HandleRegister, m.logger)).Methods("POST")
+	r.HandleFunc("/auth/change-password", observability.HTTPWrap(m.handler.ChangePasswordPage, m.logger)).Methods("GET")
+	r.HandleFunc("/auth/change-password", observability.HTTPWrap(m.handler.HandleChangePassword, m.logger)).Methods("POST")
 	r.HandleFunc("/auth/menuIcon", observability.HTTPWrap(m.handler.AuthMenuItem, m.logger)).Methods("GET", "OPTIONS")
 
 	r.HandleFunc("/checkout", observability.HTTPWrap(m.handler.Checkout, m.logger)).Methods("GET")

--- a/backend/layout/http.go
+++ b/backend/layout/http.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/bkielbasa/go-ecommerce/backend/internal/imagestore"
+	"github.com/bkielbasa/go-ecommerce/backend/internal/mailer"
 	"github.com/bkielbasa/go-ecommerce/backend/internal/observability"
 	"github.com/gorilla/mux"
 	"github.com/gorilla/sessions"
@@ -46,6 +47,8 @@ type httpHandler struct {
 	checkoutQry checkoutQueries
 	shipSrv     shippingService
 	imageStore  imagestore.Store
+	mailer      mailer.Mailer
+	baseURL     string
 	logger      logrus.FieldLogger
 }
 
@@ -129,6 +132,10 @@ func (m boundedContext) MuxRegister(r *mux.Router) {
 	r.HandleFunc("/auth/register", observability.HTTPWrap(m.handler.HandleRegister, m.logger)).Methods("POST")
 	r.HandleFunc("/auth/change-password", observability.HTTPWrap(m.handler.ChangePasswordPage, m.logger)).Methods("GET")
 	r.HandleFunc("/auth/change-password", observability.HTTPWrap(m.handler.HandleChangePassword, m.logger)).Methods("POST")
+	r.HandleFunc("/auth/forgot", observability.HTTPWrap(m.handler.ForgotPasswordPage, m.logger)).Methods("GET")
+	r.HandleFunc("/auth/forgot", observability.HTTPWrap(m.handler.HandleForgotPassword, m.logger)).Methods("POST")
+	r.HandleFunc("/auth/reset", observability.HTTPWrap(m.handler.ResetPasswordPage, m.logger)).Methods("GET")
+	r.HandleFunc("/auth/reset", observability.HTTPWrap(m.handler.HandleResetPassword, m.logger)).Methods("POST")
 	r.HandleFunc("/auth/menuIcon", observability.HTTPWrap(m.handler.AuthMenuItem, m.logger)).Methods("GET", "OPTIONS")
 
 	r.HandleFunc("/checkout", observability.HTTPWrap(m.handler.Checkout, m.logger)).Methods("GET")

--- a/backend/layout/http.go
+++ b/backend/layout/http.go
@@ -219,6 +219,21 @@ func (handler httpHandler) renderTemplate(w http.ResponseWriter, r *http.Request
 	}).ParseFiles(files...))
 
 	session, _ := store.Get(r, "ecommerce")
+	// CSRFToken is injected into every page so:
+	//   * hidden <input name="csrf_token"> fields in <form method="post"> get a
+	//     fresh value on each render, and
+	//   * the htmx:configRequest snippet in layout.gohtml can stamp the same
+	//     value onto the X-CSRF-Token header for HTMX-driven POSTs.
+	// issueCSRFToken shares the request-scoped gorilla/sessions registry, so
+	// it mutates the same `session` pointer; the flash reads and the
+	// session.Save below therefore see the just-minted token.
+	csrfToken, err := issueCSRFToken(r, w)
+	if err != nil {
+		handler.logger.WithError(err).Error("cannot issue CSRF token")
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+	data["CSRFToken"] = csrfToken
 	data["FlashInfo"] = session.Flashes()
 	data["FlashError"] = session.Flashes("error")
 	data["AuthMenuItem"] = renderPartial(w, r, http.HandlerFunc(handler.AuthMenuItem))
@@ -283,10 +298,20 @@ func (handler httpHandler) renderAdminTemplate(w http.ResponseWriter, r *http.Re
 	}).ParseFiles(files...))
 
 	session, _ := store.Get(r, "ecommerce")
+	// Same CSRF/htmx contract as renderTemplate — the admin shell also
+	// embeds the configRequest script that stamps X-CSRF-Token on every
+	// HTMX request, and admin templates emit a hidden csrf_token input.
+	csrfToken, err := issueCSRFToken(r, w)
+	if err != nil {
+		handler.logger.WithError(err).Error("cannot issue CSRF token")
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+	data["CSRFToken"] = csrfToken
 	data["FlashInfo"] = session.Flashes()
 	data["FlashError"] = session.Flashes("error")
 	data["AdminEmail"] = handler.currentCustomerID(r)
-	err := session.Save(r, w)
+	err = session.Save(r, w)
 	if err != nil {
 		handler.logger.WithError(err).Error("cannot save session")
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)

--- a/backend/layout/http.go
+++ b/backend/layout/http.go
@@ -200,8 +200,15 @@ func (m boundedContext) MuxRegister(r *mux.Router) {
 	r.HandleFunc("/admin/attribute-sets/{id}", observability.HTTPWrap(m.handler.AdminUpdateAttributeSet, m.logger)).Methods("POST")
 
 	r.HandleFunc("/admin/orders", observability.HTTPWrap(m.handler.AdminOrders, m.logger)).Methods("GET")
+	// Specific fulfillment sub-paths must be registered before the
+	// /admin/orders/{orderID} catch-all so they don't get shadowed.
 	r.HandleFunc("/admin/orders/{orderID}/cancel", observability.HTTPWrap(m.handler.AdminCancelOrder, m.logger)).Methods("POST")
+	r.HandleFunc("/admin/orders/{orderID}/ship", observability.HTTPWrap(m.handler.AdminShipOrder, m.logger)).Methods("POST")
+	r.HandleFunc("/admin/orders/{orderID}/deliver", observability.HTTPWrap(m.handler.AdminDeliverOrder, m.logger)).Methods("POST")
+	r.HandleFunc("/admin/orders/{orderID}/refund", observability.HTTPWrap(m.handler.AdminRefundOrder, m.logger)).Methods("POST")
 	r.HandleFunc("/admin/orders/{orderID}", observability.HTTPWrap(m.handler.AdminOrderDetail, m.logger)).Methods("GET")
+
+	r.HandleFunc("/admin/inventory", observability.HTTPWrap(m.handler.AdminInventory, m.logger)).Methods("GET")
 }
 
 func (handler httpHandler) renderTemplate(w http.ResponseWriter, r *http.Request, templateName string, data map[string]any) {

--- a/backend/layout/http_account.go
+++ b/backend/layout/http_account.go
@@ -9,7 +9,28 @@ import (
 )
 
 // requireLogin resolves the current customer or redirects to the login page.
+// If the customer still has must_change_password set, the gate diverts them
+// to /auth/change-password so the forced reset cannot be skipped by visiting
+// /account/* directly. The change-password handlers themselves use
+// requireLoginAllowMustChange to avoid an infinite redirect loop.
 func (handler httpHandler) requireLogin(w http.ResponseWriter, r *http.Request) (string, bool) {
+	cid := handler.currentCustomerID(r)
+	if cid == "" {
+		http.Redirect(w, r, "/auth/login", http.StatusSeeOther)
+		return "", false
+	}
+	if must, err := handler.authSrv.MustChangePassword(r.Context(), cid); err == nil && must {
+		http.Redirect(w, r, "/auth/change-password", http.StatusSeeOther)
+		return "", false
+	}
+	return cid, true
+}
+
+// requireLoginAllowMustChange is the variant used by the forced-reset page
+// itself: it confirms the caller is logged in but does NOT redirect when the
+// must_change_password flag is set (which is exactly the state in which the
+// caller is allowed to be on this page).
+func (handler httpHandler) requireLoginAllowMustChange(w http.ResponseWriter, r *http.Request) (string, bool) {
 	cid := handler.currentCustomerID(r)
 	if cid == "" {
 		http.Redirect(w, r, "/auth/login", http.StatusSeeOther)

--- a/backend/layout/http_admin.go
+++ b/backend/layout/http_admin.go
@@ -9,6 +9,10 @@ import (
 // already written the response (a redirect to login for anonymous users, or a
 // 403 for non-admins) and returns ok=false; callers should simply return.
 //
+// If the admin still has the must_change_password flag set, the gate sends
+// them to /auth/change-password so the forced-reset flow cannot be skipped
+// by deep-linking to an admin page.
+//
 // Later admin phases (products, categories, orders, ...) reuse this gate as
 // their first line.
 func (handler httpHandler) requireAdmin(w http.ResponseWriter, r *http.Request) (string, bool) {
@@ -21,6 +25,14 @@ func (handler httpHandler) requireAdmin(w http.ResponseWriter, r *http.Request) 
 	isAdmin, err := handler.authSrv.IsAdmin(r.Context(), email)
 	if err != nil || !isAdmin {
 		http.Error(w, "Forbidden", http.StatusForbidden)
+		return "", false
+	}
+
+	// Force the password change before any admin work. A lookup error here
+	// is treated as "not flagged" so a transient DB hiccup doesn't lock
+	// the admin out of the panel.
+	if must, mcpErr := handler.authSrv.MustChangePassword(r.Context(), email); mcpErr == nil && must {
+		http.Redirect(w, r, "/auth/change-password", http.StatusSeeOther)
 		return "", false
 	}
 

--- a/backend/layout/http_admin_orders.go
+++ b/backend/layout/http_admin_orders.go
@@ -3,6 +3,7 @@ package layout
 import (
 	"errors"
 	"net/http"
+	"strings"
 
 	checkoutDomain "github.com/bkielbasa/go-ecommerce/backend/checkout/domain"
 	"github.com/bkielbasa/go-ecommerce/backend/internal/https"
@@ -27,8 +28,10 @@ func (handler httpHandler) AdminOrders(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-// AdminOrderDetail renders a single order's detail with an admin cancel form
-// for paid orders.
+// AdminOrderDetail renders a single order's detail with the admin
+// fulfillment controls — buttons appropriate to the order's current status
+// (cancel/ship for paid, mark-delivered for shipped, refund for any paid
+// or fulfilled order).
 func (handler httpHandler) AdminOrderDetail(w http.ResponseWriter, r *http.Request) {
 	email, ok := handler.requireAdmin(w, r)
 	if !ok {
@@ -44,11 +47,18 @@ func (handler httpHandler) AdminOrderDetail(w http.ResponseWriter, r *http.Reque
 		https.InternalError(w, "internal-error", err.Error())
 		return
 	}
+	status := order.Status()
+	canRefund := status == checkoutDomain.StatusPaid ||
+		status == checkoutDomain.StatusShipped ||
+		status == checkoutDomain.StatusDelivered
 	handler.renderAdminTemplate(w, r, "admin/order_detail", map[string]any{
-		"Active":    "orders",
-		"Email":     email,
-		"Order":     order,
-		"CanCancel": order.Status() == checkoutDomain.StatusPaid,
+		"Active":       "orders",
+		"Email":        email,
+		"Order":        order,
+		"CanCancel":    status == checkoutDomain.StatusPaid,
+		"CanShip":      status == checkoutDomain.StatusPaid,
+		"CanDeliver":   status == checkoutDomain.StatusShipped,
+		"CanRefund":    canRefund,
 	})
 }
 
@@ -71,6 +81,109 @@ func (handler httpHandler) AdminCancelOrder(w http.ResponseWriter, r *http.Reque
 		return
 	default:
 		handler.flash(w, r, "Order cancelled.", "info")
+	}
+	http.Redirect(w, r, "/admin/orders/"+orderID, http.StatusSeeOther)
+}
+
+// AdminShipOrder marks a paid order as shipped, optionally recording the
+// carrier and tracking code submitted on the form.
+func (handler httpHandler) AdminShipOrder(w http.ResponseWriter, r *http.Request) {
+	if _, ok := handler.requireAdmin(w, r); !ok {
+		return
+	}
+	if err := r.ParseForm(); err != nil {
+		https.InternalError(w, "internal-error", err.Error())
+		return
+	}
+	orderID := mux.Vars(r)["orderID"]
+	carrier := r.FormValue("carrier")
+	tracking := r.FormValue("tracking_code")
+	err := handler.checkoutSrv.MarkShipped(r.Context(), orderID, carrier, tracking)
+	switch {
+	case errors.Is(err, checkoutDomain.ErrOrderNotFound):
+		handler.flash(w, r, "Order not found.", "error")
+		http.Redirect(w, r, "/admin/orders", http.StatusSeeOther)
+		return
+	case errors.Is(err, checkoutDomain.ErrOrderNotShippable):
+		handler.flash(w, r, "This order cannot be shipped from its current status.", "error")
+	case err != nil:
+		https.InternalError(w, "internal-error", err.Error())
+		return
+	default:
+		handler.flash(w, r, "Order marked as shipped.", "info")
+	}
+	http.Redirect(w, r, "/admin/orders/"+orderID, http.StatusSeeOther)
+}
+
+// AdminDeliverOrder marks a shipped order as delivered.
+func (handler httpHandler) AdminDeliverOrder(w http.ResponseWriter, r *http.Request) {
+	if _, ok := handler.requireAdmin(w, r); !ok {
+		return
+	}
+	orderID := mux.Vars(r)["orderID"]
+	err := handler.checkoutSrv.MarkDelivered(r.Context(), orderID)
+	switch {
+	case errors.Is(err, checkoutDomain.ErrOrderNotFound):
+		handler.flash(w, r, "Order not found.", "error")
+		http.Redirect(w, r, "/admin/orders", http.StatusSeeOther)
+		return
+	case errors.Is(err, checkoutDomain.ErrOrderNotDeliverable):
+		handler.flash(w, r, "This order cannot be marked delivered from its current status.", "error")
+	case err != nil:
+		https.InternalError(w, "internal-error", err.Error())
+		return
+	default:
+		handler.flash(w, r, "Order marked as delivered.", "info")
+	}
+	http.Redirect(w, r, "/admin/orders/"+orderID, http.StatusSeeOther)
+}
+
+// AdminInventory renders the inventory audit-trail page: the 200 most recent
+// stock movements. Optional ?variant=<id> query filters to a single variant.
+func (handler httpHandler) AdminInventory(w http.ResponseWriter, r *http.Request) {
+	email, ok := handler.requireAdmin(w, r)
+	if !ok {
+		return
+	}
+	variantID := strings.TrimSpace(r.URL.Query().Get("variant"))
+	movements, err := handler.catalogSrv.ListStockMovements(r.Context(), variantID, 200)
+	if err != nil {
+		https.InternalError(w, "internal-error", err.Error())
+		return
+	}
+	handler.renderAdminTemplate(w, r, "admin/stock_movements", map[string]any{
+		"Active":    "inventory",
+		"Email":     email,
+		"Movements": movements,
+		"VariantID": variantID,
+	})
+}
+
+// AdminRefundOrder refunds a paid/shipped/delivered order; the underlying
+// service also releases the reserved stock back to the catalogue.
+func (handler httpHandler) AdminRefundOrder(w http.ResponseWriter, r *http.Request) {
+	if _, ok := handler.requireAdmin(w, r); !ok {
+		return
+	}
+	if err := r.ParseForm(); err != nil {
+		https.InternalError(w, "internal-error", err.Error())
+		return
+	}
+	orderID := mux.Vars(r)["orderID"]
+	reason := r.FormValue("reason")
+	err := handler.checkoutSrv.Refund(r.Context(), orderID, reason)
+	switch {
+	case errors.Is(err, checkoutDomain.ErrOrderNotFound):
+		handler.flash(w, r, "Order not found.", "error")
+		http.Redirect(w, r, "/admin/orders", http.StatusSeeOther)
+		return
+	case errors.Is(err, checkoutDomain.ErrOrderNotRefundable):
+		handler.flash(w, r, "This order cannot be refunded from its current status.", "error")
+	case err != nil:
+		https.InternalError(w, "internal-error", err.Error())
+		return
+	default:
+		handler.flash(w, r, "Order refunded.", "info")
 	}
 	http.Redirect(w, r, "/admin/orders/"+orderID, http.StatusSeeOther)
 }

--- a/backend/layout/http_auth.go
+++ b/backend/layout/http_auth.go
@@ -101,8 +101,21 @@ func (handler httpHandler) HandleLogin(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	session.Values["session_id"] = sess.ID()
+
+	// Forced password change: if the just-logged-in customer is flagged,
+	// short-circuit the normal landing page and send them to the gate. A
+	// lookup error is treated as "not flagged" so a transient DB hiccup
+	// doesn't lock the user out of the storefront.
+	mustChange, mcpErr := handler.authSrv.MustChangePassword(r.Context(), c.Username)
+	if mcpErr == nil && mustChange {
+		session.AddFlash("Please choose a new password to continue.")
+		_ = session.Save(r, w)
+		http.Redirect(w, r, "/auth/change-password", http.StatusSeeOther)
+		return
+	}
+
 	session.AddFlash("You are logged in")
-  session.Values["session_id"] = sess.ID()
 	_ = session.Save(r, w)
 
 	http.Redirect(w, r, "/", http.StatusSeeOther)
@@ -151,4 +164,64 @@ func (handler httpHandler) HandleRegister(w http.ResponseWriter, r *http.Request
 	session.AddFlash("You are registered. You can log in now")
 	_ = session.Save(r, w)
 	http.Redirect(w, r, "/auth/login", http.StatusSeeOther)
+}
+
+// ChangePasswordPage renders the forced password-change form. It is only
+// reachable for a logged-in customer whose must_change_password flag is true.
+// Any other caller is redirected away so the page never serves as a stealth
+// alternative to /account/details/password.
+func (handler httpHandler) ChangePasswordPage(w http.ResponseWriter, r *http.Request) {
+	email, ok := handler.requireLoginAllowMustChange(w, r)
+	if !ok {
+		return
+	}
+	must, err := handler.authSrv.MustChangePassword(r.Context(), email)
+	if err != nil || !must {
+		http.Redirect(w, r, "/account", http.StatusSeeOther)
+		return
+	}
+	handler.renderTemplate(w, r, "auth/change_password", map[string]any{
+		"Email": email,
+	})
+}
+
+// HandleChangePassword processes the forced password-change form. On success
+// the auth service clears the must_change_password flag and the user is sent
+// to /admin (the only flag holders today are admins). On policy/old-password
+// errors we flash and re-render the form.
+func (handler httpHandler) HandleChangePassword(w http.ResponseWriter, r *http.Request) {
+	email, ok := handler.requireLoginAllowMustChange(w, r)
+	if !ok {
+		return
+	}
+	must, err := handler.authSrv.MustChangePassword(r.Context(), email)
+	if err != nil || !must {
+		http.Redirect(w, r, "/account", http.StatusSeeOther)
+		return
+	}
+
+	if err := r.ParseForm(); err != nil {
+		handler.flash(w, r, err.Error(), "error")
+		http.Redirect(w, r, "/auth/change-password", http.StatusSeeOther)
+		return
+	}
+
+	oldPassword := r.FormValue("current_password")
+	newPassword := r.FormValue("new_password")
+	confirm := r.FormValue("confirm_password")
+
+	if newPassword != confirm {
+		handler.flash(w, r, "new password and confirmation do not match", "error")
+		http.Redirect(w, r, "/auth/change-password", http.StatusSeeOther)
+		return
+	}
+
+	if err := handler.authSrv.ChangePassword(r.Context(), email, oldPassword, newPassword); err != nil {
+		handler.flash(w, r, err.Error(), "error")
+		http.Redirect(w, r, "/auth/change-password", http.StatusSeeOther)
+		return
+	}
+
+	handler.flash(w, r, "Password updated. Welcome to GoCommerce admin.", "info")
+	http.Redirect(w, r, "/admin", http.StatusSeeOther)
 }

--- a/backend/layout/http_auth.go
+++ b/backend/layout/http_auth.go
@@ -88,10 +88,22 @@ type Client struct {
 }
 
 func (handler httpHandler) HandleLogin(w http.ResponseWriter, r *http.Request) {
+	session, _ := store.Get(r, "ecommerce")
+
+	// Per-IP rate limit: 5/min. Credential stuffing is the threat model; a
+	// human re-typing the wrong password a handful of times still gets
+	// through, but a bot trying dozens of passwords from the same source
+	// gets bounced back to the login form with a flash.
+	if !loginLimiter.Allow(clientIP(r)) {
+		session.AddFlash("Too many login attempts, please try again in a moment.", "error")
+		_ = session.Save(r, w)
+		http.Redirect(w, r, "/auth/login", http.StatusSeeOther)
+		return
+	}
+
 	var c Client
 	c.Username = r.FormValue("email")
 	c.Password = r.FormValue("password")
-	session, _ := store.Get(r, "ecommerce")
 
 	sess, err := handler.authSrv.Login(r.Context(), c.Username, c.Password)
 	if err != nil {
@@ -132,11 +144,23 @@ type NewClient struct {
 
 func (handler httpHandler) HandleRegister(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
+	session, _ := store.Get(r, "ecommerce")
+
+	// Per-IP rate limit: 3/hour. Real account signups are infrequent; the
+	// rate is deliberately tight enough to throttle automated account
+	// creation but loose enough that a household behind one NAT can still
+	// register a couple of customers.
+	if !registerLimiter.Allow(clientIP(r)) {
+		session.AddFlash("Too many registration attempts, please try again later.", "error")
+		_ = session.Save(r, w)
+		http.Redirect(w, r, "/auth/register", http.StatusSeeOther)
+		return
+	}
+
 	var c NewClient
 
 	c.Username = r.FormValue("email")
 	c.Password = r.FormValue("password")
-	session, _ := store.Get(r, "ecommerce")
 
 	if err := handler.authSrv.CreateNewCustomer(ctx, c.Username, c.Password); err != nil {
 		var e domain.PasswordPolicyError

--- a/backend/layout/http_cart.go
+++ b/backend/layout/http_cart.go
@@ -14,6 +14,16 @@ import (
 )
 
 func (handler httpHandler) AddToCart(w http.ResponseWriter, r *http.Request) {
+	// Per-IP rate limit: 30 cart-adds/minute. The legitimate flow is one
+	// click → one POST, so 30/min easily covers an enthusiastic shopper;
+	// anything beyond that smells like a scraper or a stuck retry loop and
+	// gets a clean 429 (HTMX surfaces it as a failed request without
+	// disturbing the rest of the page).
+	if !addToCartLimiter.Allow(clientIP(r)) {
+		http.Error(w, "too many requests, please slow down", http.StatusTooManyRequests)
+		return
+	}
+
 	cartID := cartIDFromCookies(w, r)
 	variantID := mux.Vars(r)["variantID"]
 

--- a/backend/layout/http_password_reset.go
+++ b/backend/layout/http_password_reset.go
@@ -1,0 +1,118 @@
+package layout
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/bkielbasa/go-ecommerce/backend/auth/adapter"
+)
+
+// passwordResetTTLMinutes mirrors the auth-app TTL (30 minutes) so the email
+// body can advertise how long the link stays valid without dragging the app
+// constant into the template layer.
+const passwordResetTTLMinutes = 30
+
+// genericForgotConfirmation is the single message every /auth/forgot POST
+// flashes back. The wording deliberately does NOT confirm whether the
+// account existed — that would turn the form into an account-enumeration
+// oracle.
+const genericForgotConfirmation = "If an account exists, an email is on its way."
+
+// ForgotPasswordPage renders the request form. It is always reachable —
+// there is no point in gating it on session state, since the user is
+// definitionally locked out at this point.
+func (handler httpHandler) ForgotPasswordPage(w http.ResponseWriter, r *http.Request) {
+	handler.renderTemplate(w, r, "auth/forgot", nil)
+}
+
+// HandleForgotPassword processes the request form. The flow is intentionally
+// stateless from the caller's perspective: regardless of whether the email
+// matches an account, we flash the same generic confirmation and redirect
+// to /auth/login. The mailer call only fires when a token was actually
+// minted (i.e. the account existed); failures inside the mailer are logged
+// but never surfaced to the caller — leaking "we tried to email you but it
+// bounced" would re-introduce the enumeration leak.
+func (handler httpHandler) HandleForgotPassword(w http.ResponseWriter, r *http.Request) {
+	session, _ := store.Get(r, "ecommerce")
+
+	if !forgotPasswordLimiter.Allow(clientIP(r)) {
+		session.AddFlash("Too many reset requests, please try again later.", "error")
+		_ = session.Save(r, w)
+		http.Redirect(w, r, "/auth/forgot", http.StatusSeeOther)
+		return
+	}
+
+	email := r.FormValue("email")
+	rawToken, err := handler.authSrv.RequestPasswordReset(r.Context(), email)
+	if err != nil {
+		// A transient DB error gets logged and surfaced as the generic
+		// confirmation — we still don't want to confirm or deny the
+		// account's existence. The operator sees the real cause in
+		// the logs.
+		handler.logger.WithError(err).Warn("RequestPasswordReset failed")
+	}
+
+	if rawToken != "" {
+		msg, rerr := RenderPasswordReset(email, rawToken, handler.baseURL, passwordResetTTLMinutes)
+		if rerr != nil {
+			handler.logger.WithError(rerr).Error("cannot render password reset email")
+		} else if handler.mailer != nil {
+			if serr := handler.mailer.Send(r.Context(), msg); serr != nil {
+				handler.logger.WithError(serr).Error("cannot send password reset email")
+			}
+		}
+	}
+
+	session.AddFlash(genericForgotConfirmation)
+	_ = session.Save(r, w)
+	http.Redirect(w, r, "/auth/login", http.StatusSeeOther)
+}
+
+// ResetPasswordPage renders the new-password form. The token from the URL
+// is passed through as a hidden input so the POST has it without us having
+// to round-trip it via the session.
+func (handler httpHandler) ResetPasswordPage(w http.ResponseWriter, r *http.Request) {
+	token := r.URL.Query().Get("token")
+	handler.renderTemplate(w, r, "auth/reset", map[string]any{
+		"Token": token,
+	})
+}
+
+// HandleResetPassword processes the new-password form. On any token
+// failure (unknown / expired / already-used) the caller is bounced back
+// to /auth/forgot with a generic message; the underlying ErrInvalidResetToken
+// from the storage layer is intentionally opaque.
+func (handler httpHandler) HandleResetPassword(w http.ResponseWriter, r *http.Request) {
+	if err := r.ParseForm(); err != nil {
+		handler.flash(w, r, "could not parse form", "error")
+		http.Redirect(w, r, "/auth/forgot", http.StatusSeeOther)
+		return
+	}
+
+	token := r.FormValue("token")
+	newPassword := r.FormValue("new_password")
+	confirm := r.FormValue("confirm_password")
+
+	if newPassword != confirm {
+		handler.flash(w, r, "new password and confirmation do not match", "error")
+		http.Redirect(w, r, "/auth/reset?token="+token, http.StatusSeeOther)
+		return
+	}
+
+	if err := handler.authSrv.ResetPassword(r.Context(), token, newPassword); err != nil {
+		if errors.Is(err, adapter.ErrInvalidResetToken) {
+			handler.flash(w, r, "this reset link is invalid or has expired. Please request a new one.", "error")
+			http.Redirect(w, r, "/auth/forgot", http.StatusSeeOther)
+			return
+		}
+		// Any other error (policy failure, hash failure, storage
+		// failure) is surfaced verbatim — these are all things the
+		// user can either fix (policy) or report (everything else).
+		handler.flash(w, r, err.Error(), "error")
+		http.Redirect(w, r, "/auth/reset?token="+token, http.StatusSeeOther)
+		return
+	}
+
+	handler.flash(w, r, "Your password has been updated. Please sign in.", "info")
+	http.Redirect(w, r, "/auth/login", http.StatusSeeOther)
+}

--- a/backend/layout/ratelimits.go
+++ b/backend/layout/ratelimits.go
@@ -27,6 +27,13 @@ var (
 	loginLimiter     = ratelimit.New(5.0/60.0, 5)
 	registerLimiter  = ratelimit.New(3.0/3600.0, 3)
 	addToCartLimiter = ratelimit.New(30.0/60.0, 30)
+	// forgotPasswordLimiter caps the password-reset request rate at 3/hour
+	// per IP. Reset emails are an asymmetric workload (one cheap form post
+	// triggers a full SMTP send), and they double as an enumeration vector
+	// (timing differences between "exists" and "doesn't exist" code paths
+	// can leak signal); the same per-IP throttle that protects /auth/
+	// register fits here for the same reasons.
+	forgotPasswordLimiter = ratelimit.New(3.0/3600.0, 3)
 )
 
 // clientIP returns a best-effort source IP for rate-limiting decisions.

--- a/backend/layout/ratelimits.go
+++ b/backend/layout/ratelimits.go
@@ -1,0 +1,62 @@
+package layout
+
+import (
+	"net"
+	"net/http"
+	"strings"
+
+	"github.com/bkielbasa/go-ecommerce/backend/internal/ratelimit"
+)
+
+// Package-level limiters. One process, one set of buckets — keeping them
+// here (rather than on httpHandler) avoids threading them through every
+// handler signature and matches the existing `store` package var pattern.
+//
+// Rates are tuned conservatively for the abuse surface, not for legitimate
+// repeat traffic:
+//
+//   - loginLimiter: 5 logins / minute / IP. A human typing the wrong
+//     password a handful of times still gets through; credential-stuffing
+//     bots do not.
+//   - registerLimiter: 3 registrations / hour / IP. Real signups are rare;
+//     anything above this rate is almost certainly account-creation abuse.
+//   - addToCartLimiter: 30 cart-adds / minute / IP. The storefront triggers
+//     this once per click, so legitimate browsing stays well under; rapid
+//     scraping that hammers the variant box gets a 429.
+var (
+	loginLimiter     = ratelimit.New(5.0/60.0, 5)
+	registerLimiter  = ratelimit.New(3.0/3600.0, 3)
+	addToCartLimiter = ratelimit.New(30.0/60.0, 30)
+)
+
+// clientIP returns a best-effort source IP for rate-limiting decisions.
+// The first comma-delimited entry of X-Forwarded-For is honored when
+// present (typical for deployments behind a reverse proxy); otherwise we
+// fall back to the host portion of r.RemoteAddr. The string is normalized
+// (trimmed, lower-cased) so two requests from the same source always hash
+// to the same bucket key.
+//
+// We deliberately do NOT honor X-Real-IP or other arbitrary headers — only
+// X-Forwarded-For, which is the convention every proxy in our stack emits.
+// In a setup that does not strip these headers at the edge, a malicious
+// client could spoof X-Forwarded-For; the protections here are still a
+// useful first line, but a hardened deployment should terminate XFF at the
+// reverse proxy.
+func clientIP(r *http.Request) string {
+	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+		if i := strings.IndexByte(xff, ','); i >= 0 {
+			xff = xff[:i]
+		}
+		ip := strings.TrimSpace(xff)
+		if ip != "" {
+			return strings.ToLower(ip)
+		}
+	}
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		// RemoteAddr without a port (rare, but documented as
+		// possible for non-TCP transports) — use the whole string.
+		return strings.ToLower(r.RemoteAddr)
+	}
+	return strings.ToLower(host)
+}

--- a/backend/layout/static/admin.css
+++ b/backend/layout/static/admin.css
@@ -381,10 +381,12 @@ input:focus, select:focus, textarea:focus {
 }
 .order-status--paid { background: #e3f5ea; color: #1f7a44; border-color: #b8e6c9; }
 .order-status--pending { background: #fef3e0; color: #9a6300; border-color: #f6d99e; }
-.order-status--shipped { background: #e6effd; color: #1f5bbf; border-color: #bcd6fb; }
+.order-status--shipped { background: #e3f5ea; color: #1f7a44; border-color: #b8e6c9; }
+.order-status--delivered { background: #ececec; color: #4a4a4a; border-color: #cccccc; }
+.order-status--failed { background: #fdecec; color: #a52f2f; border-color: #f3bcbc; }
 .order-status--cancelled,
 .order-status--canceled { background: #fdecec; color: #a52f2f; border-color: #f3bcbc; }
-.order-status--refunded { background: #efeafd; color: #5a3fbf; border-color: #d6cbf6; }
+.order-status--refunded { background: #fdefdc; color: #a26200; border-color: #f4d199; }
 
 /* --- Order detail -------------------------------------------------------- */
 .order__header { margin-bottom: 16px; }

--- a/backend/layout/static/main.css
+++ b/backend/layout/static/main.css
@@ -576,6 +576,9 @@ main {
 .order-status--failed    { color: var(--danger); }
 .order-status--pending   { color: var(--info); }
 .order-status--cancelled { color: var(--danger); }
+.order-status--shipped   { color: #1f7a44; }
+.order-status--delivered { color: var(--fg-muted); }
+.order-status--refunded  { color: #a26200; }
 .order__actions { display: flex; align-items: center; gap: var(--space-3); margin-top: var(--space-2); }
 
 /* ---------- order confirmation ---------- */

--- a/backend/layout/tmpl/account/address_edit.gohtml
+++ b/backend/layout/tmpl/account/address_edit.gohtml
@@ -10,6 +10,7 @@
       <h2 class="account-card__title">edit address</h2>
 
       <form class="form" method="post" action="/account/addresses/{{.Address.ID}}">
+        <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
         <div class="field"><label for="a-name">full name</label><input id="a-name" name="name" value="{{.Address.Name}}" required></div>
         <div class="field"><label for="a-street1">street</label><input id="a-street1" name="street1" value="{{.Address.Street1}}" required></div>
         <div class="field"><label for="a-street2">street (line 2)</label><input id="a-street2" name="street2" value="{{.Address.Street2}}"></div>

--- a/backend/layout/tmpl/account/addresses.gohtml
+++ b/backend/layout/tmpl/account/addresses.gohtml
@@ -23,9 +23,9 @@
               <div class="addr-card__actions">
                 <a href="/account/addresses/{{$a.ID}}/edit">edit</a>
                 {{if not $a.IsDefault}}
-                  <form method="post" action="/account/addresses/{{$a.ID}}/default"><button type="submit" class="linkbtn">make default</button></form>
+                  <form method="post" action="/account/addresses/{{$a.ID}}/default"><input type="hidden" name="csrf_token" value="{{$.CSRFToken}}"><button type="submit" class="linkbtn">make default</button></form>
                 {{end}}
-                <form method="post" action="/account/addresses/{{$a.ID}}/delete"><button type="submit" class="linkbtn linkbtn--danger">delete</button></form>
+                <form method="post" action="/account/addresses/{{$a.ID}}/delete"><input type="hidden" name="csrf_token" value="{{$.CSRFToken}}"><button type="submit" class="linkbtn linkbtn--danger">delete</button></form>
               </div>
             </article>
           {{end}}
@@ -37,6 +37,7 @@
       <section class="addr-add">
         <h3 class="account-card__title">add an address</h3>
         <form class="form" method="post" action="/account/addresses">
+          <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
           <div class="field"><label for="a-name">full name</label><input id="a-name" name="name" required></div>
           <div class="field"><label for="a-street1">street</label><input id="a-street1" name="street1" required></div>
           <div class="field"><label for="a-street2">street (line 2)</label><input id="a-street2" name="street2"></div>

--- a/backend/layout/tmpl/account/details.gohtml
+++ b/backend/layout/tmpl/account/details.gohtml
@@ -16,6 +16,7 @@
       <section class="addr-add">
         <h3 class="account-card__title">change password</h3>
         <form class="form" method="post" action="/account/details/password">
+          <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
           <div class="field">
             <label for="cur">current password</label>
             <input id="cur" type="password" name="current_password" autocomplete="current-password" required>

--- a/backend/layout/tmpl/admin/attribute_edit.gohtml
+++ b/backend/layout/tmpl/admin/attribute_edit.gohtml
@@ -3,6 +3,7 @@
   <h2 class="account-card__title">edit attribute type</h2>
 
   <form class="form" method="post" action="/admin/attributes/{{.Attribute.ID}}">
+    <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
     <div class="field"><label for="a-name">name</label><input id="a-name" name="name" value="{{.Attribute.Name}}" required></div>
     <div class="field"><label for="a-unit">unit (optional)</label><input id="a-unit" name="unit" value="{{.Attribute.Unit}}"></div>
     <div class="field">

--- a/backend/layout/tmpl/admin/attribute_set_edit.gohtml
+++ b/backend/layout/tmpl/admin/attribute_set_edit.gohtml
@@ -3,6 +3,7 @@
   <h2 class="account-card__title">{{if .IsNew}}new attribute set{{else}}edit attribute set{{end}}</h2>
 
   <form class="form" method="post" action="{{if .IsNew}}/admin/attribute-sets{{else}}/admin/attribute-sets/{{.SetID}}{{end}}">
+    <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
     <div class="field"><label for="s-name">name</label><input id="s-name" name="name" value="{{.SetName}}" required></div>
 
     <h3 class="account-card__title">members</h3>

--- a/backend/layout/tmpl/admin/attribute_sets.gohtml
+++ b/backend/layout/tmpl/admin/attribute_sets.gohtml
@@ -24,6 +24,7 @@
               <a href="/admin/attribute-sets/{{$s.ID}}/edit">edit</a>
               <form method="post" action="/admin/attribute-sets/{{$s.ID}}/delete"
                     onsubmit="return confirm('Delete this attribute set? Its member links will be removed.');">
+                <input type="hidden" name="csrf_token" value="{{$.CSRFToken}}">
                 <button type="submit" class="linkbtn linkbtn--danger">delete</button>
               </form>
             </td>

--- a/backend/layout/tmpl/admin/attributes.gohtml
+++ b/backend/layout/tmpl/admin/attributes.gohtml
@@ -18,6 +18,7 @@
               <a href="/admin/attributes/{{$t.ID}}/edit">edit</a>
               <form method="post" action="/admin/attributes/{{$t.ID}}/delete"
                     onsubmit="return confirm('Delete this attribute type? Its product values will be removed.');">
+                <input type="hidden" name="csrf_token" value="{{$.CSRFToken}}">
                 <button type="submit" class="linkbtn linkbtn--danger">delete</button>
               </form>
             </td>
@@ -32,6 +33,7 @@
   <section class="admin-form">
     <h3 class="account-card__title">add an attribute type</h3>
     <form class="form" method="post" action="/admin/attributes">
+      <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
       <div class="field"><label for="a-name">name</label><input id="a-name" name="name" required></div>
       <div class="field"><label for="a-unit">unit (optional)</label><input id="a-unit" name="unit"></div>
       <div class="field">

--- a/backend/layout/tmpl/admin/categories.gohtml
+++ b/backend/layout/tmpl/admin/categories.gohtml
@@ -16,6 +16,7 @@
               <a href="/admin/categories/{{$c.ID}}/edit">edit</a>
               <form method="post" action="/admin/categories/{{$c.ID}}/delete"
                     onsubmit="return confirm('Delete this category? Its product links will be removed.');">
+                <input type="hidden" name="csrf_token" value="{{$.CSRFToken}}">
                 <button type="submit" class="linkbtn linkbtn--danger">delete</button>
               </form>
             </td>
@@ -30,6 +31,7 @@
   <section class="admin-form">
     <h3 class="account-card__title">add a category</h3>
     <form class="form" method="post" action="/admin/categories">
+      <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
       <div class="field"><label for="c-name">name</label><input id="c-name" name="name" required></div>
       <div class="field"><label for="c-slug">slug</label><input id="c-slug" name="slug" required placeholder="lowercase-with-hyphens"></div>
       <button type="submit" class="btn">create category</button>

--- a/backend/layout/tmpl/admin/category_edit.gohtml
+++ b/backend/layout/tmpl/admin/category_edit.gohtml
@@ -3,6 +3,7 @@
   <h2 class="account-card__title">edit category</h2>
 
   <form class="form" method="post" action="/admin/categories/{{.Category.ID}}">
+    <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
     <div class="field"><label for="c-name">name</label><input id="c-name" name="name" value="{{.Category.Name}}" required></div>
     <div class="field"><label for="c-slug">slug</label><input id="c-slug" name="slug" value="{{.Category.Slug}}" required placeholder="lowercase-with-hyphens"></div>
     <div class="field"><label for="c-position">position</label><input id="c-position" name="position" type="number" value="{{.Category.Position}}"></div>

--- a/backend/layout/tmpl/admin/layout.gohtml
+++ b/backend/layout/tmpl/admin/layout.gohtml
@@ -8,6 +8,15 @@
 
     <link rel="stylesheet" href="/static/admin.css">
     <script src="https://unpkg.com/htmx.org@1.9.5"></script>
+    <script>
+      // Mirror of the storefront layout: every HTMX request from the admin
+      // shell carries the per-session CSRF token in X-CSRF-Token so
+      // csrfMiddleware lets it through. Attached to `document` because the
+      // <body> element has not been parsed yet.
+      document.addEventListener('htmx:configRequest', function (event) {
+        event.detail.headers['X-CSRF-Token'] = {{ .CSRFToken }};
+      });
+    </script>
   </head>
   <body class="admin-body">
 

--- a/backend/layout/tmpl/admin/order_detail.gohtml
+++ b/backend/layout/tmpl/admin/order_detail.gohtml
@@ -78,6 +78,7 @@
           {{if .CanCancel}}
             <form method="post" action="/admin/orders/{{.Order.ID}}/cancel"
                   onsubmit="return confirm('Cancel this order as admin? Reserved stock will be released.');">
+              <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
               <button type="submit" class="linkbtn linkbtn--danger">cancel order</button>
             </form>
           {{end}}

--- a/backend/layout/tmpl/admin/order_detail.gohtml
+++ b/backend/layout/tmpl/admin/order_detail.gohtml
@@ -35,10 +35,18 @@
               <td colspan="3">subtotal</td>
               <td class="col-total">{{.Order.SubtotalDisplay}} {{.Order.TotalCurrency}}</td>
             </tr>
+            {{if gt .Order.TaxAmount 0}}
+              <tr>
+                <td colspan="3">tax</td>
+                <td class="col-total">{{.Order.TaxDisplay}} {{.Order.TotalCurrency}}</td>
+              </tr>
+            {{end}}
             {{if not .Order.ShippingMethod.IsZero}}
               <tr>
                 <td colspan="3">shipping &middot; {{.Order.ShippingMethod.Label}}</td>
-                <td class="col-total">{{.Order.ShippingCostDisplay}} {{.Order.TotalCurrency}}</td>
+                <td class="col-total">
+                  {{if eq .Order.ShippingCost 0}}free{{else}}{{.Order.ShippingCostDisplay}} {{.Order.TotalCurrency}}{{end}}
+                </td>
               </tr>
             {{end}}
             <tr>
@@ -66,6 +74,17 @@
           </section>
         {{end}}
 
+        {{if or .Order.Carrier .Order.TrackingCode}}
+          <section class="order__ship">
+            <h2 class="order__ship-heading">fulfillment</h2>
+            <p>
+              {{with .Order.Carrier}}carrier: {{.}}{{end}}
+              {{if and .Order.Carrier .Order.TrackingCode}} &middot; {{end}}
+              {{with .Order.TrackingCode}}tracking: <code>{{.}}</code>{{end}}
+            </p>
+          </section>
+        {{end}}
+
         {{if not .Order.PaymentMethod.IsZero}}
           <section class="order__ship">
             <h2 class="order__ship-heading">payment</h2>
@@ -75,11 +94,33 @@
 
         <div class="order__actions">
           <a href="/admin/orders" class="btn btn--ghost">back to orders</a>
+          {{if .CanShip}}
+            <form method="post" action="/admin/orders/{{.Order.ID}}/ship" class="order__action-form">
+              <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
+              <input type="text" name="carrier" placeholder="carrier (optional)" class="order__action-input">
+              <input type="text" name="tracking_code" placeholder="tracking code (optional)" class="order__action-input">
+              <button type="submit" class="btn">mark shipped</button>
+            </form>
+          {{end}}
+          {{if .CanDeliver}}
+            <form method="post" action="/admin/orders/{{.Order.ID}}/deliver">
+              <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
+              <button type="submit" class="btn">mark delivered</button>
+            </form>
+          {{end}}
           {{if .CanCancel}}
             <form method="post" action="/admin/orders/{{.Order.ID}}/cancel"
                   onsubmit="return confirm('Cancel this order as admin? Reserved stock will be released.');">
               <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
               <button type="submit" class="linkbtn linkbtn--danger">cancel order</button>
+            </form>
+          {{end}}
+          {{if .CanRefund}}
+            <form method="post" action="/admin/orders/{{.Order.ID}}/refund" class="order__action-form"
+                  onsubmit="return confirm('Refund this order? Reserved stock will be returned to the catalogue.');">
+              <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
+              <textarea name="reason" placeholder="refund reason (optional)" class="order__action-input" rows="2"></textarea>
+              <button type="submit" class="linkbtn linkbtn--danger">refund</button>
             </form>
           {{end}}
     </div>

--- a/backend/layout/tmpl/admin/product_edit.gohtml
+++ b/backend/layout/tmpl/admin/product_edit.gohtml
@@ -12,6 +12,7 @@
     <section class="admin-section">
       <h3 class="admin-section__title">core fields</h3>
       <form class="form" method="post" action="/admin/products/{{.Product.ID}}" data-tab="details" enctype="multipart/form-data">
+        <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
         <div class="field"><label for="p-name">name</label><input id="p-name" name="name" value="{{.Product.Name}}" required></div>
         <div class="field"><label for="p-description">description</label><textarea id="p-description" name="description" required>{{.Product.Description}}</textarea></div>
         <div class="field"><label for="p-price">price (major units, e.g. 9.00)</label><input id="p-price" name="price" value="{{.Product.Price.Display}}" required></div>
@@ -30,6 +31,7 @@
       <h3 class="admin-section__title">categories</h3>
       {{if .Categories}}
         <form class="form" method="post" action="/admin/products/{{.Product.ID}}/categories" data-tab="details">
+          <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
           <div class="admin-checks">
             {{range $c := .Categories}}
               <label class="admin-check"><input type="checkbox" name="category" value="{{$c.ID}}" {{if index $.Assigned $c.ID}}checked{{end}}> {{$c.Name}}</label>
@@ -54,6 +56,7 @@
               <tr>
                 <td colspan="2">
                   <form class="form form--inline" method="post" action="/admin/products/{{$.Product.ID}}/options/update" data-tab="options-variants">
+                    <input type="hidden" name="csrf_token" value="{{$.CSRFToken}}">
                     <input type="hidden" name="current_name" value="{{$ot.Name}}">
                     <input name="new_name" value="{{$ot.Name}}" placeholder="name" aria-label="name" required>
                     <input name="values" value="{{join ", " $ot.Values}}" placeholder="Red, Blue" aria-label="values" required>
@@ -63,6 +66,7 @@
                 <td class="admin-table__actions">
                   <form method="post" action="/admin/products/{{$.Product.ID}}/options/delete" data-tab="options-variants"
                         onsubmit="return confirm('Delete this option type? It will be removed from every variant.');">
+                    <input type="hidden" name="csrf_token" value="{{$.CSRFToken}}">
                     <input type="hidden" name="name" value="{{$ot.Name}}">
                     <button type="submit" class="linkbtn linkbtn--danger">delete</button>
                   </form>
@@ -77,6 +81,7 @@
 
       <h4 class="admin-section__subtitle">add an option type</h4>
       <form class="form" method="post" action="/admin/products/{{.Product.ID}}/options" data-tab="options-variants">
+        <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
         <div class="field"><label for="ot-name">name</label><input id="ot-name" name="name" required placeholder="Color"></div>
         <div class="field"><label for="ot-values">values (comma-separated)</label><input id="ot-values" name="values" required placeholder="Red, Blue"></div>
         <div class="field"><label for="ot-default">default value</label><input id="ot-default" name="default" required placeholder="Red"></div>
@@ -98,6 +103,7 @@
                 <td>{{with $v.Label $ots}}{{.}}{{else}}default{{end}}</td>
                 <td colspan="4">
                   <form class="form form--inline" method="post" action="/admin/products/{{$.Product.ID}}/variants/{{$v.ID}}" data-tab="options-variants" enctype="multipart/form-data">
+                    <input type="hidden" name="csrf_token" value="{{$.CSRFToken}}">
                     <input name="sku" value="{{$v.SKU}}" placeholder="sku" aria-label="sku">
                     <input name="price" value="{{$v.Price.Display}}" placeholder="9.00" aria-label="price">
                     <input type="file" name="image_file" accept="image/jpeg,image/png,image/webp,image/gif" aria-label="image upload">
@@ -110,6 +116,7 @@
                   {{if not $single}}
                     <form method="post" action="/admin/products/{{$.Product.ID}}/variants/{{$v.ID}}/delete" data-tab="options-variants"
                           onsubmit="return confirm('Delete this variant?');">
+                      <input type="hidden" name="csrf_token" value="{{$.CSRFToken}}">
                       <button type="submit" class="linkbtn linkbtn--danger">delete</button>
                     </form>
                   {{else}}
@@ -127,6 +134,7 @@
       {{if .Product.HasOptions}}
         <h4 class="admin-section__subtitle">add a variant</h4>
         <form class="form" method="post" action="/admin/products/{{.Product.ID}}/variants" data-tab="options-variants" enctype="multipart/form-data">
+          <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
           {{range $ot := .Product.OptionTypes}}
             <div class="field">
               <label for="opt-{{$ot.Name}}">{{$ot.Name}}</label>
@@ -155,6 +163,7 @@
       <h3 class="admin-section__title">attribute set</h3>
       <p class="form__aside muted">the chosen set controls which attributes appear below (and in what order). Choose &ldquo;none&rdquo; to fall back to all attribute types.</p>
       <form class="form" method="post" action="/admin/products/{{.Product.ID}}/attribute-set" data-tab="attributes">
+        <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
         <div class="field">
           <label for="p-attribute-set">attribute set</label>
           <select id="p-attribute-set" name="attribute_set">
@@ -170,6 +179,7 @@
       <h3 class="admin-section__title">attributes</h3>
       {{if .AttrTypes}}
         <form class="form" method="post" action="/admin/products/{{.Product.ID}}/attributes" data-tab="attributes">
+          <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
           {{range $t := .AttrTypes}}
             <div class="field">
               <label for="attr-{{$t.ID}}">{{$t.Name}}{{with $t.Unit}} ({{.}}){{end}}</label>

--- a/backend/layout/tmpl/admin/product_new.gohtml
+++ b/backend/layout/tmpl/admin/product_new.gohtml
@@ -4,6 +4,7 @@
 
   <section class="admin-section">
     <form class="form" method="post" action="/admin/products" enctype="multipart/form-data">
+      <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
       <div class="field"><label for="p-id">id (slug)</label><input id="p-id" name="id" required placeholder="lowercase-with-hyphens"></div>
       <div class="field"><label for="p-name">name</label><input id="p-name" name="name" required></div>
       <div class="field"><label for="p-description">description</label><textarea id="p-description" name="description" required></textarea></div>

--- a/backend/layout/tmpl/admin/product_new_variant.gohtml
+++ b/backend/layout/tmpl/admin/product_new_variant.gohtml
@@ -3,6 +3,7 @@
   <h2 class="account-card__title">create a variant product</h2>
 
   <form class="form" method="post" action="/admin/products/new-variant" enctype="multipart/form-data">
+    <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
     <section class="admin-section">
       <h3 class="admin-section__title">product</h3>
       <div class="field"><label for="p-id">id (slug)</label><input id="p-id" name="id" required placeholder="lowercase-with-hyphens"></div>

--- a/backend/layout/tmpl/admin/products.gohtml
+++ b/backend/layout/tmpl/admin/products.gohtml
@@ -30,6 +30,7 @@
               <a href="/admin/products/{{$p.ID}}/edit">edit</a>
               <form method="post" action="/admin/products/{{$p.ID}}/delete"
                     onsubmit="return confirm('Delete this product? Its variants, category and attribute links will be removed.');">
+                <input type="hidden" name="csrf_token" value="{{$.CSRFToken}}">
                 <button type="submit" class="linkbtn linkbtn--danger">delete</button>
               </form>
             </td>

--- a/backend/layout/tmpl/admin/stock_movements.gohtml
+++ b/backend/layout/tmpl/admin/stock_movements.gohtml
@@ -1,0 +1,45 @@
+{{define "main"}}
+  <h2 class="account-card__title">inventory · stock movements</h2>
+
+  <form method="get" action="/admin/inventory" class="admin-filter">
+    <label class="admin-filter__label" for="variant">variant id</label>
+    <input class="admin-filter__input" id="variant" name="variant" value="{{.VariantID}}" placeholder="filter by variant id">
+    <button type="submit" class="btn btn--ghost">filter</button>
+    {{if .VariantID}}
+      <a href="/admin/inventory" class="linkbtn">clear</a>
+    {{end}}
+  </form>
+
+  {{if .Movements}}
+    <table class="admin-table">
+      <thead>
+        <tr>
+          <th>when</th>
+          <th>variant</th>
+          <th class="col-qty">delta</th>
+          <th>reason</th>
+          <th>order</th>
+        </tr>
+      </thead>
+      <tbody>
+        {{range $m := .Movements}}
+          <tr>
+            <td>{{$m.At.Format "Jan 2, 2006 15:04 MST"}}</td>
+            <td><code>{{$m.VariantID}}</code></td>
+            <td class="col-qty">{{$m.Delta}}</td>
+            <td>{{$m.Reason}}</td>
+            <td>
+              {{if $m.RefOrderID}}
+                <a href="/admin/orders/{{$m.RefOrderID}}"><code>{{$m.RefOrderID}}</code></a>
+              {{else}}
+                <span class="muted">—</span>
+              {{end}}
+            </td>
+          </tr>
+        {{end}}
+      </tbody>
+    </table>
+  {{else}}
+    <p class="muted">no stock movements recorded yet.</p>
+  {{end}}
+{{end}}

--- a/backend/layout/tmpl/auth/change_password.gohtml
+++ b/backend/layout/tmpl/auth/change_password.gohtml
@@ -11,6 +11,7 @@
   </p>
 
   <form class="form" method="post" action="/auth/change-password">
+    <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
     <div class="field">
       <label for="cp-current">current password</label>
       <input id="cp-current" type="password" name="current_password" autocomplete="current-password" required>

--- a/backend/layout/tmpl/auth/change_password.gohtml
+++ b/backend/layout/tmpl/auth/change_password.gohtml
@@ -1,0 +1,31 @@
+{{define "title"}}Change password · {{.SiteName}}{{end}}
+{{define "description"}}Choose a new password for your {{.SiteName}} account.{{end}}
+
+{{define "main"}}
+  <h1 class="page-title">change your password</h1>
+
+  <p class="form__aside">
+    Your account requires a password change before you can continue. Please pick a
+    new password — at least 8 characters, with upper- and lower-case letters, a
+    number, and a special character.
+  </p>
+
+  <form class="form" method="post" action="/auth/change-password">
+    <div class="field">
+      <label for="cp-current">current password</label>
+      <input id="cp-current" type="password" name="current_password" autocomplete="current-password" required>
+    </div>
+
+    <div class="field">
+      <label for="cp-new">new password</label>
+      <input id="cp-new" type="password" name="new_password" autocomplete="new-password" required>
+    </div>
+
+    <div class="field">
+      <label for="cp-confirm">confirm new password</label>
+      <input id="cp-confirm" type="password" name="confirm_password" autocomplete="new-password" required>
+    </div>
+
+    <button type="submit" class="btn btn--block">update password</button>
+  </form>
+{{end}}

--- a/backend/layout/tmpl/auth/forgot.gohtml
+++ b/backend/layout/tmpl/auth/forgot.gohtml
@@ -1,0 +1,20 @@
+{{define "title"}}Forgot password · {{.SiteName}}{{end}}
+{{define "description"}}Request a password reset link for your {{.SiteName}} account.{{end}}
+
+{{define "main"}}
+  <h1 class="page-title">forgot password</h1>
+
+  <p class="form__aside">Enter your account email and we'll send you a link to choose a new password.</p>
+
+  <form class="form" method="post" action="/auth/forgot">
+    <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
+    <div class="field">
+      <label for="forgot-email">email</label>
+      <input id="forgot-email" type="email" name="email" autocomplete="email" required>
+    </div>
+
+    <button type="submit" class="btn btn--block">send reset link</button>
+
+    <p class="form__aside">remembered it? <a href="/auth/login">sign in</a></p>
+  </form>
+{{end}}

--- a/backend/layout/tmpl/auth/login.gohtml
+++ b/backend/layout/tmpl/auth/login.gohtml
@@ -5,6 +5,7 @@
   <h1 class="page-title">sign in</h1>
 
   <form class="form" method="post" action="/auth/login">
+    <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
     <div class="field">
       <label for="login-email">email</label>
       <input id="login-email" type="email" name="email" autocomplete="email" required>

--- a/backend/layout/tmpl/auth/login.gohtml
+++ b/backend/layout/tmpl/auth/login.gohtml
@@ -19,5 +19,6 @@
     <button type="submit" class="btn btn--block">sign in</button>
 
     <p class="form__aside">not a member? <a href="/auth/register">register</a></p>
+    <p class="form__aside"><a href="/auth/forgot">forgot password?</a></p>
   </form>
 {{end}}

--- a/backend/layout/tmpl/auth/register.gohtml
+++ b/backend/layout/tmpl/auth/register.gohtml
@@ -5,6 +5,7 @@
   <h1 class="page-title">register</h1>
 
   <form class="form" method="post" action="/auth/register">
+    <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
     <div class="field">
       <label for="register-email">email</label>
       <input id="register-email" type="email" name="email" autocomplete="email" required>

--- a/backend/layout/tmpl/auth/reset.gohtml
+++ b/backend/layout/tmpl/auth/reset.gohtml
@@ -1,0 +1,25 @@
+{{define "title"}}Choose a new password · {{.SiteName}}{{end}}
+{{define "description"}}Set a new password for your {{.SiteName}} account.{{end}}
+
+{{define "main"}}
+  <h1 class="page-title">choose a new password</h1>
+
+  <form class="form" method="post" action="/auth/reset">
+    <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
+    <input type="hidden" name="token" value="{{.Token}}">
+
+    <div class="field">
+      <label for="reset-password">new password</label>
+      <input id="reset-password" type="password" name="new_password" autocomplete="new-password" required>
+    </div>
+
+    <div class="field">
+      <label for="reset-password-confirm">confirm new password</label>
+      <input id="reset-password-confirm" type="password" name="confirm_password" autocomplete="new-password" required>
+    </div>
+
+    <button type="submit" class="btn btn--block">update password</button>
+
+    <p class="form__aside">need a fresh link? <a href="/auth/forgot">request another</a></p>
+  </form>
+{{end}}

--- a/backend/layout/tmpl/checkout/show.gohtml
+++ b/backend/layout/tmpl/checkout/show.gohtml
@@ -38,6 +38,7 @@
       <p class="muted checkout__note">demo only — no real card is charged. enter anything in the payment fields.</p>
 
       <form class="form" method="post" action="/checkout">
+        <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
         <fieldset class="fieldset">
           <legend class="fieldset__legend">shipping method</legend>
           {{range .ShippingMethods}}

--- a/backend/layout/tmpl/emails/order_confirmation.html.tmpl
+++ b/backend/layout/tmpl/emails/order_confirmation.html.tmpl
@@ -1,0 +1,71 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Order {{.Order.ID}} confirmed</title>
+</head>
+<body style="font-family: -apple-system, Segoe UI, Roboto, sans-serif; color: #1d1d1f; line-height: 1.5; max-width: 560px; margin: 24px auto; padding: 0 16px;">
+  <h1 style="font-size: 22px; font-weight: 600;">Thanks for your order.</h1>
+  <p>Order <strong>{{.Order.ID}}</strong> &middot; placed {{.Order.PlacedAt.Format "Jan 2, 2006 15:04 MST"}}.</p>
+
+  <table cellspacing="0" cellpadding="6" style="width: 100%; border-collapse: collapse; margin-top: 16px;">
+    <thead>
+      <tr style="text-align: left; border-bottom: 1px solid #d2d2d7;">
+        <th>Item</th>
+        <th style="text-align: right;">Qty</th>
+        <th style="text-align: right;">Unit</th>
+        <th style="text-align: right;">Subtotal</th>
+      </tr>
+    </thead>
+    <tbody>
+      {{range $line := .Order.Items}}
+        <tr style="border-bottom: 1px solid #f0f0f0;">
+          <td>{{$line.ProductName}}</td>
+          <td style="text-align: right;">{{$line.Quantity}}</td>
+          <td style="text-align: right;">{{$line.PriceDisplay}} {{$line.PriceCurrency}}</td>
+          <td style="text-align: right;">{{$line.LineTotalDisplay}} {{$line.PriceCurrency}}</td>
+        </tr>
+      {{end}}
+    </tbody>
+    <tfoot>
+      <tr>
+        <td colspan="3" style="text-align: right;">Subtotal</td>
+        <td style="text-align: right;">{{.Order.SubtotalDisplay}} {{.Order.TotalCurrency}}</td>
+      </tr>
+      {{if not .Order.ShippingMethod.IsZero}}
+        <tr>
+          <td colspan="3" style="text-align: right;">Shipping &middot; {{.Order.ShippingMethod.Label}}</td>
+          <td style="text-align: right;">{{.Order.ShippingCostDisplay}} {{.Order.TotalCurrency}}</td>
+        </tr>
+      {{end}}
+      <tr style="font-weight: 600; border-top: 1px solid #d2d2d7;">
+        <td colspan="3" style="text-align: right;">Total</td>
+        <td style="text-align: right;">{{.Order.TotalDisplay}} {{.Order.TotalCurrency}}</td>
+      </tr>
+    </tfoot>
+  </table>
+
+  {{if not .Order.PaymentMethod.IsZero}}
+    <p style="margin-top: 16px;"><strong>Payment:</strong> {{.Order.PaymentMethod.Label}}</p>
+  {{end}}
+
+  {{if eq .Order.ShippingMethod.Code "pickup"}}
+    <p><strong>Collection:</strong> Personal pickup — collect in store.</p>
+  {{else if not .Order.ShipTo.IsZero}}
+    <p style="margin-top: 8px;"><strong>Shipping to</strong></p>
+    <p style="margin: 0;">
+      {{.Order.ShipTo.Name}}<br>
+      {{.Order.ShipTo.Street1}}<br>
+      {{with .Order.ShipTo.Street2}}{{.}}<br>{{end}}
+      {{.Order.ShipTo.City}}, {{.Order.ShipTo.Zip}}<br>
+      {{.Order.ShipTo.Country}}
+    </p>
+  {{end}}
+
+  <p style="margin-top: 24px;">
+    <a href="{{.OrderURL}}" style="background: #1d1d1f; color: #fff; padding: 10px 16px; border-radius: 6px; text-decoration: none;">View your order</a>
+  </p>
+
+  <p style="color: #6e6e73; font-size: 12px; margin-top: 32px;">This email confirms an order on {{.SiteName}}. If you did not place this order, please reply to let us know.</p>
+</body>
+</html>

--- a/backend/layout/tmpl/emails/order_confirmation.txt.tmpl
+++ b/backend/layout/tmpl/emails/order_confirmation.txt.tmpl
@@ -1,0 +1,23 @@
+Thanks for your order.
+
+Order {{.Order.ID}} - placed {{.Order.PlacedAt.Format "Jan 2, 2006 15:04 MST"}}
+
+Items:
+{{range $line := .Order.Items}}- {{$line.ProductName}} x {{$line.Quantity}} @ {{$line.PriceDisplay}} {{$line.PriceCurrency}} = {{$line.LineTotalDisplay}} {{$line.PriceCurrency}}
+{{end}}
+Subtotal: {{.Order.SubtotalDisplay}} {{.Order.TotalCurrency}}
+{{if not .Order.ShippingMethod.IsZero}}Shipping ({{.Order.ShippingMethod.Label}}): {{.Order.ShippingCostDisplay}} {{.Order.TotalCurrency}}
+{{end}}Total: {{.Order.TotalDisplay}} {{.Order.TotalCurrency}}
+
+{{if not .Order.PaymentMethod.IsZero}}Payment: {{.Order.PaymentMethod.Label}}
+{{end}}{{if eq .Order.ShippingMethod.Code "pickup"}}Collection: Personal pickup - collect in store.
+{{else if not .Order.ShipTo.IsZero}}Shipping to:
+  {{.Order.ShipTo.Name}}
+  {{.Order.ShipTo.Street1}}{{with .Order.ShipTo.Street2}}
+  {{.}}{{end}}
+  {{.Order.ShipTo.City}}, {{.Order.ShipTo.Zip}}
+  {{.Order.ShipTo.Country}}
+{{end}}
+View your order: {{.OrderURL}}
+
+If you did not place this order on {{.SiteName}}, please reply to let us know.

--- a/backend/layout/tmpl/emails/password_reset.html.tmpl
+++ b/backend/layout/tmpl/emails/password_reset.html.tmpl
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Reset your {{.SiteName}} password</title>
+</head>
+<body style="font-family: -apple-system, Segoe UI, Roboto, sans-serif; color: #1d1d1f; line-height: 1.5; max-width: 560px; margin: 24px auto; padding: 0 16px;">
+  <h1 style="font-size: 22px; font-weight: 600;">Reset your password</h1>
+  <p>We received a request to reset the password for your {{.SiteName}} account.</p>
+  <p>The link below is valid for {{.TTLMinutes}} minutes. If you didn't ask for a reset, you can safely ignore this email — your current password stays in effect.</p>
+  <p style="margin-top: 24px;">
+    <a href="{{.ResetURL}}" style="background: #1d1d1f; color: #fff; padding: 10px 16px; border-radius: 6px; text-decoration: none;">Choose a new password</a>
+  </p>
+  <p style="margin-top: 24px; color: #6e6e73; font-size: 13px;">If the button doesn't work, paste this link into your browser:<br>
+    <a href="{{.ResetURL}}">{{.ResetURL}}</a>
+  </p>
+</body>
+</html>

--- a/backend/layout/tmpl/emails/password_reset.txt.tmpl
+++ b/backend/layout/tmpl/emails/password_reset.txt.tmpl
@@ -1,0 +1,9 @@
+Reset your {{.SiteName}} password
+
+We received a request to reset the password for your {{.SiteName}} account.
+
+The link below is valid for {{.TTLMinutes}} minutes. If you didn't ask for a reset,
+you can safely ignore this email - your current password stays in effect.
+
+Open this link to choose a new password:
+{{.ResetURL}}

--- a/backend/layout/tmpl/layout.gohtml
+++ b/backend/layout/tmpl/layout.gohtml
@@ -26,6 +26,19 @@
 
     <link rel="stylesheet" href="/static/main.css">
     <script src="https://unpkg.com/htmx.org@1.9.5"></script>
+    <script>
+      // Stamp X-CSRF-Token on every HTMX-issued request. HTMX-driven
+      // POSTs (most notably the add-to-cart button on the variant box)
+      // do not include the hidden csrf_token form field that server-
+      // rendered <form method="post"> blocks carry, so the header is
+      // the only channel they have to satisfy csrfMiddleware. Wiring
+      // this once in the base layout covers every HTMX call site.
+      // The listener is attached to `document` (which exists in <head>)
+      // because htmx events bubble — `document.body` does not exist yet.
+      document.addEventListener('htmx:configRequest', function (event) {
+        event.detail.headers['X-CSRF-Token'] = {{ .CSRFToken }};
+      });
+    </script>
   </head>
   <body>
     <a class="skip-link" href="#main">Skip to main content</a>

--- a/backend/layout/tmpl/order/show.gohtml
+++ b/backend/layout/tmpl/order/show.gohtml
@@ -8,6 +8,12 @@
     <header class="order__header">
       {{if eq .Order.Status "cancelled"}}
         <h1 class="order__title">order cancelled.</h1>
+      {{else if eq .Order.Status "refunded"}}
+        <h1 class="order__title">order refunded.</h1>
+      {{else if eq .Order.Status "delivered"}}
+        <h1 class="order__title">delivered.</h1>
+      {{else if eq .Order.Status "shipped"}}
+        <h1 class="order__title">on its way.</h1>
       {{else}}
         <h1 class="order__title">thank you.</h1>
       {{end}}
@@ -42,10 +48,18 @@
           <td colspan="3">subtotal</td>
           <td class="col-total">{{.Order.SubtotalDisplay}} {{.Order.TotalCurrency}}</td>
         </tr>
+        {{if gt .Order.TaxAmount 0}}
+          <tr>
+            <td colspan="3">tax</td>
+            <td class="col-total">{{.Order.TaxDisplay}} {{.Order.TotalCurrency}}</td>
+          </tr>
+        {{end}}
         {{if not .Order.ShippingMethod.IsZero}}
           <tr>
             <td colspan="3">shipping &middot; {{.Order.ShippingMethod.Label}}</td>
-            <td class="col-total">{{.Order.ShippingCostDisplay}} {{.Order.TotalCurrency}}</td>
+            <td class="col-total">
+              {{if eq .Order.ShippingCost 0}}free{{else}}{{.Order.ShippingCostDisplay}} {{.Order.TotalCurrency}}{{end}}
+            </td>
           </tr>
         {{end}}
         <tr>
@@ -70,6 +84,17 @@
           {{.Order.ShipTo.City}}, {{.Order.ShipTo.Zip}}<br>
           {{.Order.ShipTo.Country}}
         </address>
+      </section>
+    {{end}}
+
+    {{if or (eq .Order.Status "shipped") (eq .Order.Status "delivered")}}
+      <section class="order__ship">
+        <h2 class="order__ship-heading">fulfillment</h2>
+        <p>
+          {{if eq .Order.Status "shipped"}}shipped{{else}}delivered{{end}}
+          {{with .Order.Carrier}} &middot; carrier: {{.}}{{end}}
+          {{with .Order.TrackingCode}} &middot; tracking: <code>{{.}}</code>{{end}}
+        </p>
       </section>
     {{end}}
 

--- a/backend/layout/tmpl/order/show.gohtml
+++ b/backend/layout/tmpl/order/show.gohtml
@@ -87,6 +87,7 @@
       {{if .CanCancel}}
         <form method="post" action="/order/{{.Order.ID}}/cancel"
               onsubmit="return confirm('Cancel this order? Reserved stock will be released.');">
+          <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
           <button type="submit" class="linkbtn linkbtn--danger">cancel order</button>
         </form>
       {{end}}

--- a/backend/layout/tmpl/partials/admin-nav.gohtml
+++ b/backend/layout/tmpl/partials/admin-nav.gohtml
@@ -6,6 +6,7 @@
   <a href="/admin/attributes" class="admin-nav__link {{if eq .Active "attributes"}}is-active{{end}}">attributes</a>
   <a href="/admin/attribute-sets" class="admin-nav__link {{if eq .Active "attribute-sets"}}is-active{{end}}">attribute sets</a>
   <a href="/admin/orders" class="admin-nav__link {{if eq .Active "orders"}}is-active{{end}}">orders</a>
+  <a href="/admin/inventory" class="admin-nav__link {{if eq .Active "inventory"}}is-active{{end}}">inventory</a>
   <span class="admin-nav__rule"></span>
   <a href="/" class="admin-nav__link admin-nav__link--muted">back to store</a>
 </nav>

--- a/backend/productcatalog/adapter/inmemory.go
+++ b/backend/productcatalog/adapter/inmemory.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/bkielbasa/go-ecommerce/backend/productcatalog/app"
 	"github.com/bkielbasa/go-ecommerce/backend/productcatalog/domain"
@@ -24,6 +25,12 @@ type inMemory struct {
 	// attribute sets: the set row plus its ordered member attribute type ids.
 	attrSets     map[string]attrSetRow
 	attrSetItems map[string][]string
+	// movements is the in-memory inventory audit log, kept oldest-first; the
+	// adapter slices/sorts it newest-first when returning.
+	movements []domain.StockMovement
+	// nextMovementID is the auto-increment cursor mirroring the postgres
+	// bigserial column.
+	nextMovementID int64
 }
 
 // attrSetRow holds an attribute set's own fields (members are tracked
@@ -462,6 +469,31 @@ func (im *inMemory) SetAttributeSetItems(ctx context.Context, setID string, attr
 	copy(items, attributeTypeIDs)
 	im.attrSetItems[setID] = items
 	return nil
+}
+
+// InsertStockMovement appends an audit-log entry. IDs are assigned in
+// insertion order, mirroring the postgres bigserial column.
+func (im *inMemory) InsertStockMovement(ctx context.Context, variantID string, delta int, reason, refOrderID string) error {
+	im.nextMovementID++
+	im.movements = append(im.movements, domain.NewStockMovement(im.nextMovementID, variantID, delta, reason, refOrderID, time.Now().UTC()))
+	return nil
+}
+
+// ListStockMovements returns up to limit movements newest-first; when
+// variantID is empty the full log is returned.
+func (im *inMemory) ListStockMovements(ctx context.Context, variantID string, limit int) ([]domain.StockMovement, error) {
+	filtered := make([]domain.StockMovement, 0, len(im.movements))
+	for i := len(im.movements) - 1; i >= 0; i-- {
+		m := im.movements[i]
+		if variantID != "" && m.VariantID != variantID {
+			continue
+		}
+		filtered = append(filtered, m)
+		if len(filtered) >= limit {
+			break
+		}
+	}
+	return filtered, nil
 }
 
 func (im *inMemory) inCategory(productID, slug string) bool {

--- a/backend/productcatalog/adapter/postgres.go
+++ b/backend/productcatalog/adapter/postgres.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/bkielbasa/go-ecommerce/backend/productcatalog/app"
 	"github.com/bkielbasa/go-ecommerce/backend/productcatalog/domain"
@@ -1115,6 +1116,64 @@ func (db postgres) Facets(ctx context.Context, categorySlug string) ([]app.Facet
 		facets = append(facets, app.Facet{Type: t, Values: values})
 	}
 	return facets, nil
+}
+
+// InsertStockMovement appends a row to the inventory audit log. delta is the
+// signed change in stock units; reason describes the cause; refOrderID is the
+// triggering order id when the change came from checkout (empty for direct
+// admin edits).
+func (db postgres) InsertStockMovement(ctx context.Context, variantID string, delta int, reason, refOrderID string) error {
+	if _, err := db.db.ExecContext(ctx, `
+		INSERT INTO productcatalog_stock_movement (variant_id, delta, reason, ref_order_id)
+		VALUES ($1, $2, $3, $4)
+	`, variantID, delta, reason, refOrderID); err != nil {
+		return fmt.Errorf("insert stock movement: %w", err)
+	}
+	return nil
+}
+
+// ListStockMovements returns up to limit movements newest-first. When
+// variantID is empty the full log is returned (admin overview); otherwise
+// the log is scoped to a single variant. limit must be positive; the caller
+// (app layer) clamps zero/negative to a default.
+func (db postgres) ListStockMovements(ctx context.Context, variantID string, limit int) ([]domain.StockMovement, error) {
+	var (
+		rows *sql.Rows
+		err  error
+	)
+	if variantID == "" {
+		rows, err = db.db.QueryContext(ctx, `
+			SELECT id, variant_id, delta, reason, ref_order_id, at
+			FROM productcatalog_stock_movement
+			ORDER BY id DESC
+			LIMIT $1
+		`, limit)
+	} else {
+		rows, err = db.db.QueryContext(ctx, `
+			SELECT id, variant_id, delta, reason, ref_order_id, at
+			FROM productcatalog_stock_movement
+			WHERE variant_id = $1
+			ORDER BY id DESC
+			LIMIT $2
+		`, variantID, limit)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("query stock movements: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []domain.StockMovement
+	for rows.Next() {
+		var id int64
+		var vID, reason, refOrderID string
+		var delta int
+		var at time.Time
+		if err := rows.Scan(&id, &vID, &delta, &reason, &refOrderID, &at); err != nil {
+			return nil, fmt.Errorf("scan stock movement: %w", err)
+		}
+		out = append(out, domain.NewStockMovement(id, vID, delta, reason, refOrderID, at))
+	}
+	return out, rows.Err()
 }
 
 // sortedKeys returns the map keys sorted, so generated SQL placeholders are

--- a/backend/productcatalog/app/product.go
+++ b/backend/productcatalog/app/product.go
@@ -53,6 +53,10 @@ type ProductStorage interface {
 	UpdateAttributeSet(ctx context.Context, s domain.AttributeSet) error
 	DeleteAttributeSet(ctx context.Context, id string) error
 	SetAttributeSetItems(ctx context.Context, setID string, attributeTypeIDs []string) error
+
+	// Inventory audit trail.
+	InsertStockMovement(ctx context.Context, variantID string, delta int, reason, refOrderID string) error
+	ListStockMovements(ctx context.Context, variantID string, limit int) ([]domain.StockMovement, error)
 }
 
 func NewProductService(s ProductStorage) ProductService {
@@ -350,12 +354,45 @@ func (ps ProductService) DeleteProduct(ctx context.Context, id string) error {
 	return ps.storage.DeleteProduct(ctx, id)
 }
 
-// SetVariantStock sets a single variant's stock level (rejecting negatives).
+// SetVariantStock sets a single variant's stock level (rejecting negatives)
+// and records the change in the inventory audit log. The delta is computed
+// against the variant's current stock so the audit row reflects the actual
+// movement, not just the new level.
 func (ps ProductService) SetVariantStock(ctx context.Context, variantID string, stock int) error {
 	if stock < 0 {
 		return fmt.Errorf("stock cannot be negative: %d", stock)
 	}
-	return ps.storage.SetVariantStock(ctx, variantID, stock)
+	_, current, err := ps.storage.FindVariant(ctx, variantID)
+	if err != nil {
+		return err
+	}
+	if err := ps.storage.SetVariantStock(ctx, variantID, stock); err != nil {
+		return err
+	}
+	delta := stock - current.Stock()
+	if delta == 0 {
+		return nil
+	}
+	// Best-effort audit row: a logging failure should not undo the stock
+	// update the operator just confirmed.
+	_ = ps.storage.InsertStockMovement(ctx, variantID, delta, "admin-adjust", "")
+	return nil
+}
+
+// Record writes a single audit row to the stock movement log. Intended as
+// the StockMovements seam for the checkout context (reserve / release /
+// refund flows).
+func (ps ProductService) Record(ctx context.Context, variantID string, delta int, reason, refOrderID string) error {
+	return ps.storage.InsertStockMovement(ctx, variantID, delta, reason, refOrderID)
+}
+
+// ListStockMovements returns the most recent audit rows, optionally scoped
+// to one variant. A non-positive limit falls back to 200 rows.
+func (ps ProductService) ListStockMovements(ctx context.Context, variantID string, limit int) ([]domain.StockMovement, error) {
+	if limit <= 0 {
+		limit = 200
+	}
+	return ps.storage.ListStockMovements(ctx, variantID, limit)
 }
 
 // SetProductCategories replaces the product's category links with the given set.

--- a/backend/productcatalog/app/product_test.go
+++ b/backend/productcatalog/app/product_test.go
@@ -48,6 +48,8 @@ type productStorage interface {
 	UpdateAttributeSet(ctx context.Context, s domain.AttributeSet) error
 	DeleteAttributeSet(ctx context.Context, id string) error
 	SetAttributeSetItems(ctx context.Context, setID string, attributeTypeIDs []string) error
+	InsertStockMovement(ctx context.Context, variantID string, delta int, reason, refOrderID string) error
+	ListStockMovements(ctx context.Context, variantID string, limit int) ([]domain.StockMovement, error)
 }
 
 var storage productStorage

--- a/backend/productcatalog/domain/stock_movement.go
+++ b/backend/productcatalog/domain/stock_movement.go
@@ -1,0 +1,29 @@
+package domain
+
+import "time"
+
+// StockMovement is a single audit-log entry for a variant's stock level. A
+// positive delta increases stock (release, refund, admin top-up); a negative
+// delta decreases stock (reservation, manual adjustment down). RefOrderID is
+// non-empty when the movement was driven by a checkout flow.
+type StockMovement struct {
+	ID         int64
+	VariantID  string
+	Delta      int
+	Reason     string
+	RefOrderID string
+	At         time.Time
+}
+
+// NewStockMovement is the convenience constructor used by storage adapters
+// when reading rows out of the audit log.
+func NewStockMovement(id int64, variantID string, delta int, reason, refOrderID string, at time.Time) StockMovement {
+	return StockMovement{
+		ID:         id,
+		VariantID:  variantID,
+		Delta:      delta,
+		Reason:     reason,
+		RefOrderID: refOrderID,
+		At:         at,
+	}
+}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -22,6 +22,11 @@ services:
       SMTP_HOST: mailhog:1025
       MAIL_FROM: no-reply@gocommerce.local
       BASE_URL: http://localhost:8080
+      # Stock reservation TTL: orders still pending after this duration are
+      # marked failed by the background sweeper and their reserved stock is
+      # released. Defaults: 30m / 5m. Override here for dev/testing.
+      RESERVATION_TTL: ${RESERVATION_TTL:-30m}
+      RESERVATION_SWEEP_INTERVAL: ${RESERVATION_SWEEP_INTERVAL:-5m}
     volumes:
       # User-uploaded admin images are persisted on the host. The Dockerfile
       # creates /uploads owned by the app user (uid 10001).

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -27,6 +27,10 @@ services:
       # released. Defaults: 30m / 5m. Override here for dev/testing.
       RESERVATION_TTL: ${RESERVATION_TTL:-30m}
       RESERVATION_SWEEP_INTERVAL: ${RESERVATION_SWEEP_INTERVAL:-5m}
+      # Tax rate (percent, e.g. 8.875 for 8.875%) and the free-shipping
+      # threshold in MINOR units (cents). Both default to zero (disabled).
+      TAX_RATE_PERCENT: ${TAX_RATE_PERCENT:-0}
+      FREE_SHIPPING_THRESHOLD: ${FREE_SHIPPING_THRESHOLD:-0}
     volumes:
       # User-uploaded admin images are persisted on the host. The Dockerfile
       # creates /uploads owned by the app user (uid 10001).

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,6 +6,7 @@ services:
     restart: unless-stopped
     depends_on:
       - migrate
+      - mailhog
     ports:
       - 8080:8080
     networks:
@@ -15,10 +16,28 @@ services:
       POSTGRES_PASSWORD: postgres
       POSTGRES_HOST: postgres
       UPLOADS_DIR: /uploads
+      # MailHog is the dev SMTP catch-all (see the mailhog service below).
+      # The web UI at http://localhost:8025 shows every email the app
+      # sends — far easier than tailing logs for the LogMailer fallback.
+      SMTP_HOST: mailhog:1025
+      MAIL_FROM: no-reply@gocommerce.local
+      BASE_URL: http://localhost:8080
     volumes:
       # User-uploaded admin images are persisted on the host. The Dockerfile
       # creates /uploads owned by the app user (uid 10001).
       - ./data/uploads:/uploads
+  mailhog:
+    # MailHog is a single-binary SMTP sink with a built-in web inbox. It
+    # listens for SMTP on :1025 and exposes the captured messages over a
+    # browser UI on :8025 — exactly the right shape for local dev: the app
+    # sends real SMTP, MailHog catches it, no email ever leaves the host.
+    image: mailhog/mailhog
+    restart: unless-stopped
+    ports:
+      - 1025:1025
+      - 8025:8025
+    networks:
+      - ecommerce
   postgres:
     image: postgres
     restart: always

--- a/migrations/000019_auth_customer_must_change_password.down.sql
+++ b/migrations/000019_auth_customer_must_change_password.down.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+ALTER TABLE auth_customer DROP COLUMN IF EXISTS must_change_password;
+
+COMMIT;

--- a/migrations/000019_auth_customer_must_change_password.up.sql
+++ b/migrations/000019_auth_customer_must_change_password.up.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+ALTER TABLE auth_customer ADD COLUMN must_change_password boolean NOT NULL DEFAULT false;
+
+COMMIT;

--- a/migrations/000020_auth_password_reset.down.sql
+++ b/migrations/000020_auth_password_reset.down.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+DROP INDEX IF EXISTS auth_password_reset_customer_idx;
+DROP TABLE IF EXISTS auth_password_reset;
+
+COMMIT;

--- a/migrations/000020_auth_password_reset.up.sql
+++ b/migrations/000020_auth_password_reset.up.sql
@@ -1,0 +1,12 @@
+BEGIN;
+
+CREATE TABLE auth_password_reset (
+    token_hash text PRIMARY KEY,    -- sha256(token); we don't store the raw token
+    customer_id text NOT NULL,      -- the customer's email
+    expires_at timestamptz NOT NULL,
+    consumed_at timestamptz
+);
+
+CREATE INDEX auth_password_reset_customer_idx ON auth_password_reset(customer_id);
+
+COMMIT;

--- a/migrations/000021_checkout_order_tax_shipping.down.sql
+++ b/migrations/000021_checkout_order_tax_shipping.down.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+ALTER TABLE public.checkout_order
+    DROP COLUMN IF EXISTS tax_amount;
+
+COMMIT;

--- a/migrations/000021_checkout_order_tax_shipping.up.sql
+++ b/migrations/000021_checkout_order_tax_shipping.up.sql
@@ -1,0 +1,9 @@
+BEGIN;
+
+-- Tax amount captured at place time, in minor units. Existing rows default
+-- to 0 (no tax) so historical orders' totals remain unchanged. The
+-- ship_cost column already exists (000007_checkout_order_shipping_method).
+ALTER TABLE public.checkout_order
+    ADD COLUMN tax_amount bigint NOT NULL DEFAULT 0;
+
+COMMIT;

--- a/migrations/000022_checkout_order_fulfillment.down.sql
+++ b/migrations/000022_checkout_order_fulfillment.down.sql
@@ -1,0 +1,7 @@
+BEGIN;
+
+ALTER TABLE public.checkout_order
+    DROP COLUMN IF EXISTS carrier,
+    DROP COLUMN IF EXISTS tracking_code;
+
+COMMIT;

--- a/migrations/000022_checkout_order_fulfillment.up.sql
+++ b/migrations/000022_checkout_order_fulfillment.up.sql
@@ -1,0 +1,9 @@
+BEGIN;
+
+-- Fulfillment metadata stored alongside the status. Carrier/tracking are
+-- optional (empty string when not supplied). Existing rows default to ''.
+ALTER TABLE public.checkout_order
+    ADD COLUMN carrier text NOT NULL DEFAULT '',
+    ADD COLUMN tracking_code text NOT NULL DEFAULT '';
+
+COMMIT;

--- a/migrations/000023_productcatalog_stock_movement.down.sql
+++ b/migrations/000023_productcatalog_stock_movement.down.sql
@@ -1,0 +1,7 @@
+BEGIN;
+
+DROP INDEX IF EXISTS productcatalog_stock_movement_order_idx;
+DROP INDEX IF EXISTS productcatalog_stock_movement_variant_idx;
+DROP TABLE IF EXISTS public.productcatalog_stock_movement;
+
+COMMIT;

--- a/migrations/000023_productcatalog_stock_movement.up.sql
+++ b/migrations/000023_productcatalog_stock_movement.up.sql
@@ -1,0 +1,17 @@
+BEGIN;
+
+CREATE TABLE public.productcatalog_stock_movement (
+    id bigserial PRIMARY KEY,
+    variant_id text NOT NULL,
+    delta int NOT NULL,
+    reason text NOT NULL,
+    ref_order_id text NOT NULL DEFAULT '',
+    at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX productcatalog_stock_movement_variant_idx
+    ON public.productcatalog_stock_movement(variant_id);
+CREATE INDEX productcatalog_stock_movement_order_idx
+    ON public.productcatalog_stock_movement(ref_order_id) WHERE ref_order_id <> '';
+
+COMMIT;


### PR DESCRIPTION
Five-phase production hardening pass.

- **P1 security primitives**: SESSION_SECRET + COOKIE_SECURE from env; admin must-change-password on first login (migration 000019).
- **P2 defenses**: CSRF middleware (session-bound token, header or form fallback); in-memory token-bucket rate limiter on login (5/min), register (3/hour), cart-add (30/min).
- **P3 email**: Mailer interface (SMTP + LogMailer fallback), MailHog in dev; order-confirmation email on OrderPaid; password-reset flow with hashed-token table (migration 000020).
- **P4 stock TTL sweeper**: background sweeper marks abandoned pending orders failed and releases reserved stock.
- **P5 commerce**: configurable flat tax + free-shipping threshold (migration 000021); fulfillment workflow shipped/delivered/refunded with new aggregate events (migration 000022); inventory stock_movement audit trail covering reserve/release/admin-adjust call sites (migration 000023).

## Test plan
- [x] build / build -tags integration / vet / tests / lint green
- [x] docker: admin must-change gate; CSRF 403 vs 303; rate-limiter logs allowed:false; mailhog receives confirmation + reset emails; sweeper polls; tax + free-shipping correctly applied; ship/deliver/refund transitions; refund releases stock with audit entry; /admin/inventory renders movements