### PR TITLE
docs(adr): backfill the React → HTMX migration

### DIFF
--- a/docs/adr/18.09.2023-htmx.md
+++ b/docs/adr/18.09.2023-htmx.md
@@ -1,0 +1,62 @@
+# Switch the frontend from ReactJS to HTMX
+
+## The problem
+
+The original [ReactJS ADR](19.04.2022-reactjs.md) picked React because it was
+popular and a sensible thing for a backend engineer to learn. After a year of
+living with that choice the costs had become hard to ignore:
+
+* Every interactive page required two implementations — the Go handler that
+  shaped the data and a React component that rendered it. Keeping those in
+  sync was a constant tax on small product changes.
+* The frontend had its own build pipeline, lockfile, container, CI job and
+  deployment story; for a project this size that complexity was outsized.
+* The data-fetching layer was effectively a hand-written API contract between
+  the React app and the Go backend, with the usual pains: bespoke endpoints,
+  ad-hoc state management, duplicated validation, and a tendency to drift.
+* The goal of the project — "show good practices for a DDD Go application" —
+  doesn't benefit from a SPA. The interesting design questions live in the
+  backend; the frontend was sucking time away from them.
+
+## Why's behind the decision
+
+[HTMX](https://htmx.org/) lets the server keep returning HTML and use small
+HTML attributes (`hx-get`, `hx-post`, `hx-target`, `hx-swap`, `hx-trigger`)
+to drive partial updates from the browser. In practice that means:
+
+* **One language, one place.** Pages are `html/template` files rendered by
+  the same handlers that already exist. Adding interactivity is an attribute,
+  not a new component.
+* **No build step.** A single `<script>` tag pulls htmx in. There is no
+  `node_modules`, no bundler, no separate container, no separate CI job.
+* **The API surface shrinks to URLs that return HTML fragments** for the
+  parts of the page that re-render — the cart badge, the variant box, the
+  product grid, etc. The "API contract" is the markup itself, which is the
+  same markup we already render.
+* **Server-side rendering by default**, so SEO, accessibility and progressive
+  enhancement come almost for free.
+
+The trade-offs we accept:
+
+* Heavily client-state-driven UIs (drag-and-drop builders, real-time charts,
+  offline-capable apps) are not what htmx is for. We do not have those.
+* Some interactions that would be trivial in React (debounced searches,
+  optimistic updates) need a small bit of vanilla JS or a tiny library on top
+  of htmx. We're fine with that; the surface stays small.
+* "I learn React" — the rationale in the original ADR — stops applying. That
+  was a personal-learning goal that has been served.
+
+## Consequences
+
+* The whole React app and its `Dockerfile` / GitHub Action / lockfile were
+  deleted in the "initial HTMX support" commit. The frontend is now part of
+  the `backend/layout` Go package: handlers in `http_*.go`, templates in
+  `tmpl/*.gohtml`, static assets in `static/`. There is one binary and one
+  deploy artifact.
+* New features ship as Go handler + template change. No frontend PR/round-trip.
+* The team interface to the frontend is "know Go, html/template, a little
+  CSS, and the half-dozen htmx attributes we use" — a much lower bar than
+  the React stack the previous ADR implied.
+
+This decision is the one made by the project today; the ReactJS ADR is left
+in place as the historical record it is.

--- a/docs/adr/Readme.md
+++ b/docs/adr/Readme.md
@@ -4,7 +4,8 @@
 
 ## List of accepted ADRs
 
-* [ReactJS](19.04.2022-reactjs.md)
+* [ReactJS](19.04.2022-reactjs.md) (superseded by the HTMX ADR below)
+* [Switch the frontend from ReactJS to HTMX](18.09.2023-htmx.md)
 
 ## Template
 We'll use a simple template just to not overcomplicate it:


### PR DESCRIPTION
The original ReactJS ADR (2022-04-19) was never followed up when the frontend was rewritten in HTMX (commit eedc86f, 2023-09-18). Adds an ADR that records the actual decision and supersedes the React one. Docs-only.