### PR TITLE
feat: reviews, wishlist, promo codes, multi-currency display

### DIFF
--- a/backend/checkout/adapter/events_codec.go
+++ b/backend/checkout/adapter/events_codec.go
@@ -42,16 +42,18 @@ type lineDTO struct {
 }
 
 type orderPlacedDTO struct {
-	OrderID      string            `json:"order_id"`
-	UserID       string            `json:"user_id"`
-	CustomerID   string            `json:"customer_id"`
-	ShipTo       addressDTO        `json:"ship_to"`
-	ShipMethod   shippingMethodDTO `json:"ship_method"`
-	PayMethod    paymentMethodDTO  `json:"pay_method"`
-	Lines        []lineDTO         `json:"lines"`
-	Tax          int64             `json:"tax,omitempty"`
-	ShippingCost int64             `json:"shipping_cost,omitempty"`
-	At           time.Time         `json:"at"`
+	OrderID        string            `json:"order_id"`
+	UserID         string            `json:"user_id"`
+	CustomerID     string            `json:"customer_id"`
+	ShipTo         addressDTO        `json:"ship_to"`
+	ShipMethod     shippingMethodDTO `json:"ship_method"`
+	PayMethod      paymentMethodDTO  `json:"pay_method"`
+	Lines          []lineDTO         `json:"lines"`
+	Tax            int64             `json:"tax,omitempty"`
+	ShippingCost   int64             `json:"shipping_cost,omitempty"`
+	DiscountCode   string            `json:"discount_code,omitempty"`
+	DiscountAmount int64             `json:"discount_amount,omitempty"`
+	At             time.Time         `json:"at"`
 }
 
 type paymentSucceededDTO struct {
@@ -105,16 +107,18 @@ func marshalEvent(e domain.Event) (string, []byte, error) {
 			})
 		}
 		payload = orderPlacedDTO{
-			OrderID:      ev.OrderID,
-			UserID:       ev.UserID,
-			CustomerID:   ev.CustomerID,
-			ShipTo:       toAddressDTO(ev.ShipTo),
-			ShipMethod:   shippingMethodDTO{Code: ev.ShipMethod.Code(), Label: ev.ShipMethod.Label(), Cost: ev.ShipMethod.Cost()},
-			PayMethod:    paymentMethodDTO{Code: ev.PayMethod.Code(), Label: ev.PayMethod.Label()},
-			Lines:        lines,
-			Tax:          ev.Tax,
-			ShippingCost: ev.ShippingCost,
-			At:           ev.At,
+			OrderID:        ev.OrderID,
+			UserID:         ev.UserID,
+			CustomerID:     ev.CustomerID,
+			ShipTo:         toAddressDTO(ev.ShipTo),
+			ShipMethod:     shippingMethodDTO{Code: ev.ShipMethod.Code(), Label: ev.ShipMethod.Label(), Cost: ev.ShipMethod.Cost()},
+			PayMethod:      paymentMethodDTO{Code: ev.PayMethod.Code(), Label: ev.PayMethod.Label()},
+			Lines:          lines,
+			Tax:            ev.Tax,
+			ShippingCost:   ev.ShippingCost,
+			DiscountCode:   ev.DiscountCode,
+			DiscountAmount: ev.DiscountAmount,
+			At:             ev.At,
 		}
 	case domain.PaymentSucceeded:
 		payload = paymentSucceededDTO{OrderID: ev.OrderID, At: ev.At}
@@ -152,16 +156,18 @@ func unmarshalEvent(eventType string, payload []byte) (domain.Event, error) {
 			lines = append(lines, domain.NewLine(l.ProductID, l.ProductName, l.Qty, l.PriceAmount, l.PriceCurrency))
 		}
 		return domain.OrderPlaced{
-			OrderID:      dto.OrderID,
-			UserID:       dto.UserID,
-			CustomerID:   dto.CustomerID,
-			ShipTo:       domain.RebuildAddress(dto.ShipTo.Name, dto.ShipTo.Street1, dto.ShipTo.Street2, dto.ShipTo.City, dto.ShipTo.Zip, dto.ShipTo.Country),
-			ShipMethod:   domain.RebuildShippingMethod(dto.ShipMethod.Code, dto.ShipMethod.Label, dto.ShipMethod.Cost),
-			PayMethod:   domain.RebuildPaymentMethod(dto.PayMethod.Code, dto.PayMethod.Label),
-			Lines:        lines,
-			Tax:          dto.Tax,
-			ShippingCost: dto.ShippingCost,
-			At:           dto.At,
+			OrderID:        dto.OrderID,
+			UserID:         dto.UserID,
+			CustomerID:     dto.CustomerID,
+			ShipTo:         domain.RebuildAddress(dto.ShipTo.Name, dto.ShipTo.Street1, dto.ShipTo.Street2, dto.ShipTo.City, dto.ShipTo.Zip, dto.ShipTo.Country),
+			ShipMethod:     domain.RebuildShippingMethod(dto.ShipMethod.Code, dto.ShipMethod.Label, dto.ShipMethod.Cost),
+			PayMethod:      domain.RebuildPaymentMethod(dto.PayMethod.Code, dto.PayMethod.Label),
+			Lines:          lines,
+			Tax:            dto.Tax,
+			ShippingCost:   dto.ShippingCost,
+			DiscountCode:   dto.DiscountCode,
+			DiscountAmount: dto.DiscountAmount,
+			At:             dto.At,
 		}, nil
 	case "PaymentSucceeded":
 		var dto paymentSucceededDTO

--- a/backend/checkout/adapter/events_codec_test.go
+++ b/backend/checkout/adapter/events_codec_test.go
@@ -19,9 +19,11 @@ func TestEventCodecRoundTrip_OrderPlaced(t *testing.T) {
 		Lines: []domain.Line{
 			domain.NewLine("ceramic-mug-cream", "Ceramic Mug — Cream", 2, 2400, "USD"),
 		},
-		Tax:          426,
-		ShippingCost: 0,
-		At:           at,
+		Tax:            426,
+		ShippingCost:   0,
+		DiscountCode:   "SAVE10",
+		DiscountAmount: 240,
+		At:             at,
 	}
 
 	typ, payload, err := marshalEvent(original)
@@ -61,6 +63,9 @@ func TestEventCodecRoundTrip_OrderPlaced(t *testing.T) {
 	}
 	if op.Tax != 426 || op.ShippingCost != 0 {
 		t.Errorf("tax/shipping round-trip mismatch: tax=%d shipping=%d", op.Tax, op.ShippingCost)
+	}
+	if op.DiscountCode != "SAVE10" || op.DiscountAmount != 240 {
+		t.Errorf("discount round-trip mismatch: code=%q amount=%d", op.DiscountCode, op.DiscountAmount)
 	}
 }
 

--- a/backend/checkout/adapter/events_postgres.go
+++ b/backend/checkout/adapter/events_postgres.go
@@ -161,8 +161,9 @@ func projectOrderPlaced(ctx context.Context, tx *sql.Tx, ev domain.OrderPlaced) 
 			(id, user_id, customer_id, total_amount, total_currency, status, placed_at,
 			 ship_name, ship_street1, ship_street2, ship_city, ship_zip, ship_country,
 			 ship_method_code, ship_method_label, ship_cost,
-			 payment_method_code, payment_method_label, tax_amount)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19)
+			 payment_method_code, payment_method_label, tax_amount,
+			 discount_code, discount_amount)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21)
 		ON CONFLICT (id) DO UPDATE SET
 			user_id = EXCLUDED.user_id,
 			customer_id = EXCLUDED.customer_id,
@@ -180,13 +181,16 @@ func projectOrderPlaced(ctx context.Context, tx *sql.Tx, ev domain.OrderPlaced) 
 			ship_cost = EXCLUDED.ship_cost,
 			payment_method_code = EXCLUDED.payment_method_code,
 			payment_method_label = EXCLUDED.payment_method_label,
-			tax_amount = EXCLUDED.tax_amount
+			tax_amount = EXCLUDED.tax_amount,
+			discount_code = EXCLUDED.discount_code,
+			discount_amount = EXCLUDED.discount_amount
 	`,
 		o.ID(), o.UserID(), customerID, o.TotalAmount(), o.TotalCurrency(),
 		string(o.Status()), o.PlacedAt(),
 		ship.Name(), ship.Street1(), ship.Street2(), ship.City(), ship.Zip(), ship.Country(),
 		method.Code(), method.Label(), o.ShippingCost(),
 		pay.Code(), pay.Label(), o.TaxAmount(),
+		o.DiscountCode(), o.DiscountAmount(),
 	)
 	if err != nil {
 		return fmt.Errorf("project order: %w", err)

--- a/backend/checkout/adapter/postgres.go
+++ b/backend/checkout/adapter/postgres.go
@@ -88,7 +88,8 @@ func (p Postgres) Find(ctx context.Context, id string) (query.OrderView, error) 
 	var shipName, shipStreet1, shipStreet2, shipCity, shipZip, shipCountry sql.NullString
 	var shipMethodCode, shipMethodLabel sql.NullString
 	var payMethodCode, payMethodLabel sql.NullString
-	var shipCost, taxAmt int64
+	var shipCost, taxAmt, discountAmt int64
+	var discountCode string
 	var carrier, trackingCode string
 	var totalAmt int64
 	var placedAt time.Time
@@ -98,13 +99,15 @@ func (p Postgres) Find(ctx context.Context, id string) (query.OrderView, error) 
 		       ship_name, ship_street1, ship_street2, ship_city, ship_zip, ship_country,
 		       ship_method_code, ship_method_label, ship_cost,
 		       payment_method_code, payment_method_label,
-		       tax_amount, carrier, tracking_code
+		       tax_amount, carrier, tracking_code,
+		       discount_code, discount_amount
 		FROM checkout_order WHERE id = $1
 	`, id).Scan(&userID, &customerID, &totalAmt, &currency, &status, &placedAt,
 		&shipName, &shipStreet1, &shipStreet2, &shipCity, &shipZip, &shipCountry,
 		&shipMethodCode, &shipMethodLabel, &shipCost,
 		&payMethodCode, &payMethodLabel,
-		&taxAmt, &carrier, &trackingCode)
+		&taxAmt, &carrier, &trackingCode,
+		&discountCode, &discountAmt)
 	if errors.Is(err, sql.ErrNoRows) {
 		return query.OrderView{}, domain.ErrOrderNotFound
 	}
@@ -143,12 +146,16 @@ func (p Postgres) Find(ctx context.Context, id string) (query.OrderView, error) 
 	shipMethod := domain.RebuildShippingMethod(shipMethodCode.String, shipMethodLabel.String, shipCost)
 	payMethod := domain.RebuildPaymentMethod(payMethodCode.String, payMethodLabel.String)
 
-	subtotal := totalAmt - shipCost - taxAmt
+	// Reconstruct the subtotal so the read model reports the pre-discount
+	// figure: total = (subtotal - discount) + tax + shipping, therefore
+	// subtotal = total - tax - shipping + discount.
+	subtotal := totalAmt - shipCost - taxAmt + discountAmt
 	return query.NewOrderView(
 		id, customerID.String, domain.Status(status), placedAt,
 		lines, shipTo, shipMethod, payMethod,
 		subtotal, taxAmt, shipCost, totalAmt, currency,
 		carrier, trackingCode,
+		discountCode, discountAmt,
 	), nil
 }
 

--- a/backend/checkout/adapter/postgres.go
+++ b/backend/checkout/adapter/postgres.go
@@ -219,6 +219,37 @@ func (p Postgres) ListExpiredPending(ctx context.Context, olderThan time.Time) (
 	return ids, nil
 }
 
+// HasPurchasedProduct reports whether the customer has at least one
+// fulfilled order (paid / shipped / delivered) that contains any variant of
+// the given catalog product.
+//
+// Important nuance: the checkout_order_item.product_id column actually stores
+// the catalogue variant id (the cart adds variants, see
+// checkout/app/checkout.go Place where lines are built from item.Product().
+// ID()). To answer "did this customer buy this product?" we therefore join
+// the order line through productcatalog_variant to recover the parent
+// product id.
+func (p Postgres) HasPurchasedProduct(ctx context.Context, customerID, productID string) (bool, error) {
+	var dummy int
+	err := p.db.QueryRowContext(ctx, `
+		SELECT 1
+		FROM checkout_order_item oi
+		JOIN checkout_order o ON o.id = oi.order_id
+		JOIN productcatalog_variant v ON v.id = oi.product_id
+		WHERE o.customer_id = $1
+		  AND v.product_id = $2
+		  AND o.status IN ('paid', 'shipped', 'delivered')
+		LIMIT 1
+	`, customerID, productID).Scan(&dummy)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("has purchased product: %w", err)
+	}
+	return true, nil
+}
+
 // ListAll returns every order newest-first as list summaries, regardless of
 // customer (including anonymous orders with a NULL customer_id). It powers the
 // admin order list and uses the same grouped query as ListByCustomer without

--- a/backend/checkout/app/checkout.go
+++ b/backend/checkout/app/checkout.go
@@ -12,6 +12,7 @@ import (
 	"github.com/bkielbasa/go-ecommerce/backend/checkout/integration"
 	"github.com/bkielbasa/go-ecommerce/backend/internal/eventbus"
 	"github.com/bkielbasa/go-ecommerce/backend/internal/observability"
+	promodomain "github.com/bkielbasa/go-ecommerce/backend/promo/domain"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
@@ -131,6 +132,22 @@ func (p PricingPolicy) computeTaxAndShipping(subtotal int64, method domain.Shipp
 // deterministic generator.
 type IDGenerator func() string
 
+// PromoRedeemer is the seam to the promo bounded context. Place calls
+// Redeem AFTER the order's events are committed so the redemption ledger
+// only grows for orders that actually exist. A nil PromoRedeemer disables
+// the integration; the in-memory wiring used by tests doesn't need it.
+type PromoRedeemer interface {
+	Redeem(ctx context.Context, code, orderID, customerID string, discount promodomain.Discount) error
+}
+
+// nopPromoRedeemer is the default when no promo integration is wired —
+// keeps the service constructible without a promo dependency.
+type nopPromoRedeemer struct{}
+
+func (nopPromoRedeemer) Redeem(context.Context, string, string, string, promodomain.Discount) error {
+	return nil
+}
+
 type CheckoutService struct {
 	cart      CartReader
 	storage   OrderStorage
@@ -138,6 +155,7 @@ type CheckoutService struct {
 	stock     StockReserver
 	movements StockMovements
 	events    EventPublisher
+	promo     PromoRedeemer
 	newID     IDGenerator
 	now       func() time.Time
 	pricing   PricingPolicy
@@ -163,10 +181,22 @@ func NewCheckoutService(
 		stock:     stock,
 		movements: movements,
 		events:    events,
+		promo:     nopPromoRedeemer{},
 		newID:     newID,
 		now:       func() time.Time { return time.Now().UTC() },
 		pricing:   pricing,
 	}
+}
+
+// WithPromoRedeemer wires the promo redemption seam — only the
+// composition root in cmd/web calls this so the historical zero-promo
+// wiring stays untouched in tests.
+func (s CheckoutService) WithPromoRedeemer(p PromoRedeemer) CheckoutService {
+	if p == nil {
+		p = nopPromoRedeemer{}
+	}
+	s.promo = p
+	return s
 }
 
 // Place runs the checkout command: it snapshots the cart into a new order
@@ -177,7 +207,19 @@ func NewCheckoutService(
 //
 // customerID may be empty for anonymous checkout; in that case the order is
 // recorded but will not appear in any customer's order history.
-func (s CheckoutService) Place(ctx context.Context, sessID, customerID, cardNumber string, shipTo domain.Address, shipMethod domain.ShippingMethod, payMethod domain.PaymentMethod) (domain.Order, error) {
+//
+// discount carries an already-resolved promo code (see promo/app.Service.
+// Resolve). Pricing math applies it BEFORE tax:
+//
+//	discountedSubtotal = subtotal - discount.AmountMinor
+//	tax                = round(discountedSubtotal * cfg.TaxRate / 100)
+//	effectiveShipping  = 0 if discount.FreeShipping
+//	                     else (free-shipping-threshold logic on discountedSubtotal)
+//	total              = discountedSubtotal + tax + effectiveShipping
+//
+// An empty Discount value (no code applied) is the same arithmetic as
+// before promo codes existed.
+func (s CheckoutService) Place(ctx context.Context, sessID, customerID, cardNumber string, shipTo domain.Address, shipMethod domain.ShippingMethod, payMethod domain.PaymentMethod, discount promodomain.Discount) (domain.Order, error) {
 	ctx, span := tracer.Start(ctx, "Checkout.Place", trace.WithAttributes(
 		attribute.String("cart.session_id", sessID),
 		attribute.String("customer.id", customerID),
@@ -249,21 +291,40 @@ func (s CheckoutService) Place(ctx context.Context, sessID, customerID, cardNumb
 		_ = s.movements.Record(ctx, vid, -qty, "reserve", orderID)
 	}
 
-	// Apply the configured tax + free-shipping threshold to derive what the
-	// customer is actually charged. Both default to 0 so an unconfigured
-	// app behaves exactly like before this change.
+	// Pricing math, in order:
+	//   1. sum line totals → subtotal
+	//   2. subtract discount.AmountMinor (capped to 0) → discountedSubtotal
+	//   3. compute tax on discountedSubtotal so the saving carries through
+	//      the tax line (avoids charging tax on a discount the customer
+	//      never paid)
+	//   4. compute shipping from discountedSubtotal via the free-shipping
+	//      threshold; a free-shipping promo overrides that to 0 outright
+	//   5. total = discountedSubtotal + tax + effectiveShipping
 	var subtotal int64
 	for _, ln := range lines {
 		subtotal += ln.LineTotal()
 	}
-	tax, effectiveShipping := s.pricing.computeTaxAndShipping(subtotal, shipMethod)
+	discountAmount := discount.AmountMinor()
+	if discountAmount < 0 {
+		discountAmount = 0
+	}
+	if discountAmount > subtotal {
+		discountAmount = subtotal
+	}
+	discountedSubtotal := subtotal - discountAmount
+	tax, effectiveShipping := s.pricing.computeTaxAndShipping(discountedSubtotal, shipMethod)
+	if discount.FreeShipping() {
+		effectiveShipping = 0
+	}
 	span.SetAttributes(
 		attribute.Int64("order.subtotal", subtotal),
+		attribute.Int64("order.discount", discountAmount),
+		attribute.String("order.discount_code", discount.Code()),
 		attribute.Int64("order.tax", tax),
 		attribute.Int64("order.shipping", effectiveShipping),
 	)
 
-	order, err := domain.PlaceOrder(orderID, sessID, customerID, shipTo, shipMethod, payMethod, lines, tax, effectiveShipping, s.now())
+	order, err := domain.PlaceOrder(orderID, sessID, customerID, shipTo, shipMethod, payMethod, lines, tax, effectiveShipping, discount.Code(), discountAmount, s.now())
 	if err != nil {
 		_ = s.stock.Release(ctx, quantities)
 		for vid, qty := range quantities {
@@ -343,6 +404,19 @@ func (s CheckoutService) Place(ctx context.Context, sessID, customerID, cardNumb
 	// so a write failure doesn't double-book the totals.
 	observability.RevenueAdd(ctx, order.TotalAmount(), order.TotalCurrency())
 	observability.OrdersFinalizedInc(ctx, string(domain.StatusPaid))
+
+	// Record the promo redemption (best-effort, like the cart-clear): the
+	// order is now committed so a failed redemption ledger insertion must
+	// not roll the order back. The (code, order_id) PK on
+	// promo_redemption keeps the call idempotent if a retry lands.
+	if discount.Code() != "" {
+		if err := s.promo.Redeem(ctx, discount.Code(), order.ID(), customerID, discount); err != nil {
+			span.AddEvent("promo.redeem.failed", trace.WithAttributes(
+				attribute.String("promo.code", discount.Code()),
+				attribute.String("error", err.Error()),
+			))
+		}
+	}
 
 	// Announce the paid order. Subscribers (e.g. the cart context emptying the
 	// basket) react best-effort; their failures never block the confirmation.

--- a/backend/checkout/domain/events.go
+++ b/backend/checkout/domain/events.go
@@ -17,19 +17,28 @@ type Event interface {
 //
 // Tax is the tax amount in minor units computed at place time from the
 // configured tax rate; ShippingCost is the EFFECTIVE shipping price at place
-// time (which may be 0 if the configured free-shipping threshold was met,
-// overriding the catalogue method's Cost()).
+// time (which may be 0 if the configured free-shipping threshold was met OR
+// because a free-shipping promo code was applied, overriding the catalogue
+// method's Cost()).
+//
+// DiscountCode is the literal text of the promo code that was applied (empty
+// when no code was used). DiscountAmount is the resolved discount in minor
+// units that was subtracted from the subtotal before computing tax. For
+// free_shipping codes DiscountAmount stays 0 — the saving is reflected in
+// ShippingCost=0, not in the subtotal.
 type OrderPlaced struct {
-	OrderID      string
-	UserID       string
-	CustomerID   string
-	ShipTo       Address
-	ShipMethod   ShippingMethod
-	PayMethod    PaymentMethod
-	Lines        []Line
-	Tax          int64
-	ShippingCost int64
-	At           time.Time
+	OrderID        string
+	UserID         string
+	CustomerID     string
+	ShipTo         Address
+	ShipMethod     ShippingMethod
+	PayMethod      PaymentMethod
+	Lines          []Line
+	Tax            int64
+	ShippingCost   int64
+	DiscountCode   string
+	DiscountAmount int64
+	At             time.Time
 }
 
 func (e OrderPlaced) EventType() string     { return "OrderPlaced" }

--- a/backend/checkout/domain/order.go
+++ b/backend/checkout/domain/order.go
@@ -46,6 +46,8 @@ type Order struct {
 	subtotalAmt  int64
 	taxAmt       int64
 	shipCostAmt  int64
+	discountCode string
+	discountAmt  int64
 	totalAmt     int64
 	totalCcy     string
 	status       Status
@@ -138,31 +140,53 @@ func (o Order) TotalDisplay() string  { return money(o.totalAmt) }
 func (o Order) Carrier() string       { return o.carrier }
 func (o Order) TrackingCode() string  { return o.trackingCode }
 
+// DiscountCode returns the literal promo code applied at place time
+// (empty when no code was used). The order is event-sourced so the
+// historical value is preserved across replays.
+func (o Order) DiscountCode() string { return o.discountCode }
+
+// DiscountAmount returns the resolved discount in minor units that was
+// subtracted from the subtotal before tax. For free-shipping codes this
+// is 0 — the saving is reflected in ShippingCost instead.
+func (o Order) DiscountAmount() int64 { return o.discountAmt }
+
+// DiscountDisplay renders the discount amount for the totals row in the
+// templates (negative sign included).
+func (o Order) DiscountDisplay() string { return money(o.discountAmt) }
+
 // --- event-sourced write side ---
 
 // PlaceOrder is the command that creates a new order from a cart snapshot
 // and the customer's checkout choices. It emits an OrderPlaced event.
 //
 // tax is the tax amount in minor units already computed by the caller
-// (CheckoutService) from the configured rate. effectiveShipping is the
-// shipping price actually charged — equal to shipMethod.Cost() in the normal
-// case, but 0 when a configured free-shipping threshold knocked it down.
-func PlaceOrder(id, userID, customerID string, shipTo Address, shipMethod ShippingMethod, payMethod PaymentMethod, lines []Line, tax, effectiveShipping int64, at time.Time) (*Order, error) {
+// (CheckoutService) from the configured rate AFTER the promo-code discount
+// has been subtracted from the subtotal. effectiveShipping is the shipping
+// price actually charged — 0 when a configured free-shipping threshold
+// knocked it down, 0 when a free-shipping promo code was applied, or the
+// catalogue method's Cost() otherwise.
+//
+// discountCode/discountAmount carry the resolved promo code (empty / 0 when
+// none was used). The event-sourced aggregate keeps these so replaying
+// history reproduces the original totals.
+func PlaceOrder(id, userID, customerID string, shipTo Address, shipMethod ShippingMethod, payMethod PaymentMethod, lines []Line, tax, effectiveShipping int64, discountCode string, discountAmount int64, at time.Time) (*Order, error) {
 	if len(lines) == 0 {
 		return nil, ErrCartEmpty
 	}
 	o := &Order{}
 	o.raise(OrderPlaced{
-		OrderID:      id,
-		UserID:       userID,
-		CustomerID:   customerID,
-		ShipTo:       shipTo,
-		ShipMethod:   shipMethod,
-		PayMethod:    payMethod,
-		Lines:        lines,
-		Tax:          tax,
-		ShippingCost: effectiveShipping,
-		At:           at,
+		OrderID:        id,
+		UserID:         userID,
+		CustomerID:     customerID,
+		ShipTo:         shipTo,
+		ShipMethod:     shipMethod,
+		PayMethod:      payMethod,
+		Lines:          lines,
+		Tax:            tax,
+		ShippingCost:   effectiveShipping,
+		DiscountCode:   discountCode,
+		DiscountAmount: discountAmount,
+		At:             at,
 	})
 	return o, nil
 }
@@ -211,7 +235,15 @@ func (o *Order) apply(e Event) {
 		} else {
 			o.shipCostAmt = ev.ShippingCost
 		}
-		o.totalAmt = subtotal + o.taxAmt + o.shipCostAmt
+		// Promo code is replayed verbatim from the event so historical
+		// orders preserve the math: the discount was subtracted from the
+		// subtotal BEFORE tax, so the total is computed as
+		//   (subtotal - discount) + tax + effective_shipping
+		// — see checkout/app.Place for the live computation that
+		// produced these fields.
+		o.discountCode = ev.DiscountCode
+		o.discountAmt = ev.DiscountAmount
+		o.totalAmt = subtotal - o.discountAmt + o.taxAmt + o.shipCostAmt
 		o.totalCcy = ccy
 		o.status = StatusPending
 		o.placedAt = ev.At

--- a/backend/checkout/domain/order_test.go
+++ b/backend/checkout/domain/order_test.go
@@ -88,6 +88,30 @@ func TestCancel_FailedOrderNotCancellable(t *testing.T) {
 	}
 }
 
+// TestPlaceOrder_AppliesDiscount locks in the discount-before-tax pricing
+// math: the OrderPlaced event carries the resolved discount and the
+// rehydrated order's total reflects (subtotal - discount) + tax + shipping.
+func TestPlaceOrder_AppliesDiscount(t *testing.T) {
+	at := time.Date(2026, 5, 27, 9, 0, 0, 0, time.UTC)
+	lines := []domain.Line{domain.NewLine("v1", "Mug", 4, 1000, "USD")} // subtotal 4000
+	method := domain.RebuildShippingMethod("courier", "Courier", 1500)
+
+	// Caller resolved a 10% code: discount=400 on subtotal 4000;
+	// discounted subtotal = 3600; caller computed tax 320 on it and kept
+	// shipping at 1500. Total = 3600 + 320 + 1500 = 5420.
+	o, err := domain.PlaceOrder("ord-d", "cart-1", "jane@example.com", domain.Address{}, method,
+		domain.RebuildPaymentMethod("card", "Card"), lines, 320, 1500, "SAVE10", 400, at)
+	if err != nil {
+		t.Fatalf("PlaceOrder: %v", err)
+	}
+	if o.DiscountCode() != "SAVE10" || o.DiscountAmount() != 400 {
+		t.Errorf("discount fields lost: code=%q amount=%d", o.DiscountCode(), o.DiscountAmount())
+	}
+	if o.TotalAmount() != 5420 {
+		t.Errorf("total = %d, want 5420 (3600 discounted subtotal + 320 tax + 1500 shipping)", o.TotalAmount())
+	}
+}
+
 // TestPlaceOrder_AppliesTaxAndEffectiveShipping locks in the tax/shipping
 // math driven by the new PricingPolicy: the OrderPlaced event carries the
 // derived numbers and the rehydrated order's total reflects them.
@@ -98,7 +122,7 @@ func TestPlaceOrder_AppliesTaxAndEffectiveShipping(t *testing.T) {
 
 	// Caller computed an 8.875% tax on 4000 = 355 and free shipping (threshold met).
 	o, err := domain.PlaceOrder("ord-3", "cart-1", "jane@example.com", domain.Address{}, method,
-		domain.RebuildPaymentMethod("card", "Card"), lines, 355, 0, at)
+		domain.RebuildPaymentMethod("card", "Card"), lines, 355, 0, "", 0, at)
 	if err != nil {
 		t.Fatalf("PlaceOrder: %v", err)
 	}

--- a/backend/checkout/domain/place_test.go
+++ b/backend/checkout/domain/place_test.go
@@ -12,7 +12,7 @@ func TestPlaceOrder_EmptyCartRejected(t *testing.T) {
 	_, err := domain.PlaceOrder("ord-1", "cart-1", "", domain.Address{},
 		domain.RebuildShippingMethod("pickup", "Personal pickup", 0),
 		domain.RebuildPaymentMethod("cod", "Cash on delivery"),
-		nil, 0, 0, time.Now())
+		nil, 0, 0, "", 0, time.Now())
 	if !errors.Is(err, domain.ErrCartEmpty) {
 		t.Errorf("err = %v, want ErrCartEmpty", err)
 	}
@@ -28,7 +28,7 @@ func TestPlaceOrder_EmitsPendingOrderPlaced(t *testing.T) {
 	o, err := domain.PlaceOrder("ord-1", "cart-1", "jane@example.com", domain.Address{},
 		method,
 		domain.RebuildPaymentMethod("card", "Credit / debit card"),
-		lines, 0, method.Cost(), at)
+		lines, 0, method.Cost(), "", 0, at)
 	if err != nil {
 		t.Fatalf("PlaceOrder: %v", err)
 	}

--- a/backend/checkout/query/service.go
+++ b/backend/checkout/query/service.go
@@ -16,6 +16,11 @@ type Repository interface {
 	// reservation TTL sweeper uses this to find orphaned reservations to
 	// release.
 	ListExpiredPending(ctx context.Context, olderThan time.Time) ([]string, error)
+	// HasPurchasedProduct reports whether the customer has at least one
+	// fulfilled order (paid / shipped / delivered) containing any variant
+	// of the catalog product. It exists to power the reviews context's
+	// verified-buyer gate; see the reviews bounded context for the use site.
+	HasPurchasedProduct(ctx context.Context, customerID, productID string) (bool, error)
 }
 
 // Service is the checkout query side. It is intentionally separate from the
@@ -53,4 +58,14 @@ func (s Service) ListAll(ctx context.Context) ([]OrderSummary, error) {
 // being confirmed or explicitly failed. Used by the reservation sweeper.
 func (s Service) ListExpiredPending(ctx context.Context, olderThan time.Time) ([]string, error) {
 	return s.repo.ListExpiredPending(ctx, olderThan)
+}
+
+// HasPurchasedProduct reports whether the customer has bought at least one
+// variant of the given catalog product in a paid/shipped/delivered order.
+// Returns false (no error) for anonymous (empty) customers.
+func (s Service) HasPurchasedProduct(ctx context.Context, customerID, productID string) (bool, error) {
+	if customerID == "" || productID == "" {
+		return false, nil
+	}
+	return s.repo.HasPurchasedProduct(ctx, customerID, productID)
 }

--- a/backend/checkout/query/views.go
+++ b/backend/checkout/query/views.go
@@ -41,21 +41,23 @@ func (s OrderSummary) TotalCurrency() string { return s.currency }
 
 // OrderView is the read model for the order detail page.
 type OrderView struct {
-	id           string
-	customerID   string
-	status       domain.Status
-	placedAt     time.Time
-	items        []domain.Line
-	shipTo       domain.Address
-	shipMethod   domain.ShippingMethod
-	payMethod    domain.PaymentMethod
-	subtotal     int64
-	tax          int64
-	shipCost     int64
-	total        int64
-	currency     string
-	carrier      string
-	trackingCode string
+	id             string
+	customerID     string
+	status         domain.Status
+	placedAt       time.Time
+	items          []domain.Line
+	shipTo         domain.Address
+	shipMethod     domain.ShippingMethod
+	payMethod      domain.PaymentMethod
+	subtotal       int64
+	tax            int64
+	shipCost       int64
+	total          int64
+	currency       string
+	carrier        string
+	trackingCode   string
+	discountCode   string
+	discountAmount int64
 }
 
 func NewOrderView(
@@ -69,12 +71,15 @@ func NewOrderView(
 	subtotal, tax, shipCost, total int64,
 	currency string,
 	carrier, trackingCode string,
+	discountCode string,
+	discountAmount int64,
 ) OrderView {
 	return OrderView{
 		id: id, customerID: customerID, status: status, placedAt: placedAt,
 		items: items, shipTo: shipTo, shipMethod: shipMethod, payMethod: payMethod,
 		subtotal: subtotal, tax: tax, shipCost: shipCost, total: total, currency: currency,
 		carrier: carrier, trackingCode: trackingCode,
+		discountCode: discountCode, discountAmount: discountAmount,
 	}
 }
 
@@ -95,3 +100,23 @@ func (v OrderView) TotalDisplay() string                  { return money(v.total
 func (v OrderView) TotalCurrency() string                 { return v.currency }
 func (v OrderView) Carrier() string                       { return v.carrier }
 func (v OrderView) TrackingCode() string                  { return v.trackingCode }
+
+// DiscountCode is the literal promo code applied at place time (empty when
+// none was used).
+func (v OrderView) DiscountCode() string { return v.discountCode }
+
+// DiscountAmount is the discount in minor units that was subtracted from
+// the subtotal before tax (0 when none).
+func (v OrderView) DiscountAmount() int64 { return v.discountAmount }
+
+// DiscountDisplay renders the discount amount as the templates' totals
+// row shows it (e.g. "5.00"). Templates add the negative sign / the code
+// label themselves so the conditional formatting stays in the view.
+func (v OrderView) DiscountDisplay() string { return money(v.discountAmount) }
+
+// FreeShipping reports whether the order's shipping was zero AND a
+// discount code was applied — useful in templates to label the discount
+// row as "free shipping (CODE)" instead of a money amount.
+func (v OrderView) FreeShipping() bool {
+	return v.discountCode != "" && v.shipCost == 0 && v.discountAmount == 0
+}

--- a/backend/checkout/query/views.go
+++ b/backend/checkout/query/views.go
@@ -36,6 +36,12 @@ func (s OrderSummary) ID() string            { return s.id }
 func (s OrderSummary) Status() domain.Status { return s.status }
 func (s OrderSummary) PlacedAt() time.Time   { return s.placedAt }
 func (s OrderSummary) ItemCount() int        { return s.itemCount }
+
+// TotalAmount is the row's grand total in minor units of the order's
+// stored currency. Lists in the storefront pass this into the
+// currency-aware `money` template helper so the displayed total
+// follows the customer's chosen currency.
+func (s OrderSummary) TotalAmount() int64    { return s.total }
 func (s OrderSummary) TotalDisplay() string  { return money(s.total) }
 func (s OrderSummary) TotalCurrency() string { return s.currency }
 
@@ -91,15 +97,26 @@ func (v OrderView) Items() []domain.Line                  { return v.items }
 func (v OrderView) ShipTo() domain.Address                { return v.shipTo }
 func (v OrderView) ShippingMethod() domain.ShippingMethod { return v.shipMethod }
 func (v OrderView) PaymentMethod() domain.PaymentMethod   { return v.payMethod }
-func (v OrderView) SubtotalDisplay() string               { return money(v.subtotal) }
-func (v OrderView) ShippingCost() int64                   { return v.shipCost }
-func (v OrderView) ShippingCostDisplay() string           { return money(v.shipCost) }
-func (v OrderView) TaxAmount() int64                      { return v.tax }
-func (v OrderView) TaxDisplay() string                    { return money(v.tax) }
-func (v OrderView) TotalDisplay() string                  { return money(v.total) }
-func (v OrderView) TotalCurrency() string                 { return v.currency }
-func (v OrderView) Carrier() string                       { return v.carrier }
-func (v OrderView) TrackingCode() string                  { return v.trackingCode }
+
+// Subtotal returns the order's subtotal in minor units of the order's
+// stored currency. Exposed as an int64 so the storefront templates can
+// hand it to the currency-aware `money` FuncMap helper for conversion.
+func (v OrderView) Subtotal() int64             { return v.subtotal }
+func (v OrderView) SubtotalDisplay() string     { return money(v.subtotal) }
+func (v OrderView) ShippingCost() int64         { return v.shipCost }
+func (v OrderView) ShippingCostDisplay() string { return money(v.shipCost) }
+func (v OrderView) TaxAmount() int64            { return v.tax }
+func (v OrderView) TaxDisplay() string          { return money(v.tax) }
+
+// TotalAmount returns the order's grand total in minor units of the
+// order's stored currency. As with Subtotal, the int64 view lets the
+// storefront templates convert via the `money` helper while the
+// existing Display() string still drives any legacy / email render.
+func (v OrderView) TotalAmount() int64    { return v.total }
+func (v OrderView) TotalDisplay() string  { return money(v.total) }
+func (v OrderView) TotalCurrency() string { return v.currency }
+func (v OrderView) Carrier() string       { return v.carrier }
+func (v OrderView) TrackingCode() string  { return v.trackingCode }
 
 // DiscountCode is the literal promo code applied at place time (empty when
 // none was used).

--- a/backend/cmd/web/config.go
+++ b/backend/cmd/web/config.go
@@ -70,6 +70,24 @@ type config struct {
 	// e.g. cents) at or above which the chosen shipping method's cost is
 	// overridden to 0 at place time. 0 disables the threshold.
 	FreeShippingThreshold int64 `conf:"default:0"`
+	// DefaultCurrency is the ISO 4217 code orders are placed in — the
+	// storage currency. Every Price in the system is assumed to be
+	// denominated in it; the display-only currency picker converts FROM
+	// this code TO whatever the shopper selected.
+	DefaultCurrency string `conf:"default:USD"`
+	// SupportedCurrencies is a comma-separated list of ISO 4217 codes the
+	// header picker offers (e.g. "USD,EUR,GBP"). The DefaultCurrency is
+	// always prepended if missing. When only the default is listed (the
+	// out-of-the-box value), the picker stays hidden.
+	SupportedCurrencies string `conf:"default:USD"`
+	// FXRates are the static, operator-configured conversion multipliers
+	// FROM DefaultCurrency TO each supported display currency, in
+	// "CCY:rate" pairs (e.g. "EUR:0.92,GBP:0.79"). They are NOT a live
+	// feed — operators must update them by hand when the market drifts.
+	// Upgrading to a real provider only requires a different
+	// implementation of internal/fx.Rates; every storefront template and
+	// the /currency handler talk through that single seam.
+	FXRates string
 }
 
 // defaultSessionSecret is the placeholder value SessionSecret must NOT keep

--- a/backend/cmd/web/main.go
+++ b/backend/cmd/web/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/bkielbasa/go-ecommerce/backend/internal/observability"
 	"github.com/bkielbasa/go-ecommerce/backend/layout"
 	"github.com/bkielbasa/go-ecommerce/backend/productcatalog"
+	"github.com/bkielbasa/go-ecommerce/backend/reviews"
 	"github.com/bkielbasa/go-ecommerce/backend/shippinginfo"
 	"github.com/joho/godotenv"
 	"github.com/sirupsen/logrus"
@@ -128,6 +129,11 @@ func main() {
 	}
 	checkoutBD, checkoutSrv, checkoutQry := checkout.New(db, cartSrv, bus, catalogService, catalogService, pricing)
 	shipSrv := shippinginfo.New(db)
+	// Reviews context: depends on productcatalog (via FK in storage) and on
+	// checkout's HasPurchasedProduct (wired through a tiny ACL on the
+	// reviews side). Returns both the BoundedContext envelope and the
+	// concrete service which layout consumes.
+	reviewsBD, reviewsSrv := reviews.New(db, checkoutQry)
 
 	// Mailer is the outbound-email abstraction. When SMTP_HOST is empty
 	// (the dev default), New() returns a LogMailer that writes each email
@@ -179,7 +185,7 @@ func main() {
 
 	imgStore := imagestore.NewDisk(cfg.UploadsDir, "/uploads")
 
-	app.AddBoundedContext(layout.New(logger, cartSrv, catalogService, authService, checkoutSrv, checkoutQry, shipSrv, imgStore, cfg.UploadsDir, []byte(cfg.SessionSecret), cfg.CookieSecure, cfg.CSRFEnabled, mailerSrv, cfg.BaseURL))
+	app.AddBoundedContext(layout.New(logger, cartSrv, catalogService, authService, checkoutSrv, checkoutQry, shipSrv, reviewsSrv, imgStore, cfg.UploadsDir, []byte(cfg.SessionSecret), cfg.CookieSecure, cfg.CSRFEnabled, mailerSrv, cfg.BaseURL))
 	// CSRF protection wraps every route on the application router. It must be
 	// installed after layout.New has set up the session store (which the
 	// middleware reads from) but before app.Run() begins serving.
@@ -187,6 +193,7 @@ func main() {
 	app.AddBoundedContext(pcBD)
 	app.AddBoundedContext(authBD)
 	app.AddBoundedContext(checkoutBD)
+	app.AddBoundedContext(reviewsBD)
 
 	// Reservation TTL sweeper: releases stock held by pending orders whose
 	// confirmation never arrived (process crash, abandoned cart after stock

--- a/backend/cmd/web/main.go
+++ b/backend/cmd/web/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/bkielbasa/go-ecommerce/backend/productcatalog"
 	"github.com/bkielbasa/go-ecommerce/backend/reviews"
 	"github.com/bkielbasa/go-ecommerce/backend/shippinginfo"
+	"github.com/bkielbasa/go-ecommerce/backend/wishlist"
 	"github.com/joho/godotenv"
 	"github.com/sirupsen/logrus"
 	"github.com/uptrace/opentelemetry-go-extra/otelsql"
@@ -134,6 +135,10 @@ func main() {
 	// reviews side). Returns both the BoundedContext envelope and the
 	// concrete service which layout consumes.
 	reviewsBD, reviewsSrv := reviews.New(db, checkoutQry)
+	// Wishlist context: owns its data wholly, depends only on
+	// productcatalog_variant through the table's FK. Returns both the
+	// BoundedContext envelope and the concrete service which layout consumes.
+	wishlistBD, wishlistSrv := wishlist.New(db)
 
 	// Mailer is the outbound-email abstraction. When SMTP_HOST is empty
 	// (the dev default), New() returns a LogMailer that writes each email
@@ -185,7 +190,7 @@ func main() {
 
 	imgStore := imagestore.NewDisk(cfg.UploadsDir, "/uploads")
 
-	app.AddBoundedContext(layout.New(logger, cartSrv, catalogService, authService, checkoutSrv, checkoutQry, shipSrv, reviewsSrv, imgStore, cfg.UploadsDir, []byte(cfg.SessionSecret), cfg.CookieSecure, cfg.CSRFEnabled, mailerSrv, cfg.BaseURL))
+	app.AddBoundedContext(layout.New(logger, cartSrv, catalogService, authService, checkoutSrv, checkoutQry, shipSrv, reviewsSrv, wishlistSrv, imgStore, cfg.UploadsDir, []byte(cfg.SessionSecret), cfg.CookieSecure, cfg.CSRFEnabled, mailerSrv, cfg.BaseURL))
 	// CSRF protection wraps every route on the application router. It must be
 	// installed after layout.New has set up the session store (which the
 	// middleware reads from) but before app.Run() begins serving.
@@ -194,6 +199,7 @@ func main() {
 	app.AddBoundedContext(authBD)
 	app.AddBoundedContext(checkoutBD)
 	app.AddBoundedContext(reviewsBD)
+	app.AddBoundedContext(wishlistBD)
 
 	// Reservation TTL sweeper: releases stock held by pending orders whose
 	// confirmation never arrived (process crash, abandoned cart after stock

--- a/backend/cmd/web/main.go
+++ b/backend/cmd/web/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/bkielbasa/go-ecommerce/backend/internal/observability"
 	"github.com/bkielbasa/go-ecommerce/backend/layout"
 	"github.com/bkielbasa/go-ecommerce/backend/productcatalog"
+	"github.com/bkielbasa/go-ecommerce/backend/promo"
 	"github.com/bkielbasa/go-ecommerce/backend/reviews"
 	"github.com/bkielbasa/go-ecommerce/backend/shippinginfo"
 	"github.com/bkielbasa/go-ecommerce/backend/wishlist"
@@ -129,6 +130,11 @@ func main() {
 		FreeShippingThreshold: cfg.FreeShippingThreshold,
 	}
 	checkoutBD, checkoutSrv, checkoutQry := checkout.New(db, cartSrv, bus, catalogService, catalogService, pricing)
+	// Promo bounded context: owns promo_code + promo_redemption. The
+	// checkout service redeems through its narrow PromoRedeemer seam so
+	// the math stays inside checkout while the ledger lives here.
+	promoBD, promoSrv := promo.New(db)
+	checkoutSrv = checkoutSrv.WithPromoRedeemer(promoSrv)
 	shipSrv := shippinginfo.New(db)
 	// Reviews context: depends on productcatalog (via FK in storage) and on
 	// checkout's HasPurchasedProduct (wired through a tiny ACL on the
@@ -190,7 +196,7 @@ func main() {
 
 	imgStore := imagestore.NewDisk(cfg.UploadsDir, "/uploads")
 
-	app.AddBoundedContext(layout.New(logger, cartSrv, catalogService, authService, checkoutSrv, checkoutQry, shipSrv, reviewsSrv, wishlistSrv, imgStore, cfg.UploadsDir, []byte(cfg.SessionSecret), cfg.CookieSecure, cfg.CSRFEnabled, mailerSrv, cfg.BaseURL))
+	app.AddBoundedContext(layout.New(logger, cartSrv, catalogService, authService, checkoutSrv, checkoutQry, shipSrv, reviewsSrv, wishlistSrv, promoSrv, imgStore, cfg.UploadsDir, []byte(cfg.SessionSecret), cfg.CookieSecure, cfg.CSRFEnabled, mailerSrv, cfg.BaseURL))
 	// CSRF protection wraps every route on the application router. It must be
 	// installed after layout.New has set up the session store (which the
 	// middleware reads from) but before app.Run() begins serving.
@@ -200,6 +206,7 @@ func main() {
 	app.AddBoundedContext(checkoutBD)
 	app.AddBoundedContext(reviewsBD)
 	app.AddBoundedContext(wishlistBD)
+	app.AddBoundedContext(promoBD)
 
 	// Reservation TTL sweeper: releases stock held by pending orders whose
 	// confirmation never arrived (process crash, abandoned cart after stock

--- a/backend/cmd/web/main.go
+++ b/backend/cmd/web/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/bkielbasa/go-ecommerce/backend/internal/application"
 	"github.com/bkielbasa/go-ecommerce/backend/internal/dependency"
 	"github.com/bkielbasa/go-ecommerce/backend/internal/eventbus"
+	"github.com/bkielbasa/go-ecommerce/backend/internal/fx"
 	"github.com/bkielbasa/go-ecommerce/backend/internal/imagestore"
 	"github.com/bkielbasa/go-ecommerce/backend/internal/mailer"
 	"github.com/bkielbasa/go-ecommerce/backend/internal/observability"
@@ -196,7 +197,13 @@ func main() {
 
 	imgStore := imagestore.NewDisk(cfg.UploadsDir, "/uploads")
 
-	app.AddBoundedContext(layout.New(logger, cartSrv, catalogService, authService, checkoutSrv, checkoutQry, shipSrv, reviewsSrv, wishlistSrv, promoSrv, imgStore, cfg.UploadsDir, []byte(cfg.SessionSecret), cfg.CookieSecure, cfg.CSRFEnabled, mailerSrv, cfg.BaseURL))
+	// fxRates are static, operator-configured. They are NOT a live feed —
+	// upgrading to a real provider only requires a different implementation
+	// of fx.Rates. The conversion is purely a render transformation: orders
+	// remain stored and charged in DefaultCurrency (USD).
+	fxRates := fx.New(cfg.DefaultCurrency, cfg.SupportedCurrencies, cfg.FXRates, logger)
+
+	app.AddBoundedContext(layout.New(logger, cartSrv, catalogService, authService, checkoutSrv, checkoutQry, shipSrv, reviewsSrv, wishlistSrv, promoSrv, imgStore, cfg.UploadsDir, []byte(cfg.SessionSecret), cfg.CookieSecure, cfg.CSRFEnabled, mailerSrv, cfg.BaseURL, fxRates))
 	// CSRF protection wraps every route on the application router. It must be
 	// installed after layout.New has set up the session store (which the
 	// middleware reads from) but before app.Run() begins serving.

--- a/backend/internal/fx/fx.go
+++ b/backend/internal/fx/fx.go
@@ -1,0 +1,191 @@
+// Package fx is the display-only multi-currency seam for the storefront.
+//
+// Rates is a static, operator-configured table of conversion multipliers
+// FROM the storage currency (USD) TO each supported display currency. It
+// is NOT a live FX feed: the multipliers are read once at startup from
+// config (cmd/web/config.go FXRates) and never refreshed. To swap in a
+// real provider, replace this type with one that fetches and caches
+// rates from your favourite FX API — every caller (templates, the
+// /currency handler) talks through the same Default / Supported /
+// IsSupported / Convert / Format surface.
+//
+// Conversion is a render transformation only: orders are placed and
+// persisted in USD minor units. Convert rounds to the nearest minor
+// unit (cents) using math.Round, which matches what a customer expects
+// when comparing "5.00 USD" to its EUR sticker.
+package fx
+
+import (
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+)
+
+// Rates is the operator-configured conversion table. It is constructed
+// once at boot from comma-separated env input and is immutable for the
+// lifetime of the process. The zero value is unusable — call New.
+type Rates struct {
+	rates     map[string]float64
+	def       string
+	supported []string
+}
+
+// New parses the three config strings into a Rates value.
+//
+//   - defaultCcy is the storage currency. It is guaranteed to be in
+//     Supported() (prepended when missing) and always has a rate of 1.0.
+//   - supportedCSV is a comma-separated list of ISO codes ("USD,EUR,GBP").
+//     Empty or unparseable entries are skipped with a warn.
+//   - ratesCSV is a comma-separated list of CCY:rate pairs giving the
+//     multiplier to convert FROM the default currency TO that currency
+//     ("EUR:0.92,GBP:0.79"). Missing rates for supported currencies
+//     degrade to 1.0 with a warn at startup.
+//
+// The returned Rates is safe for concurrent reads — callers may share a
+// single instance across goroutines.
+func New(defaultCcy, supportedCSV, ratesCSV string, logger logrus.FieldLogger) Rates {
+	def := strings.ToUpper(strings.TrimSpace(defaultCcy))
+	if def == "" {
+		def = "USD"
+	}
+
+	supported := make([]string, 0)
+	seen := make(map[string]bool)
+	// Default currency is always listed first so the picker shows it on top.
+	supported = append(supported, def)
+	seen[def] = true
+	for _, tok := range strings.Split(supportedCSV, ",") {
+		c := strings.ToUpper(strings.TrimSpace(tok))
+		if c == "" || seen[c] {
+			continue
+		}
+		if len(c) != 3 {
+			logger.WithField("currency", c).Warn("fx: skipping non-ISO-4217 currency in SUPPORTED_CURRENCIES")
+			continue
+		}
+		supported = append(supported, c)
+		seen[c] = true
+	}
+
+	rates := make(map[string]float64, len(supported))
+	rates[def] = 1.0
+	for _, tok := range strings.Split(ratesCSV, ",") {
+		tok = strings.TrimSpace(tok)
+		if tok == "" {
+			continue
+		}
+		parts := strings.SplitN(tok, ":", 2)
+		if len(parts) != 2 {
+			logger.WithField("entry", tok).Warn("fx: skipping malformed FX_RATES entry (expected CCY:rate)")
+			continue
+		}
+		ccy := strings.ToUpper(strings.TrimSpace(parts[0]))
+		rate, err := strconv.ParseFloat(strings.TrimSpace(parts[1]), 64)
+		if err != nil {
+			logger.WithError(err).WithField("entry", tok).Warn("fx: skipping FX_RATES entry with unparseable rate")
+			continue
+		}
+		if rate <= 0 {
+			logger.WithField("entry", tok).Warn("fx: skipping FX_RATES entry with non-positive rate")
+			continue
+		}
+		rates[ccy] = rate
+	}
+
+	// Any supported currency without an explicit rate falls back to 1.0
+	// (i.e. shows the USD amount) and gets a loud warning so the operator
+	// notices the missing entry.
+	for _, c := range supported {
+		if _, ok := rates[c]; !ok {
+			logger.WithField("currency", c).Warn("fx: missing FX_RATES entry for supported currency; falling back to 1.0")
+			rates[c] = 1.0
+		}
+	}
+
+	return Rates{rates: rates, def: def, supported: supported}
+}
+
+// Default returns the storage / fallback currency. Every Price in the
+// system is assumed to be denominated in it.
+func (r Rates) Default() string { return r.def }
+
+// Supported returns the offered ISO codes in declared order, with the
+// default first. The returned slice is a copy — callers may mutate it
+// without affecting the underlying table.
+func (r Rates) Supported() []string {
+	out := make([]string, len(r.supported))
+	copy(out, r.supported)
+	return out
+}
+
+// IsSupported reports whether ccy is one of the offered display
+// currencies. It is the gate the /currency handler uses to reject a
+// crafted POST that tries to set an unsupported value.
+func (r Rates) IsSupported(ccy string) bool {
+	ccy = strings.ToUpper(strings.TrimSpace(ccy))
+	for _, c := range r.supported {
+		if c == ccy {
+			return true
+		}
+	}
+	return false
+}
+
+// Convert returns amountMinorUSD converted to targetCcy in that
+// currency's minor units. targetCcy == Default() (or any unknown ccy)
+// returns the input unchanged so storefront renders fall back to USD
+// transparently.
+//
+// Rounding is to the nearest minor unit via math.Round; the conversion
+// is intentionally lossy (display only) and we accept a 1-cent rounding
+// across the catalogue.
+func (r Rates) Convert(amountMinorUSD int64, targetCcy string) int64 {
+	targetCcy = strings.ToUpper(strings.TrimSpace(targetCcy))
+	if targetCcy == "" || targetCcy == r.def {
+		return amountMinorUSD
+	}
+	rate, ok := r.rates[targetCcy]
+	if !ok {
+		return amountMinorUSD
+	}
+	return int64(math.Round(float64(amountMinorUSD) * rate))
+}
+
+// Money is the formatted result of Format: the converted minor-unit
+// amount and the currency code it is denominated in. Display is the
+// human-facing "X.YY" string in major units; the Currency field is the
+// ISO code the template appends after the amount.
+type Money struct {
+	Amount   int64
+	Currency string
+}
+
+// Display formats the amount in major units as "X.YY" — the same format
+// the existing Price.Display methods return so the storefront keeps a
+// consistent look in any currency.
+func (m Money) Display() string {
+	a := m.Amount
+	sign := ""
+	if a < 0 {
+		sign = "-"
+		a = -a
+	}
+	return fmt.Sprintf("%s%d.%02d", sign, a/100, a%100)
+}
+
+// Format converts amountMinorUSD to targetCcy via r.Convert and wraps
+// the result in a Money. It is the workhorse the `money` template
+// FuncMap calls on every render.
+func Format(r Rates, amountMinorUSD int64, targetCcy string) Money {
+	targetCcy = strings.ToUpper(strings.TrimSpace(targetCcy))
+	if targetCcy == "" || !r.IsSupported(targetCcy) {
+		targetCcy = r.Default()
+	}
+	return Money{
+		Amount:   r.Convert(amountMinorUSD, targetCcy),
+		Currency: targetCcy,
+	}
+}

--- a/backend/internal/fx/fx_test.go
+++ b/backend/internal/fx/fx_test.go
@@ -1,0 +1,133 @@
+package fx_test
+
+import (
+	"testing"
+
+	"github.com/bkielbasa/go-ecommerce/backend/internal/fx"
+	"github.com/matryer/is"
+	"github.com/sirupsen/logrus"
+)
+
+func newSilentLogger() logrus.FieldLogger {
+	l := logrus.New()
+	l.SetLevel(logrus.PanicLevel)
+	return l
+}
+
+func TestRates_Defaults(t *testing.T) {
+	is := is.New(t)
+
+	r := fx.New("USD", "USD,EUR,GBP", "EUR:0.92,GBP:0.79", newSilentLogger())
+
+	is.Equal(r.Default(), "USD")
+	is.Equal(r.Supported(), []string{"USD", "EUR", "GBP"})
+	is.True(r.IsSupported("USD"))
+	is.True(r.IsSupported("eur")) // case-insensitive
+	is.True(!r.IsSupported("JPY"))
+}
+
+func TestRates_DefaultIsPrependedWhenMissingFromSupported(t *testing.T) {
+	is := is.New(t)
+
+	r := fx.New("USD", "EUR,GBP", "EUR:0.92,GBP:0.79", newSilentLogger())
+
+	// Default is always first in Supported even if the operator forgot it.
+	is.Equal(r.Supported()[0], "USD")
+	is.True(r.IsSupported("USD"))
+}
+
+func TestRates_ConvertRoundsToNearestMinorUnit(t *testing.T) {
+	is := is.New(t)
+
+	r := fx.New("USD", "USD,EUR", "EUR:0.92", newSilentLogger())
+
+	// 500 cents * 0.92 = 460 cents
+	is.Equal(r.Convert(500, "EUR"), int64(460))
+	// 199 cents * 0.92 = 183.08 -> 183 (round half-even / math.Round)
+	is.Equal(r.Convert(199, "EUR"), int64(183))
+	// 1 cent * 0.92 = 0.92 -> 1
+	is.Equal(r.Convert(1, "EUR"), int64(1))
+}
+
+func TestRates_ConvertRoundTripWithRateOne(t *testing.T) {
+	is := is.New(t)
+
+	r := fx.New("USD", "USD,EUR", "EUR:1.0", newSilentLogger())
+
+	is.Equal(r.Convert(12345, "EUR"), int64(12345))
+}
+
+func TestRates_ConvertToDefaultReturnsInputUnchanged(t *testing.T) {
+	is := is.New(t)
+
+	r := fx.New("USD", "USD,EUR", "EUR:0.5", newSilentLogger())
+
+	is.Equal(r.Convert(987, "USD"), int64(987))
+	// And the default is itself convertible (rate=1.0).
+	is.Equal(r.Convert(987, "usd"), int64(987))
+}
+
+func TestRates_ConvertUnknownCurrencyIsPassthrough(t *testing.T) {
+	is := is.New(t)
+
+	r := fx.New("USD", "USD,EUR", "EUR:0.5", newSilentLogger())
+
+	// Crafted POSTs that slip past IsSupported still produce a sensible
+	// number rather than zero.
+	is.Equal(r.Convert(1000, "JPY"), int64(1000))
+	is.Equal(r.Convert(1000, ""), int64(1000))
+}
+
+func TestRates_MissingRateDegradesToOne(t *testing.T) {
+	is := is.New(t)
+
+	// EUR is supported but absent from the rates CSV — should warn and
+	// fall back to 1.0.
+	r := fx.New("USD", "USD,EUR", "", newSilentLogger())
+
+	is.Equal(r.Convert(1234, "EUR"), int64(1234))
+}
+
+func TestRates_MalformedEntriesAreSkipped(t *testing.T) {
+	is := is.New(t)
+
+	r := fx.New("USD", "USD,EUR,GBP", "EUR:not-a-number,GBP:-1,JPY:130", newSilentLogger())
+
+	// Both EUR (unparseable) and GBP (negative) fall back to 1.0; JPY is
+	// not supported so its parsed rate never gets used.
+	is.Equal(r.Convert(100, "EUR"), int64(100))
+	is.Equal(r.Convert(100, "GBP"), int64(100))
+	is.True(!r.IsSupported("JPY"))
+}
+
+func TestFormat_BuildsMoneyInTargetCurrency(t *testing.T) {
+	is := is.New(t)
+
+	r := fx.New("USD", "USD,EUR", "EUR:0.92", newSilentLogger())
+
+	m := fx.Format(r, 500, "EUR")
+	is.Equal(m.Amount, int64(460))
+	is.Equal(m.Currency, "EUR")
+	is.Equal(m.Display(), "4.60")
+}
+
+func TestFormat_UnknownCurrencyFallsBackToDefault(t *testing.T) {
+	is := is.New(t)
+
+	r := fx.New("USD", "USD,EUR", "EUR:0.92", newSilentLogger())
+
+	m := fx.Format(r, 500, "JPY")
+	is.Equal(m.Currency, "USD")
+	is.Equal(m.Amount, int64(500))
+	is.Equal(m.Display(), "5.00")
+}
+
+func TestMoney_DisplayPadsCents(t *testing.T) {
+	is := is.New(t)
+
+	is.Equal(fx.Money{Amount: 100, Currency: "USD"}.Display(), "1.00")
+	is.Equal(fx.Money{Amount: 105, Currency: "USD"}.Display(), "1.05")
+	is.Equal(fx.Money{Amount: 0, Currency: "USD"}.Display(), "0.00")
+	is.Equal(fx.Money{Amount: 99, Currency: "USD"}.Display(), "0.99")
+	is.Equal(fx.Money{Amount: -150, Currency: "USD"}.Display(), "-1.50")
+}

--- a/backend/layout/bounded_context.go
+++ b/backend/layout/bounded_context.go
@@ -13,6 +13,7 @@ import (
 	"github.com/bkielbasa/go-ecommerce/backend/internal/mailer"
 	pcapp "github.com/bkielbasa/go-ecommerce/backend/productcatalog/app"
 	pcdomain "github.com/bkielbasa/go-ecommerce/backend/productcatalog/domain"
+	reviewsDomain "github.com/bkielbasa/go-ecommerce/backend/reviews/domain"
 	shipDomain "github.com/bkielbasa/go-ecommerce/backend/shippinginfo/domain"
 	"github.com/sirupsen/logrus"
 )
@@ -97,12 +98,27 @@ type checkoutCommands interface {
 	Refund(ctx context.Context, orderID, reason string) error
 }
 
+// reviewsService is the narrow seam the layout package needs from the
+// reviews bounded context: list / aggregate for the product page, submit /
+// has-reviewed for the customer-facing review form, and delete for the
+// admin moderation page. Mirrors *reviews/app.Service.
+type reviewsService interface {
+	ListForProduct(ctx context.Context, productID string, limit int) ([]reviewsDomain.Review, error)
+	AggregateForProducts(ctx context.Context, productIDs []string) (map[string]reviewsDomain.Aggregate, error)
+	HasReviewed(ctx context.Context, productID, customerID string) (bool, error)
+	Submit(ctx context.Context, productID, customerID, body string, rating int) error
+	Delete(ctx context.Context, id string) error
+}
+
 // checkoutQueries is the read side of the checkout context (CQRS); it returns
 // dedicated read models, not the write aggregate.
 type checkoutQueries interface {
 	Find(ctx context.Context, id string) (checkoutQuery.OrderView, error)
 	ListByCustomer(ctx context.Context, customerID string) ([]checkoutQuery.OrderSummary, error)
 	ListAll(ctx context.Context) ([]checkoutQuery.OrderSummary, error)
+	// HasPurchasedProduct gates the verified-buyer rule for the reviews
+	// context; layout passes it through a tiny adapter when wiring reviews.
+	HasPurchasedProduct(ctx context.Context, customerID, productID string) (bool, error)
 }
 
 // New wires the layout bounded context. It also initialises the process-wide
@@ -113,7 +129,7 @@ type checkoutQueries interface {
 // csrfEnabled toggles the request-level CSRF check; production always wants
 // true, and only local debugging should ever flip it to false (see
 // cmd/web/config.go CSRFEnabled for the operator-facing knob).
-func New(logger logrus.FieldLogger, cartSrv cartService, catalogSrv catalogService, authSrv authService, checkoutSrv checkoutCommands, checkoutQry checkoutQueries, shipSrv shippingService, imageStore imagestore.Store, uploadsDir string, sessionSecret []byte, cookieSecure, csrfEnabled bool, mailerSrv mailer.Mailer, baseURL string) application.BoundedContext {
+func New(logger logrus.FieldLogger, cartSrv cartService, catalogSrv catalogService, authSrv authService, checkoutSrv checkoutCommands, checkoutQry checkoutQueries, shipSrv shippingService, reviewsSrv reviewsService, imageStore imagestore.Store, uploadsDir string, sessionSecret []byte, cookieSecure, csrfEnabled bool, mailerSrv mailer.Mailer, baseURL string) application.BoundedContext {
 	store = newCookieStore(sessionSecret, cookieSecure)
 	setCSRFEnabled(csrfEnabled)
 	return &boundedContext{
@@ -124,6 +140,7 @@ func New(logger logrus.FieldLogger, cartSrv cartService, catalogSrv catalogServi
 			checkoutSrv: checkoutSrv,
 			checkoutQry: checkoutQry,
 			shipSrv:     shipSrv,
+			reviewsSrv:  reviewsSrv,
 			imageStore:  imageStore,
 			mailer:      mailerSrv,
 			baseURL:     baseURL,

--- a/backend/layout/bounded_context.go
+++ b/backend/layout/bounded_context.go
@@ -15,6 +15,7 @@ import (
 	pcdomain "github.com/bkielbasa/go-ecommerce/backend/productcatalog/domain"
 	reviewsDomain "github.com/bkielbasa/go-ecommerce/backend/reviews/domain"
 	shipDomain "github.com/bkielbasa/go-ecommerce/backend/shippinginfo/domain"
+	wishlistDomain "github.com/bkielbasa/go-ecommerce/backend/wishlist/domain"
 	"github.com/sirupsen/logrus"
 )
 
@@ -22,6 +23,7 @@ type catalogService interface {
 	AllProducts(ctx context.Context) ([]pcdomain.Product, error)
 	Newest(ctx context.Context, limit int) ([]pcdomain.Product, error)
 	Find(ctx context.Context, id string) (pcdomain.Product, error)
+	FindVariant(ctx context.Context, variantID string) (pcdomain.Product, pcdomain.Variant, error)
 	List(ctx context.Context, q pcapp.ProductQuery) ([]pcdomain.Product, error)
 	Categories(ctx context.Context) ([]pcdomain.Category, error)
 	Facets(ctx context.Context, categorySlug string) ([]pcapp.Facet, error)
@@ -110,6 +112,17 @@ type reviewsService interface {
 	Delete(ctx context.Context, id string) error
 }
 
+// wishlistService is the narrow seam the layout package needs from the
+// wishlist bounded context. Toggle drives the product-page heart button
+// (returns the new state for the htmx outerHTML swap); ListByCustomer
+// powers /account/wishlist; Contains decides which of the two button
+// states (filled vs outline heart) to render on the product page.
+type wishlistService interface {
+	Toggle(ctx context.Context, customerID, variantID string) (bool, error)
+	ListByCustomer(ctx context.Context, customerID string) ([]wishlistDomain.Item, error)
+	Contains(ctx context.Context, customerID, variantID string) (bool, error)
+}
+
 // checkoutQueries is the read side of the checkout context (CQRS); it returns
 // dedicated read models, not the write aggregate.
 type checkoutQueries interface {
@@ -129,7 +142,7 @@ type checkoutQueries interface {
 // csrfEnabled toggles the request-level CSRF check; production always wants
 // true, and only local debugging should ever flip it to false (see
 // cmd/web/config.go CSRFEnabled for the operator-facing knob).
-func New(logger logrus.FieldLogger, cartSrv cartService, catalogSrv catalogService, authSrv authService, checkoutSrv checkoutCommands, checkoutQry checkoutQueries, shipSrv shippingService, reviewsSrv reviewsService, imageStore imagestore.Store, uploadsDir string, sessionSecret []byte, cookieSecure, csrfEnabled bool, mailerSrv mailer.Mailer, baseURL string) application.BoundedContext {
+func New(logger logrus.FieldLogger, cartSrv cartService, catalogSrv catalogService, authSrv authService, checkoutSrv checkoutCommands, checkoutQry checkoutQueries, shipSrv shippingService, reviewsSrv reviewsService, wishlistSrv wishlistService, imageStore imagestore.Store, uploadsDir string, sessionSecret []byte, cookieSecure, csrfEnabled bool, mailerSrv mailer.Mailer, baseURL string) application.BoundedContext {
 	store = newCookieStore(sessionSecret, cookieSecure)
 	setCSRFEnabled(csrfEnabled)
 	return &boundedContext{
@@ -141,6 +154,7 @@ func New(logger logrus.FieldLogger, cartSrv cartService, catalogSrv catalogServi
 			checkoutQry: checkoutQry,
 			shipSrv:     shipSrv,
 			reviewsSrv:  reviewsSrv,
+			wishlistSrv: wishlistSrv,
 			imageStore:  imageStore,
 			mailer:      mailerSrv,
 			baseURL:     baseURL,

--- a/backend/layout/bounded_context.go
+++ b/backend/layout/bounded_context.go
@@ -13,6 +13,7 @@ import (
 	"github.com/bkielbasa/go-ecommerce/backend/internal/mailer"
 	pcapp "github.com/bkielbasa/go-ecommerce/backend/productcatalog/app"
 	pcdomain "github.com/bkielbasa/go-ecommerce/backend/productcatalog/domain"
+	promodomain "github.com/bkielbasa/go-ecommerce/backend/promo/domain"
 	reviewsDomain "github.com/bkielbasa/go-ecommerce/backend/reviews/domain"
 	shipDomain "github.com/bkielbasa/go-ecommerce/backend/shippinginfo/domain"
 	wishlistDomain "github.com/bkielbasa/go-ecommerce/backend/wishlist/domain"
@@ -92,12 +93,24 @@ type shippingService interface {
 
 // checkoutCommands is the write side of the checkout context (CQRS).
 type checkoutCommands interface {
-	Place(ctx context.Context, sessID, customerID, cardNumber string, shipTo checkoutDomain.Address, shipMethod checkoutDomain.ShippingMethod, payMethod checkoutDomain.PaymentMethod) (checkoutDomain.Order, error)
+	Place(ctx context.Context, sessID, customerID, cardNumber string, shipTo checkoutDomain.Address, shipMethod checkoutDomain.ShippingMethod, payMethod checkoutDomain.PaymentMethod, discount promodomain.Discount) (checkoutDomain.Order, error)
 	Cancel(ctx context.Context, orderID, customerID string) error
 	AdminCancel(ctx context.Context, orderID string) error
 	MarkShipped(ctx context.Context, orderID, carrier, trackingCode string) error
 	MarkDelivered(ctx context.Context, orderID string) error
 	Refund(ctx context.Context, orderID, reason string) error
+}
+
+// promoService is the narrow seam the layout package needs from the
+// promo bounded context. Resolve runs the live validity / per-customer
+// checks for the checkout form; the CRUD methods power the admin pages.
+type promoService interface {
+	Resolve(ctx context.Context, code, customerID string, subtotal, shippingCost int64) (promodomain.Discount, error)
+	Create(ctx context.Context, c promodomain.Code) error
+	Update(ctx context.Context, c promodomain.Code) error
+	Delete(ctx context.Context, code string) error
+	Find(ctx context.Context, code string) (promodomain.Code, error)
+	ListAll(ctx context.Context) ([]promodomain.Code, error)
 }
 
 // reviewsService is the narrow seam the layout package needs from the
@@ -142,7 +155,7 @@ type checkoutQueries interface {
 // csrfEnabled toggles the request-level CSRF check; production always wants
 // true, and only local debugging should ever flip it to false (see
 // cmd/web/config.go CSRFEnabled for the operator-facing knob).
-func New(logger logrus.FieldLogger, cartSrv cartService, catalogSrv catalogService, authSrv authService, checkoutSrv checkoutCommands, checkoutQry checkoutQueries, shipSrv shippingService, reviewsSrv reviewsService, wishlistSrv wishlistService, imageStore imagestore.Store, uploadsDir string, sessionSecret []byte, cookieSecure, csrfEnabled bool, mailerSrv mailer.Mailer, baseURL string) application.BoundedContext {
+func New(logger logrus.FieldLogger, cartSrv cartService, catalogSrv catalogService, authSrv authService, checkoutSrv checkoutCommands, checkoutQry checkoutQueries, shipSrv shippingService, reviewsSrv reviewsService, wishlistSrv wishlistService, promoSrv promoService, imageStore imagestore.Store, uploadsDir string, sessionSecret []byte, cookieSecure, csrfEnabled bool, mailerSrv mailer.Mailer, baseURL string) application.BoundedContext {
 	store = newCookieStore(sessionSecret, cookieSecure)
 	setCSRFEnabled(csrfEnabled)
 	return &boundedContext{
@@ -155,6 +168,7 @@ func New(logger logrus.FieldLogger, cartSrv cartService, catalogSrv catalogServi
 			shipSrv:     shipSrv,
 			reviewsSrv:  reviewsSrv,
 			wishlistSrv: wishlistSrv,
+			promoSrv:    promoSrv,
 			imageStore:  imageStore,
 			mailer:      mailerSrv,
 			baseURL:     baseURL,

--- a/backend/layout/bounded_context.go
+++ b/backend/layout/bounded_context.go
@@ -9,6 +9,7 @@ import (
 	checkoutDomain "github.com/bkielbasa/go-ecommerce/backend/checkout/domain"
 	checkoutQuery "github.com/bkielbasa/go-ecommerce/backend/checkout/query"
 	"github.com/bkielbasa/go-ecommerce/backend/internal/application"
+	"github.com/bkielbasa/go-ecommerce/backend/internal/fx"
 	"github.com/bkielbasa/go-ecommerce/backend/internal/imagestore"
 	"github.com/bkielbasa/go-ecommerce/backend/internal/mailer"
 	pcapp "github.com/bkielbasa/go-ecommerce/backend/productcatalog/app"
@@ -155,7 +156,7 @@ type checkoutQueries interface {
 // csrfEnabled toggles the request-level CSRF check; production always wants
 // true, and only local debugging should ever flip it to false (see
 // cmd/web/config.go CSRFEnabled for the operator-facing knob).
-func New(logger logrus.FieldLogger, cartSrv cartService, catalogSrv catalogService, authSrv authService, checkoutSrv checkoutCommands, checkoutQry checkoutQueries, shipSrv shippingService, reviewsSrv reviewsService, wishlistSrv wishlistService, promoSrv promoService, imageStore imagestore.Store, uploadsDir string, sessionSecret []byte, cookieSecure, csrfEnabled bool, mailerSrv mailer.Mailer, baseURL string) application.BoundedContext {
+func New(logger logrus.FieldLogger, cartSrv cartService, catalogSrv catalogService, authSrv authService, checkoutSrv checkoutCommands, checkoutQry checkoutQueries, shipSrv shippingService, reviewsSrv reviewsService, wishlistSrv wishlistService, promoSrv promoService, imageStore imagestore.Store, uploadsDir string, sessionSecret []byte, cookieSecure, csrfEnabled bool, mailerSrv mailer.Mailer, baseURL string, rates fx.Rates) application.BoundedContext {
 	store = newCookieStore(sessionSecret, cookieSecure)
 	setCSRFEnabled(csrfEnabled)
 	return &boundedContext{
@@ -172,6 +173,7 @@ func New(logger logrus.FieldLogger, cartSrv cartService, catalogSrv catalogServi
 			imageStore:  imageStore,
 			mailer:      mailerSrv,
 			baseURL:     baseURL,
+			rates:       rates,
 			logger:      logger,
 		},
 		uploadsDir: uploadsDir,

--- a/backend/layout/emails_test.go
+++ b/backend/layout/emails_test.go
@@ -32,6 +32,8 @@ func TestRenderOrderConfirmation(t *testing.T) {
 		"USD",
 		"",
 		"",
+		"",
+		0,
 	)
 
 	msg, err := RenderOrderConfirmation(view, "http://localhost:8080")

--- a/backend/layout/http.go
+++ b/backend/layout/http.go
@@ -46,6 +46,7 @@ type httpHandler struct {
 	checkoutSrv checkoutCommands
 	checkoutQry checkoutQueries
 	shipSrv     shippingService
+	reviewsSrv  reviewsService
 	imageStore  imagestore.Store
 	mailer      mailer.Mailer
 	baseURL     string
@@ -124,6 +125,7 @@ func (m boundedContext) MuxRegister(r *mux.Router) {
 	r.HandleFunc("/api/v1/products", observability.HTTPWrap(m.handler.AllProducts, m.logger))
 	r.HandleFunc("/product/{productID}", observability.HTTPWrap(m.handler.Product, m.logger)).Methods("GET")
 	r.HandleFunc("/product/{productID}/variant", observability.HTTPWrap(m.handler.ProductVariant, m.logger)).Methods("GET")
+	r.HandleFunc("/product/{productID}/review", observability.HTTPWrap(m.handler.SubmitReview, m.logger)).Methods("POST")
 
 	r.HandleFunc("/auth/login", observability.HTTPWrap(m.handler.Login, m.logger)).Methods("GET")
 	r.HandleFunc("/auth/login", observability.HTTPWrap(m.handler.HandleLogin, m.logger)).Methods("POST")
@@ -209,6 +211,9 @@ func (m boundedContext) MuxRegister(r *mux.Router) {
 	r.HandleFunc("/admin/orders/{orderID}", observability.HTTPWrap(m.handler.AdminOrderDetail, m.logger)).Methods("GET")
 
 	r.HandleFunc("/admin/inventory", observability.HTTPWrap(m.handler.AdminInventory, m.logger)).Methods("GET")
+
+	r.HandleFunc("/admin/reviews", observability.HTTPWrap(m.handler.AdminReviews, m.logger)).Methods("GET")
+	r.HandleFunc("/admin/reviews/{id}/delete", observability.HTTPWrap(m.handler.AdminDeleteReview, m.logger)).Methods("POST")
 }
 
 func (handler httpHandler) renderTemplate(w http.ResponseWriter, r *http.Request, templateName string, data map[string]any) {

--- a/backend/layout/http.go
+++ b/backend/layout/http.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/bkielbasa/go-ecommerce/backend/internal/fx"
 	"github.com/bkielbasa/go-ecommerce/backend/internal/imagestore"
 	"github.com/bkielbasa/go-ecommerce/backend/internal/mailer"
 	"github.com/bkielbasa/go-ecommerce/backend/internal/observability"
@@ -52,7 +53,13 @@ type httpHandler struct {
 	imageStore  imagestore.Store
 	mailer      mailer.Mailer
 	baseURL     string
-	logger      logrus.FieldLogger
+	// rates is the static, operator-configured FX table. It is shared
+	// across every render through the `money` template helper and is
+	// also exposed to the picker via the Currencies / Currency template
+	// variables. The conversion is purely a display transformation:
+	// orders stay priced in rates.Default() (USD).
+	rates  fx.Rates
+	logger logrus.FieldLogger
 }
 
 // HomePage renders the storefront landing page: a "new arrivals" grid of the
@@ -119,6 +126,10 @@ func (m boundedContext) MuxRegister(r *mux.Router) {
 	r.HandleFunc("/", m.handler.HomePage)
 	r.HandleFunc("/products", observability.HTTPWrap(m.handler.ShopPage, m.logger)).Methods("GET")
 	r.HandleFunc("/category/{slug}", observability.HTTPWrap(m.handler.CategoryPage, m.logger)).Methods("GET")
+	// Display-only currency picker. Stores the chosen ISO code on the
+	// gorilla session; conversion happens at render time through the
+	// `money` template helper. CSRF-protected by the global middleware.
+	r.HandleFunc("/currency", observability.HTTPWrap(m.handler.HandleSetCurrency, m.logger)).Methods("POST")
 
 	r.HandleFunc("/cart", observability.HTTPWrap(m.handler.Cart, m.logger)).Methods("GET")
 	r.HandleFunc("/cart/{variantID}", observability.HTTPWrap(m.handler.AddToCart, m.logger)).Methods("POST")
@@ -243,6 +254,12 @@ func (handler httpHandler) renderTemplate(w http.ResponseWriter, r *http.Request
 	partials, _ := filepath.Glob("./layout/tmpl/partials/*.gohtml")
 	files = append(files, partials...)
 
+	// Active display currency is captured once per request and closed over
+	// by the `money` helper below; that way every {{ money .X }} call
+	// inside a single render uses the same currency without the template
+	// having to thread it through every partial.
+	currency := handler.currentCurrency(r)
+
 	var ts = template.Must(template.New("").Funcs(template.FuncMap{
 		"html": func(value interface{}) template.HTML {
 			return template.HTML(fmt.Sprint(value))
@@ -250,6 +267,11 @@ func (handler httpHandler) renderTemplate(w http.ResponseWriter, r *http.Request
 		"add":      func(a, b int) int { return a + b },
 		"truncate": truncateForMeta,
 		"dict":     templateDict,
+		// money converts a minor-unit amount stored in the default
+		// currency (USD) to the customer's active display currency and
+		// formats it as "X.YY CCY". The amount stays in USD inside the
+		// database; only the rendered HTML changes.
+		"money": moneyFunc(handler.rates, currency),
 	}).ParseFiles(files...))
 
 	session, _ := store.Get(r, "ecommerce")
@@ -286,6 +308,12 @@ func (handler httpHandler) renderTemplate(w http.ResponseWriter, r *http.Request
 		navCategories = nil
 	}
 	data["NavCategories"] = navCategories
+	// Currency selection: Currency is the customer's active display
+	// currency (defaults to rates.Default()), Currencies is the list the
+	// header picker offers. Admin renders do NOT set these (they always
+	// show USD); see renderAdminTemplate.
+	data["Currency"] = currency
+	data["Currencies"] = handler.rates.Supported()
 	// SearchQuery is the value the header search input shows. It defaults to
 	// "" so every page renders the box; the search/catalog pages override it
 	// from the URL `q`.
@@ -323,13 +351,22 @@ func (handler httpHandler) renderAdminTemplate(w http.ResponseWriter, r *http.Re
 	partials, _ := filepath.Glob("./layout/tmpl/partials/*.gohtml")
 	files = append(files, partials...)
 
+	// The partials glob pulls in storefront partials (e.g. variant-box)
+	// that reference the `money` helper. Admin pages never invoke those
+	// partials, but html/template still needs every function mentioned
+	// in any parsed template to be registered at parse time — so we
+	// install a USD-fixed `money` here. The admin section is deliberately
+	// pinned to the storage currency: operators see the amount that will
+	// actually be charged, not a converted display value.
+	adminMoney := moneyFunc(handler.rates, handler.rates.Default())
 	var ts = template.Must(template.New("").Funcs(template.FuncMap{
 		"html": func(value interface{}) template.HTML {
 			return template.HTML(fmt.Sprint(value))
 		},
-		"add":  func(a, b int) int { return a + b },
-		"join": func(sep string, items []string) string { return strings.Join(items, sep) },
-		"dict": templateDict,
+		"add":   func(a, b int) int { return a + b },
+		"join":  func(sep string, items []string) string { return strings.Join(items, sep) },
+		"dict":  templateDict,
+		"money": adminMoney,
 	}).ParseFiles(files...))
 
 	session, _ := store.Get(r, "ecommerce")

--- a/backend/layout/http.go
+++ b/backend/layout/http.go
@@ -48,6 +48,7 @@ type httpHandler struct {
 	shipSrv     shippingService
 	reviewsSrv  reviewsService
 	wishlistSrv wishlistService
+	promoSrv    promoService
 	imageStore  imagestore.Store
 	mailer      mailer.Mailer
 	baseURL     string
@@ -218,6 +219,15 @@ func (m boundedContext) MuxRegister(r *mux.Router) {
 
 	r.HandleFunc("/admin/reviews", observability.HTTPWrap(m.handler.AdminReviews, m.logger)).Methods("GET")
 	r.HandleFunc("/admin/reviews/{id}/delete", observability.HTTPWrap(m.handler.AdminDeleteReview, m.logger)).Methods("POST")
+
+	// Promo codes admin: list + inline create on /admin/promo-codes; the
+	// /{code}/edit and /{code}/delete sub-paths are registered before the
+	// /{code} catch-all so the latter doesn't shadow them.
+	r.HandleFunc("/admin/promo-codes", observability.HTTPWrap(m.handler.AdminPromoCodes, m.logger)).Methods("GET")
+	r.HandleFunc("/admin/promo-codes", observability.HTTPWrap(m.handler.AdminCreatePromoCode, m.logger)).Methods("POST")
+	r.HandleFunc("/admin/promo-codes/{code}/edit", observability.HTTPWrap(m.handler.AdminEditPromoCodeForm, m.logger)).Methods("GET")
+	r.HandleFunc("/admin/promo-codes/{code}/delete", observability.HTTPWrap(m.handler.AdminDeletePromoCode, m.logger)).Methods("POST")
+	r.HandleFunc("/admin/promo-codes/{code}", observability.HTTPWrap(m.handler.AdminUpdatePromoCode, m.logger)).Methods("POST")
 }
 
 func (handler httpHandler) renderTemplate(w http.ResponseWriter, r *http.Request, templateName string, data map[string]any) {

--- a/backend/layout/http.go
+++ b/backend/layout/http.go
@@ -47,6 +47,7 @@ type httpHandler struct {
 	checkoutQry checkoutQueries
 	shipSrv     shippingService
 	reviewsSrv  reviewsService
+	wishlistSrv wishlistService
 	imageStore  imagestore.Store
 	mailer      mailer.Mailer
 	baseURL     string
@@ -156,6 +157,9 @@ func (m boundedContext) MuxRegister(r *mux.Router) {
 	r.HandleFunc("/account/addresses/{id}/default", observability.HTTPWrap(m.handler.AccountSetDefaultAddress, m.logger)).Methods("POST")
 	r.HandleFunc("/account/details", observability.HTTPWrap(m.handler.AccountDetails, m.logger)).Methods("GET")
 	r.HandleFunc("/account/details/password", observability.HTTPWrap(m.handler.AccountChangePassword, m.logger)).Methods("POST")
+	r.HandleFunc("/account/wishlist", observability.HTTPWrap(m.handler.AccountWishlist, m.logger)).Methods("GET")
+
+	r.HandleFunc("/wishlist/{variantID}/toggle", observability.HTTPWrap(m.handler.WishlistToggle, m.logger)).Methods("POST")
 
 	// Admin panel. Later phases register the /admin/products, /admin/categories,
 	// /admin/attributes and /admin/orders handlers here, all behind requireAdmin.
@@ -235,6 +239,7 @@ func (handler httpHandler) renderTemplate(w http.ResponseWriter, r *http.Request
 		},
 		"add":      func(a, b int) int { return a + b },
 		"truncate": truncateForMeta,
+		"dict":     templateDict,
 	}).ParseFiles(files...))
 
 	session, _ := store.Get(r, "ecommerce")
@@ -314,6 +319,7 @@ func (handler httpHandler) renderAdminTemplate(w http.ResponseWriter, r *http.Re
 		},
 		"add":  func(a, b int) int { return a + b },
 		"join": func(sep string, items []string) string { return strings.Join(items, sep) },
+		"dict": templateDict,
 	}).ParseFiles(files...))
 
 	session, _ := store.Get(r, "ecommerce")
@@ -341,6 +347,27 @@ func (handler httpHandler) renderAdminTemplate(w http.ResponseWriter, r *http.Re
 		handler.logger.WithError(err).Error("cannot execute admin template")
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 	}
+}
+
+// templateDict builds a map[string]any from alternating key/value
+// arguments inside a template (`dict "VariantID" .Variant.ID ...`). This
+// lets a partial be invoked with a synthesised dot, which is how the
+// "wishlist-button" partial gets its fields when it's embedded inside the
+// variant-box (the parent dot there is the page's data map, not a flat
+// {VariantID, InWishlist, LoggedIn} triple).
+func templateDict(pairs ...any) (map[string]any, error) {
+	if len(pairs)%2 != 0 {
+		return nil, fmt.Errorf("dict: expected an even number of arguments, got %d", len(pairs))
+	}
+	out := make(map[string]any, len(pairs)/2)
+	for i := 0; i < len(pairs); i += 2 {
+		key, ok := pairs[i].(string)
+		if !ok {
+			return nil, fmt.Errorf("dict: key %d is not a string (%T)", i, pairs[i])
+		}
+		out[key] = pairs[i+1]
+	}
+	return out, nil
 }
 
 func renderPartial(w http.ResponseWriter, r *http.Request, h http.HandlerFunc) string {

--- a/backend/layout/http_admin_promo.go
+++ b/backend/layout/http_admin_promo.go
@@ -1,0 +1,154 @@
+package layout
+
+import (
+	"errors"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/bkielbasa/go-ecommerce/backend/internal/https"
+	promoapp "github.com/bkielbasa/go-ecommerce/backend/promo/app"
+	promodomain "github.com/bkielbasa/go-ecommerce/backend/promo/domain"
+	"github.com/gorilla/mux"
+)
+
+// AdminPromoCodes renders the promo-codes list page with the inline
+// "create" form. The handler is admin-gated like every other /admin route.
+func (handler httpHandler) AdminPromoCodes(w http.ResponseWriter, r *http.Request) {
+	email, ok := handler.requireAdmin(w, r)
+	if !ok {
+		return
+	}
+	codes, err := handler.promoSrv.ListAll(r.Context())
+	if err != nil {
+		handler.flash(w, r, err.Error(), "error")
+		codes = nil
+	}
+	handler.renderAdminTemplate(w, r, "admin/promo_codes", map[string]any{
+		"Active": "promo-codes",
+		"Email":  email,
+		"Codes":  codes,
+	})
+}
+
+// AdminCreatePromoCode handles the create-promo-code form submission.
+func (handler httpHandler) AdminCreatePromoCode(w http.ResponseWriter, r *http.Request) {
+	if _, ok := handler.requireAdmin(w, r); !ok {
+		return
+	}
+	if err := r.ParseForm(); err != nil {
+		https.InternalError(w, "internal-error", err.Error())
+		return
+	}
+	c, err := promoCodeFromForm(r, r.FormValue("code"))
+	if err != nil {
+		handler.flash(w, r, "Invalid promo code: "+err.Error(), "error")
+		http.Redirect(w, r, "/admin/promo-codes", http.StatusSeeOther)
+		return
+	}
+	if err := handler.promoSrv.Create(r.Context(), c); err != nil {
+		if errors.Is(err, promoapp.ErrCodeAlreadyExists) {
+			handler.flash(w, r, "A promo code with that name already exists.", "error")
+		} else {
+			handler.flash(w, r, err.Error(), "error")
+		}
+	} else {
+		handler.flash(w, r, "Promo code created", "info")
+	}
+	http.Redirect(w, r, "/admin/promo-codes", http.StatusSeeOther)
+}
+
+// AdminEditPromoCodeForm renders the edit form for a single promo code.
+func (handler httpHandler) AdminEditPromoCodeForm(w http.ResponseWriter, r *http.Request) {
+	email, ok := handler.requireAdmin(w, r)
+	if !ok {
+		return
+	}
+	code := mux.Vars(r)["code"]
+	c, err := handler.promoSrv.Find(r.Context(), code)
+	if errors.Is(err, promoapp.ErrCodeNotFound) {
+		handler.flash(w, r, "Promo code not found", "error")
+		http.Redirect(w, r, "/admin/promo-codes", http.StatusSeeOther)
+		return
+	}
+	if err != nil {
+		https.InternalError(w, "internal-error", err.Error())
+		return
+	}
+	handler.renderAdminTemplate(w, r, "admin/promo_code_edit", map[string]any{
+		"Active": "promo-codes",
+		"Email":  email,
+		"Code":   c,
+	})
+}
+
+// AdminUpdatePromoCode handles the edit-promo-code form submission. The
+// code text (PK) is fixed; everything else is editable.
+func (handler httpHandler) AdminUpdatePromoCode(w http.ResponseWriter, r *http.Request) {
+	if _, ok := handler.requireAdmin(w, r); !ok {
+		return
+	}
+	if err := r.ParseForm(); err != nil {
+		https.InternalError(w, "internal-error", err.Error())
+		return
+	}
+	code := mux.Vars(r)["code"]
+	c, err := promoCodeFromForm(r, code)
+	if err != nil {
+		handler.flash(w, r, "Invalid promo code: "+err.Error(), "error")
+		http.Redirect(w, r, "/admin/promo-codes/"+code+"/edit", http.StatusSeeOther)
+		return
+	}
+	if err := handler.promoSrv.Update(r.Context(), c); err != nil {
+		handler.flash(w, r, err.Error(), "error")
+		http.Redirect(w, r, "/admin/promo-codes/"+code+"/edit", http.StatusSeeOther)
+		return
+	}
+	handler.flash(w, r, "Promo code updated", "info")
+	http.Redirect(w, r, "/admin/promo-codes", http.StatusSeeOther)
+}
+
+// AdminDeletePromoCode deletes a promo code (the cascade on
+// promo_redemption keeps the per-order ledger consistent).
+func (handler httpHandler) AdminDeletePromoCode(w http.ResponseWriter, r *http.Request) {
+	if _, ok := handler.requireAdmin(w, r); !ok {
+		return
+	}
+	code := mux.Vars(r)["code"]
+	if err := handler.promoSrv.Delete(r.Context(), code); err != nil {
+		handler.flash(w, r, err.Error(), "error")
+	} else {
+		handler.flash(w, r, "Promo code deleted", "info")
+	}
+	http.Redirect(w, r, "/admin/promo-codes", http.StatusSeeOther)
+}
+
+// promoCodeFromForm parses the admin form into a domain.Code. The code
+// text is supplied separately so the same helper drives Create (form
+// value) and Update (URL path variable).
+func promoCodeFromForm(r *http.Request, code string) (promodomain.Code, error) {
+	kind := promodomain.Kind(strings.TrimSpace(r.FormValue("kind")))
+	value, _ := strconv.ParseInt(strings.TrimSpace(r.FormValue("value")), 10, 64)
+	currency := strings.TrimSpace(r.FormValue("currency"))
+	from := parseOptionalDate(r.FormValue("valid_from"))
+	until := parseOptionalDate(r.FormValue("valid_until"))
+	maxUses, _ := strconv.Atoi(strings.TrimSpace(r.FormValue("max_uses")))
+	perCustomerMax, _ := strconv.Atoi(strings.TrimSpace(r.FormValue("per_customer_max")))
+	return promodomain.NewCode(code, kind, value, currency, from, until, maxUses, perCustomerMax)
+}
+
+// parseOptionalDate accepts an empty string (meaning "no bound") or a
+// YYYY-MM-DD HTML date input, returning a *time.Time in UTC.
+func parseOptionalDate(raw string) *time.Time {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil
+	}
+	t, err := time.Parse("2006-01-02", raw)
+	if err != nil {
+		return nil
+	}
+	t = t.UTC()
+	return &t
+}

--- a/backend/layout/http_checkout.go
+++ b/backend/layout/http_checkout.go
@@ -9,6 +9,8 @@ import (
 	checkoutDomain "github.com/bkielbasa/go-ecommerce/backend/checkout/domain"
 	"github.com/bkielbasa/go-ecommerce/backend/internal/https"
 	pcdomain "github.com/bkielbasa/go-ecommerce/backend/productcatalog/domain"
+	promoapp "github.com/bkielbasa/go-ecommerce/backend/promo/app"
+	promodomain "github.com/bkielbasa/go-ecommerce/backend/promo/domain"
 	"github.com/gorilla/mux"
 )
 
@@ -119,7 +121,31 @@ func (handler httpHandler) PlaceOrder(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	order, err := handler.checkoutSrv.Place(r.Context(), sessID, customerID, cardNumber, shipTo, method, payMethod)
+	// Resolve the promo code (if any) BEFORE calling Place. We deliberately
+	// re-read the cart here to derive the live subtotal — the checkout
+	// service will read it again, but the promo Resolve call needs the
+	// subtotal NOW to compute the discount amount for the eventual
+	// OrderPlaced event. A rejected code never reaches checkoutSrv.Place;
+	// the customer gets a flash message and the form re-renders.
+	discount := promodomain.Discount{}
+	promoCode := strings.TrimSpace(r.FormValue("promo_code"))
+	if promoCode != "" {
+		cart, cartErr := handler.cartSrv.Get(r.Context(), sessID)
+		if cartErr != nil || cart == nil || len(cart.Items()) == 0 {
+			http.Redirect(w, r, "/cart", http.StatusSeeOther)
+			return
+		}
+		subtotal := cart.TotalPrice().Amount()
+		d, perr := handler.promoSrv.Resolve(r.Context(), promoCode, customerID, subtotal, method.Cost())
+		if perr != nil {
+			handler.flash(w, r, promoCodeErrorMessage(perr), "error")
+			http.Redirect(w, r, "/checkout", http.StatusSeeOther)
+			return
+		}
+		discount = d
+	}
+
+	order, err := handler.checkoutSrv.Place(r.Context(), sessID, customerID, cardNumber, shipTo, method, payMethod, discount)
 	if errors.Is(err, checkoutDomain.ErrCartEmpty) {
 		http.Redirect(w, r, "/cart", http.StatusSeeOther)
 		return
@@ -181,6 +207,26 @@ func (handler httpHandler) Order(w http.ResponseWriter, r *http.Request) {
 		"Order":     order,
 		"CanCancel": canCancel,
 	})
+}
+
+// promoCodeErrorMessage turns a promo/app sentinel error into a
+// customer-facing flash. Anything we don't recognise falls back to a
+// neutral "invalid promo code" so internal storage errors do not leak.
+func promoCodeErrorMessage(err error) string {
+	switch {
+	case errors.Is(err, promoapp.ErrCodeNotFound):
+		return "That promo code isn't recognised."
+	case errors.Is(err, promoapp.ErrCodeExpired):
+		return "That promo code is not currently active."
+	case errors.Is(err, promoapp.ErrCodeMaxUsesReached):
+		return "That promo code has reached its redemption limit."
+	case errors.Is(err, promoapp.ErrCodeCustomerLimit):
+		return "You've already used that promo code."
+	case errors.Is(err, promoapp.ErrCodeAnonymous):
+		return "Please sign in before using a promo code."
+	default:
+		return "That promo code couldn't be applied."
+	}
 }
 
 func (handler httpHandler) CancelOrder(w http.ResponseWriter, r *http.Request) {

--- a/backend/layout/http_currency.go
+++ b/backend/layout/http_currency.go
@@ -1,0 +1,119 @@
+package layout
+
+import (
+	"html"
+	"html/template"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/bkielbasa/go-ecommerce/backend/internal/fx"
+)
+
+// moneyFunc returns the template FuncMap callback bound to the active
+// rates table and the customer's chosen display currency. It is the one
+// place the conversion+format logic lives — both renderTemplate and the
+// HTMX-only fragment renderers (e.g. AllProducts) install the same
+// helper so {{ money .X }} works uniformly everywhere on the storefront.
+//
+// The helper assumes the input is a minor-unit amount in rates.Default()
+// (USD). Conversion is a render transformation; orders are placed and
+// charged in the default currency regardless of what the helper renders.
+func moneyFunc(rates fx.Rates, currency string) func(int64) template.HTML {
+	return func(minorUSD int64) template.HTML {
+		m := fx.Format(rates, minorUSD, currency)
+		// Both pieces are escaped before concatenation. Display() is a
+		// numeric "X.YY" string and Currency is an ISO code, but
+		// passing them through html.EscapeString keeps the helper
+		// XSS-safe even if a future call site sneaks in a hand-built
+		// string.
+		return template.HTML(html.EscapeString(m.Display()) + " " + html.EscapeString(m.Currency))
+	}
+}
+
+// currencySessionKey is the gorilla/sessions key under which the
+// customer's chosen display currency is stored. The default cookie
+// MaxAge (30 days) is fine — the preference is sticky across visits
+// but expires naturally if the shopper goes away.
+const currencySessionKey = "currency"
+
+// currentCurrency returns the customer's active display currency. It
+// reads the session value first and falls back to the configured
+// default when the session has no preference, is unreadable, or carries
+// a value that is no longer supported (the operator may have removed a
+// currency from SUPPORTED_CURRENCIES since the cookie was set).
+func (handler httpHandler) currentCurrency(r *http.Request) string {
+	session, err := store.Get(r, "ecommerce")
+	if err != nil {
+		return handler.rates.Default()
+	}
+	if v, ok := session.Values[currencySessionKey].(string); ok && v != "" {
+		v = strings.ToUpper(v)
+		if handler.rates.IsSupported(v) {
+			return v
+		}
+	}
+	return handler.rates.Default()
+}
+
+// HandleSetCurrency processes the header currency-picker POST. It
+// accepts a `currency` form field, validates it against the supported
+// list, persists the choice on the session, and redirects the customer
+// back to the page they came from (or `/` if no Referer was sent).
+//
+// CSRF is enforced by the global middleware: the picker form embeds the
+// hidden csrf_token input on every render.
+func (handler httpHandler) HandleSetCurrency(w http.ResponseWriter, r *http.Request) {
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, "bad request", http.StatusBadRequest)
+		return
+	}
+
+	chosen := strings.ToUpper(strings.TrimSpace(r.PostFormValue("currency")))
+	if chosen == "" || !handler.rates.IsSupported(chosen) {
+		// Unknown / unsupported codes are silently ignored — the
+		// picker only renders supported codes, so this only fires
+		// when someone is crafting a POST by hand.
+		http.Redirect(w, r, safeRedirectTarget(r), http.StatusSeeOther)
+		return
+	}
+
+	session, err := store.Get(r, "ecommerce")
+	if err != nil {
+		handler.logger.WithError(err).Warn("currency picker: cannot read session")
+		http.Redirect(w, r, safeRedirectTarget(r), http.StatusSeeOther)
+		return
+	}
+	session.Values[currencySessionKey] = chosen
+	if err := session.Save(r, w); err != nil {
+		handler.logger.WithError(err).Error("currency picker: cannot save session")
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+
+	http.Redirect(w, r, safeRedirectTarget(r), http.StatusSeeOther)
+}
+
+// safeRedirectTarget returns the Referer path the picker should send
+// the shopper back to. We only accept same-origin Referers (relative
+// paths or URLs whose Host matches the request) so an attacker cannot
+// turn the picker into an open redirect.
+func safeRedirectTarget(r *http.Request) string {
+	ref := r.Header.Get("Referer")
+	if ref == "" {
+		return "/"
+	}
+	u, err := url.Parse(ref)
+	if err != nil {
+		return "/"
+	}
+	// Same-host (or relative) Referers are safe to send the user back to.
+	if u.Host != "" && u.Host != r.Host {
+		return "/"
+	}
+	path := u.RequestURI()
+	if path == "" {
+		return "/"
+	}
+	return path
+}

--- a/backend/layout/http_product.go
+++ b/backend/layout/http_product.go
@@ -173,6 +173,18 @@ func (handler httpHandler) Product(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Wishlist state for the currently-resolved variant drives the
+	// heart-button render. Anonymous visitors see the "log in to save"
+	// hint regardless of state, so we skip the lookup for them.
+	inWishlist := false
+	if customerID != "" && !variant.IsZero() {
+		saved, wErr := handler.wishlistSrv.Contains(r.Context(), customerID, variant.ID())
+		if wErr != nil {
+			handler.logger.WithError(wErr).Warn("cannot check wishlist state")
+		}
+		inWishlist = saved
+	}
+
 	handler.renderTemplate(w, r, "productCatalog/show", map[string]any{
 		"Product":         product,
 		"Variant":         variant,
@@ -180,6 +192,7 @@ func (handler httpHandler) Product(w http.ResponseWriter, r *http.Request) {
 		"Aggregate":       aggregate,
 		"CanReview":       canReview,
 		"AlreadyReviewed": alreadyReviewed,
+		"InWishlist":      inWishlist,
 	})
 }
 
@@ -200,10 +213,29 @@ func (handler httpHandler) ProductVariant(w http.ResponseWriter, r *http.Request
 	}
 	variant, _ := product.ResolveVariant(selected)
 
-	ts := template.Must(template.New("").ParseGlob("./layout/tmpl/partials/*.gohtml"))
+	// Re-check wishlist state for the newly-resolved variant so the heart
+	// button inside the variant-box partial reflects the per-variant
+	// bookmark. Anonymous browsers skip the lookup — they render the
+	// "log in to save" hint regardless.
+	customerID := handler.currentCustomerID(r)
+	loggedIn := customerID != ""
+	inWishlist := false
+	if loggedIn && !variant.IsZero() {
+		saved, wErr := handler.wishlistSrv.Contains(r.Context(), customerID, variant.ID())
+		if wErr != nil {
+			handler.logger.WithError(wErr).Warn("cannot check wishlist state")
+		}
+		inWishlist = saved
+	}
+
+	ts := template.Must(template.New("").Funcs(template.FuncMap{
+		"dict": templateDict,
+	}).ParseGlob("./layout/tmpl/partials/*.gohtml"))
 	if err := ts.ExecuteTemplate(w, "variant-response", map[string]any{
 		"Variant":     variant,
 		"ProductName": product.Name(),
+		"LoggedIn":    loggedIn,
+		"InWishlist":  inWishlist,
 	}); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}

--- a/backend/layout/http_product.go
+++ b/backend/layout/http_product.go
@@ -135,9 +135,51 @@ func (handler httpHandler) Product(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Reviews block: aggregate badge, list of recent reviews, and the
+	// CanReview / AlreadyReviewed flags that decide whether to render the
+	// submission form. All three calls degrade gracefully — a failure in
+	// the reviews service must never block the product page from loading.
+	productID := string(product.ID())
+	reviews, err := handler.reviewsSrv.ListForProduct(r.Context(), productID, 20)
+	if err != nil {
+		handler.logger.WithError(err).Warn("cannot list reviews for product")
+		reviews = nil
+	}
+	aggMap, err := handler.reviewsSrv.AggregateForProducts(r.Context(), []string{productID})
+	if err != nil {
+		handler.logger.WithError(err).Warn("cannot aggregate reviews for product")
+		aggMap = nil
+	}
+	aggregate := aggMap[productID]
+
+	customerID := handler.currentCustomerID(r)
+	canReview := false
+	alreadyReviewed := false
+	if customerID != "" {
+		// CanReview is "the buyer has purchased this product"; we ask the
+		// checkout query directly so the rendered hint matches the same
+		// check Submit enforces.
+		bought, qErr := handler.checkoutQry.HasPurchasedProduct(r.Context(), customerID, productID)
+		if qErr != nil {
+			handler.logger.WithError(qErr).Warn("cannot verify purchase for review form")
+		}
+		canReview = bought
+		if canReview {
+			done, hErr := handler.reviewsSrv.HasReviewed(r.Context(), productID, customerID)
+			if hErr != nil {
+				handler.logger.WithError(hErr).Warn("cannot check existing review")
+			}
+			alreadyReviewed = done
+		}
+	}
+
 	handler.renderTemplate(w, r, "productCatalog/show", map[string]any{
-		"Product": product,
-		"Variant": variant,
+		"Product":         product,
+		"Variant":         variant,
+		"Reviews":         reviews,
+		"Aggregate":       aggregate,
+		"CanReview":       canReview,
+		"AlreadyReviewed": alreadyReviewed,
 	})
 }
 

--- a/backend/layout/http_product.go
+++ b/backend/layout/http_product.go
@@ -85,6 +85,10 @@ func (handler httpHandler) AllProducts(w http.ResponseWriter, r *http.Request) {
 		"./layout/tmpl/productCatalog/allProducts.gohtml",
 	}
 
+	// The grid fragment uses {{ money .PriceFrom.Amount }} to render the
+	// price in the customer's selected display currency. We bind the
+	// same FuncMap renderTemplate installs so the HTMX-only grid keeps
+	// parity with the full-page render path.
 	var ts = template.Must(template.New("").Funcs(template.FuncMap{
 		"html": func(value interface{}) template.HTML {
 			return template.HTML(fmt.Sprint(value))
@@ -92,6 +96,7 @@ func (handler httpHandler) AllProducts(w http.ResponseWriter, r *http.Request) {
 		"add": func(a, b string) float64 {
 			return 666
 		},
+		"money": moneyFunc(handler.rates, handler.currentCurrency(r)),
 	}).ParseFiles(files...))
 	err = ts.ExecuteTemplate(w, "allProducts.gohtml", resp)
 	if err != nil {
@@ -228,8 +233,14 @@ func (handler httpHandler) ProductVariant(w http.ResponseWriter, r *http.Request
 		inWishlist = saved
 	}
 
+	// The variant-response fragment embeds the variant-box partial, which
+	// renders the price via {{ money .Variant.Price.Amount }}. We have to
+	// install the same currency-aware helper renderTemplate uses so the
+	// HTMX swap doesn't fail with an "undefined function: money" parse
+	// error at execute time.
 	ts := template.Must(template.New("").Funcs(template.FuncMap{
-		"dict": templateDict,
+		"dict":  templateDict,
+		"money": moneyFunc(handler.rates, handler.currentCurrency(r)),
 	}).ParseGlob("./layout/tmpl/partials/*.gohtml"))
 	if err := ts.ExecuteTemplate(w, "variant-response", map[string]any{
 		"Variant":     variant,

--- a/backend/layout/http_reviews.go
+++ b/backend/layout/http_reviews.go
@@ -1,0 +1,129 @@
+package layout
+
+import (
+	"errors"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/bkielbasa/go-ecommerce/backend/internal/https"
+	reviewsApp "github.com/bkielbasa/go-ecommerce/backend/reviews/app"
+	reviewsDomain "github.com/bkielbasa/go-ecommerce/backend/reviews/domain"
+	"github.com/gorilla/mux"
+)
+
+// SubmitReview handles POST /product/{productID}/review. It requires a
+// logged-in customer (anonymous browsers are bounced to the login page) and
+// delegates the verified-buyer / duplicate-review checks to the reviews
+// service, surfacing failure modes as friendly flash messages. On success
+// the user is redirected back to the product page so the new review shows up
+// in the list immediately.
+func (handler httpHandler) SubmitReview(w http.ResponseWriter, r *http.Request) {
+	customerID, ok := handler.requireLogin(w, r)
+	if !ok {
+		return
+	}
+	productID := mux.Vars(r)["productID"]
+	if err := r.ParseForm(); err != nil {
+		https.InternalError(w, "internal-error", err.Error())
+		return
+	}
+	body := strings.TrimSpace(r.FormValue("body"))
+	rating, _ := strconv.Atoi(strings.TrimSpace(r.FormValue("rating")))
+
+	err := handler.reviewsSrv.Submit(r.Context(), productID, customerID, body, rating)
+	switch {
+	case errors.Is(err, reviewsApp.ErrNotVerifiedBuyer):
+		handler.flash(w, r, "Only verified buyers can leave a review.", "error")
+	case errors.Is(err, reviewsApp.ErrDuplicateReview):
+		handler.flash(w, r, "You have already reviewed this product.", "error")
+	case errors.Is(err, reviewsDomain.ErrInvalidReview):
+		handler.flash(w, r, err.Error(), "error")
+	case err != nil:
+		// Validation errors from domain.NewReview also flow here (they
+		// don't wrap ErrInvalidReview today). Surfacing the message is
+		// fine since it's deterministic ("rating must be between 1 and
+		// 5" etc.).
+		handler.flash(w, r, err.Error(), "error")
+	default:
+		handler.flash(w, r, "Thanks for your review!", "info")
+	}
+	http.Redirect(w, r, "/product/"+productID+"#reviews", http.StatusSeeOther)
+}
+
+// adminReviewRow is one row in the admin moderation table — a review plus
+// the catalogue product it belongs to. The struct is exported (capitalised
+// fields) so the html/template package can access its members.
+type adminReviewRow struct {
+	Review      reviewsDomain.Review
+	ProductID   string
+	ProductName string
+}
+
+// AdminReviews renders the moderation table. Newest first across all
+// products; each row gets a small POST form that soft-deletes the review.
+func (handler httpHandler) AdminReviews(w http.ResponseWriter, r *http.Request) {
+	email, ok := handler.requireAdmin(w, r)
+	if !ok {
+		return
+	}
+	// We do not have a global ListAll on the reviews service — that's an
+	// admin-only need and the rest of the app only reads per-product. To
+	// keep the service surface small we list per-product across the
+	// catalogue. For small/medium stores this is fine; if it became hot
+	// we'd add a dedicated query.
+	products, err := handler.catalogSrv.AllProducts(r.Context())
+	if err != nil {
+		https.InternalError(w, "internal-error", err.Error())
+		return
+	}
+	var rows []adminReviewRow
+	for _, p := range products {
+		list, err := handler.reviewsSrv.ListForProduct(r.Context(), string(p.ID()), 100)
+		if err != nil {
+			handler.logger.WithError(err).Warn("cannot list reviews for product")
+			continue
+		}
+		for _, rv := range list {
+			rows = append(rows, adminReviewRow{Review: rv, ProductID: string(p.ID()), ProductName: p.Name()})
+		}
+	}
+	// Newest first across products.
+	sortReviewRowsNewestFirst(rows)
+	handler.renderAdminTemplate(w, r, "admin/reviews", map[string]any{
+		"Active": "reviews",
+		"Email":  email,
+		"Rows":   rows,
+	})
+}
+
+// AdminDeleteReview soft-deletes a review by id and bounces back to the
+// moderation page. Admin-only; non-admins are rejected by requireAdmin.
+func (handler httpHandler) AdminDeleteReview(w http.ResponseWriter, r *http.Request) {
+	if _, ok := handler.requireAdmin(w, r); !ok {
+		return
+	}
+	id := mux.Vars(r)["id"]
+	if err := handler.reviewsSrv.Delete(r.Context(), id); err != nil {
+		https.InternalError(w, "internal-error", err.Error())
+		return
+	}
+	handler.flash(w, r, "Review removed.", "info")
+	http.Redirect(w, r, "/admin/reviews", http.StatusSeeOther)
+}
+
+// sortReviewRowsNewestFirst sorts an admin review table in-place by
+// CreatedAt descending. Pulled out of AdminReviews so the handler reads
+// linearly.
+func sortReviewRowsNewestFirst(rows []adminReviewRow) {
+	// Simple insertion sort over a typically-small list keeps us off
+	// sort.Slice (which would require a captured closure inside the
+	// handler) and stays easy to read.
+	for i := 1; i < len(rows); i++ {
+		j := i
+		for j > 0 && rows[j-1].Review.CreatedAt().Before(rows[j].Review.CreatedAt()) {
+			rows[j-1], rows[j] = rows[j], rows[j-1]
+			j--
+		}
+	}
+}

--- a/backend/layout/http_wishlist.go
+++ b/backend/layout/http_wishlist.go
@@ -1,0 +1,125 @@
+package layout
+
+import (
+	"errors"
+	"html/template"
+	"net/http"
+	"path/filepath"
+
+	"github.com/bkielbasa/go-ecommerce/backend/internal/https"
+	pcdomain "github.com/bkielbasa/go-ecommerce/backend/productcatalog/domain"
+	"github.com/gorilla/mux"
+)
+
+// wishlistEntry is the view-model the /account/wishlist page renders: one
+// row per saved variant, with the catalogue data hydrated so the template
+// can show a product card (thumbnail, name, price, link). The fields are
+// exported so html/template can read them.
+type wishlistEntry struct {
+	VariantID   string
+	ProductID   string
+	ProductName string
+	Thumbnail   string
+	Price       pcdomain.Price
+	InStock     bool
+}
+
+// WishlistToggle is the HTMX-driven endpoint behind the heart button on
+// the product page. It flips the (customer, variant) bookmark and
+// responds with the button in its new state — htmx swaps the original
+// button element with the response (outerHTML) so the page reflects the
+// change without a reload. Login-required: anonymous visitors are sent to
+// the login page (the button itself is rendered as a "log in to save"
+// hint for them, so this branch only ever fires after cookie expiry).
+func (handler httpHandler) WishlistToggle(w http.ResponseWriter, r *http.Request) {
+	cid, ok := handler.requireLogin(w, r)
+	if !ok {
+		return
+	}
+	variantID := mux.Vars(r)["variantID"]
+	added, err := handler.wishlistSrv.Toggle(r.Context(), cid, variantID)
+	if err != nil {
+		handler.logger.WithError(err).Warn("wishlist toggle failed")
+		https.InternalError(w, "internal-error", err.Error())
+		return
+	}
+	// HTMX-driven submits (the product-page heart button) want the new
+	// button fragment in their outerHTML swap. Plain form submits (the
+	// "remove" form on /account/wishlist) want to navigate back to where
+	// they came from — typically the wishlist page itself, so the
+	// just-removed row disappears.
+	if r.Header.Get("HX-Request") == "true" {
+		renderWishlistButton(w, variantID, added, true)
+		return
+	}
+	dest := r.Referer()
+	if dest == "" {
+		dest = "/account/wishlist"
+	}
+	http.Redirect(w, r, dest, http.StatusSeeOther)
+}
+
+// AccountWishlist renders the customer's wishlist page. Each item is
+// hydrated through catalogSrv.FindVariant so the template can show a
+// product card; variants whose product has been deleted are skipped (the
+// table's FK cascade will catch up on the next admin write, this is
+// belt-and-braces against an in-flight delete).
+func (handler httpHandler) AccountWishlist(w http.ResponseWriter, r *http.Request) {
+	cid, ok := handler.requireLogin(w, r)
+	if !ok {
+		return
+	}
+	items, err := handler.wishlistSrv.ListByCustomer(r.Context(), cid)
+	if err != nil {
+		https.InternalError(w, "internal-error", err.Error())
+		return
+	}
+
+	entries := make([]wishlistEntry, 0, len(items))
+	for _, it := range items {
+		product, variant, ferr := handler.catalogSrv.FindVariant(r.Context(), it.VariantID())
+		if ferr != nil {
+			if errors.Is(ferr, pcdomain.ErrProductNotFound) {
+				continue
+			}
+			handler.logger.WithError(ferr).WithField("variant_id", it.VariantID()).Warn("cannot hydrate wishlist item")
+			continue
+		}
+		thumb := product.Thumbnail()
+		if variant.Image() != "" {
+			thumb = variant.Image()
+		}
+		entries = append(entries, wishlistEntry{
+			VariantID:   variant.ID(),
+			ProductID:   string(product.ID()),
+			ProductName: product.Name(),
+			Thumbnail:   thumb,
+			Price:       variant.Price(),
+			InStock:     variant.InStock(),
+		})
+	}
+
+	handler.renderTemplate(w, r, "account/wishlist", map[string]any{
+		"Active":  "wishlist",
+		"Email":   cid,
+		"Entries": entries,
+	})
+}
+
+// renderWishlistButton emits the heart-button fragment for HTMX outerHTML
+// swaps. The same fragment definition is invoked from the product-page
+// template (via the "wishlist-button" partial); routing the toggle
+// response through the same template keeps the two button states in sync.
+func renderWishlistButton(w http.ResponseWriter, variantID string, inWishlist bool, loggedIn bool) {
+	files, _ := filepath.Glob("./layout/tmpl/partials/*.gohtml")
+	ts := template.Must(template.New("").Funcs(template.FuncMap{
+		"dict": templateDict,
+	}).ParseFiles(files...))
+	if err := ts.ExecuteTemplate(w, "wishlist-button", map[string]any{
+		"VariantID":  variantID,
+		"InWishlist": inWishlist,
+		"LoggedIn":   loggedIn,
+	}); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}

--- a/backend/layout/http_wishlist.go
+++ b/backend/layout/http_wishlist.go
@@ -49,7 +49,7 @@ func (handler httpHandler) WishlistToggle(w http.ResponseWriter, r *http.Request
 	// they came from — typically the wishlist page itself, so the
 	// just-removed row disappears.
 	if r.Header.Get("HX-Request") == "true" {
-		renderWishlistButton(w, variantID, added, true)
+		handler.renderWishlistButton(w, r, variantID, added, true)
 		return
 	}
 	dest := r.Referer()
@@ -110,10 +110,17 @@ func (handler httpHandler) AccountWishlist(w http.ResponseWriter, r *http.Reques
 // swaps. The same fragment definition is invoked from the product-page
 // template (via the "wishlist-button" partial); routing the toggle
 // response through the same template keeps the two button states in sync.
-func renderWishlistButton(w http.ResponseWriter, variantID string, inWishlist bool, loggedIn bool) {
+//
+// We parse the whole partials glob (rather than just the wishlist-button
+// file) because the partials cross-reference each other; html/template
+// requires every {{ funcName }} mentioned in any parsed template to be
+// registered, so the `money` helper that variant-box.gohtml uses must
+// be wired here even though only the wishlist button executes.
+func (handler httpHandler) renderWishlistButton(w http.ResponseWriter, r *http.Request, variantID string, inWishlist bool, loggedIn bool) {
 	files, _ := filepath.Glob("./layout/tmpl/partials/*.gohtml")
 	ts := template.Must(template.New("").Funcs(template.FuncMap{
-		"dict": templateDict,
+		"dict":  templateDict,
+		"money": moneyFunc(handler.rates, handler.currentCurrency(r)),
 	}).ParseFiles(files...))
 	if err := ts.ExecuteTemplate(w, "wishlist-button", map[string]any{
 		"VariantID":  variantID,

--- a/backend/layout/static/main.css
+++ b/backend/layout/static/main.css
@@ -152,6 +152,34 @@ main {
   outline: 0;
 }
 
+/* ---------- header: currency picker ---------- */
+/*
+  Display-only multi-currency selector. The <select> mimics the search
+  input's understated underline-only style so it doesn't compete with
+  the brand mark or the primary nav. JS-free submit on change keeps
+  the experience a single click.
+*/
+.currency-switch {
+  margin: 0;
+}
+.currency-switch select {
+  border: 0;
+  border-bottom: 1px solid var(--rule);
+  background: transparent;
+  color: var(--fg-muted);
+  font: inherit;
+  padding: var(--space-1) 0;
+  letter-spacing: .02em;
+  text-transform: uppercase;
+  cursor: pointer;
+}
+.currency-switch select:focus,
+.currency-switch select:focus-visible {
+  border-bottom-color: var(--fg);
+  color: var(--fg);
+  outline: 0;
+}
+
 /* ---------- accessibility: visually-hidden ---------- */
 /*
   Off-screen but still announced by screen readers. Use for labels that the

--- a/backend/layout/tmpl/account/orders.gohtml
+++ b/backend/layout/tmpl/account/orders.gohtml
@@ -26,7 +26,7 @@
                 </td>
                 <td class="muted">{{$order.PlacedAt.Format "Jan 2, 2006"}}</td>
                 <td><span class="order-status order-status--{{$order.Status}}">{{$order.Status}}</span></td>
-                <td class="col-total">{{$order.TotalDisplay}} {{$order.TotalCurrency}}</td>
+                <td class="col-total">{{ money $order.TotalAmount }}</td>
               </tr>
             {{end}}
           </tbody>

--- a/backend/layout/tmpl/account/overview.gohtml
+++ b/backend/layout/tmpl/account/overview.gohtml
@@ -13,7 +13,7 @@
           <h2 class="account-card__title">latest order</h2>
           {{if .LatestOrder.ID}}
             <p><a href="/order/{{.LatestOrder.ID}}" class="order-row__id">{{.LatestOrder.ID}}</a></p>
-            <p class="muted">{{.LatestOrder.PlacedAt.Format "Jan 2, 2006"}} &middot; {{.LatestOrder.TotalDisplay}} {{.LatestOrder.TotalCurrency}} &middot; {{.LatestOrder.Status}}</p>
+            <p class="muted">{{.LatestOrder.PlacedAt.Format "Jan 2, 2006"}} &middot; {{ money .LatestOrder.TotalAmount }} &middot; {{.LatestOrder.Status}}</p>
             <p><a href="/account/orders">all orders &rarr;</a></p>
           {{else}}
             <p class="muted">no orders yet. <a href="/">browse products</a></p>

--- a/backend/layout/tmpl/account/wishlist.gohtml
+++ b/backend/layout/tmpl/account/wishlist.gohtml
@@ -1,0 +1,46 @@
+{{define "title"}}Wishlist · {{.SiteName}}{{end}}
+{{define "description"}}The products you have saved for later.{{end}}
+
+{{define "main"}}
+  <h1 class="page-title">account</h1>
+  <div class="account">
+    <aside class="account__side">{{template "account-nav" .}}</aside>
+    <div class="account__content">
+      <h2 class="account-card__title">wishlist</h2>
+      {{if .Entries}}
+        <div class="product-grid">
+          {{range $e := .Entries}}
+            <div class="product-card wishlist-card">
+              <a class="wishlist-card__link" href="/product/{{$e.ProductID}}">
+                {{if $e.Thumbnail}}
+                  <img class="product-card__image"
+                       src="{{$e.Thumbnail}}"
+                       alt="{{$e.ProductName}}"
+                       loading="lazy"
+                       width="800" height="800">
+                {{end}}
+                <h3 class="product-card__name">{{$e.ProductName}}</h3>
+                <p class="product-card__price">{{$e.Price.Display}} {{$e.Price.Currency}}</p>
+              </a>
+              {{- /* The remove form POSTs to the same toggle endpoint the
+                     product page uses: since the item is currently in the
+                     wishlist, toggling removes it. Standard form POST so the
+                     page reloads and the row disappears without needing JS. */ -}}
+              <form class="wishlist-card__remove" method="post" action="/wishlist/{{$e.VariantID}}/toggle">
+                <input type="hidden" name="csrf_token" value="{{$.CSRFToken}}">
+                <button type="submit" class="btn btn--ghost" aria-label="remove from wishlist">
+                  <span aria-hidden="true">&#9829;</span> remove
+                </button>
+              </form>
+              {{if not $e.InStock}}
+                <p class="muted wishlist-card__stock">out of stock</p>
+              {{end}}
+            </div>
+          {{end}}
+        </div>
+      {{else}}
+        <p class="cart-empty">your wishlist is empty. <a href="/">browse products</a></p>
+      {{end}}
+    </div>
+  </div>
+{{end}}

--- a/backend/layout/tmpl/account/wishlist.gohtml
+++ b/backend/layout/tmpl/account/wishlist.gohtml
@@ -20,7 +20,7 @@
                        width="800" height="800">
                 {{end}}
                 <h3 class="product-card__name">{{$e.ProductName}}</h3>
-                <p class="product-card__price">{{$e.Price.Display}} {{$e.Price.Currency}}</p>
+                <p class="product-card__price">{{ money $e.Price.Amount }}</p>
               </a>
               {{- /* The remove form POSTs to the same toggle endpoint the
                      product page uses: since the item is currently in the

--- a/backend/layout/tmpl/admin/order_detail.gohtml
+++ b/backend/layout/tmpl/admin/order_detail.gohtml
@@ -35,6 +35,14 @@
               <td colspan="3">subtotal</td>
               <td class="col-total">{{.Order.SubtotalDisplay}} {{.Order.TotalCurrency}}</td>
             </tr>
+            {{if or (gt .Order.DiscountAmount 0) .Order.DiscountCode}}
+              <tr>
+                <td colspan="3">discount{{with .Order.DiscountCode}} &middot; <code>{{.}}</code>{{end}}</td>
+                <td class="col-total">
+                  {{if gt .Order.DiscountAmount 0}}-{{.Order.DiscountDisplay}} {{.Order.TotalCurrency}}{{else}}free shipping{{end}}
+                </td>
+              </tr>
+            {{end}}
             {{if gt .Order.TaxAmount 0}}
               <tr>
                 <td colspan="3">tax</td>

--- a/backend/layout/tmpl/admin/promo_code_edit.gohtml
+++ b/backend/layout/tmpl/admin/promo_code_edit.gohtml
@@ -1,0 +1,25 @@
+{{define "main"}}
+  <p class="crumbs"><a href="/admin/promo-codes">promo codes</a> / edit</p>
+  <h2 class="account-card__title">edit promo code <code>{{.Code.CodeText}}</code></h2>
+
+  <form class="form" method="post" action="/admin/promo-codes/{{.Code.CodeText}}">
+    <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
+    <div class="field">
+      <label for="p-kind">kind</label>
+      <select id="p-kind" name="kind">
+        <option value="percent" {{if eq (printf "%s" .Code.Kind) "percent"}}selected{{end}}>percent (1..100)</option>
+        <option value="fixed" {{if eq (printf "%s" .Code.Kind) "fixed"}}selected{{end}}>fixed amount (minor units)</option>
+        <option value="free_shipping" {{if eq (printf "%s" .Code.Kind) "free_shipping"}}selected{{end}}>free shipping</option>
+      </select>
+    </div>
+    <div class="field"><label for="p-value">value</label><input id="p-value" name="value" type="number" value="{{.Code.ValueMinor}}" min="0"></div>
+    <div class="field"><label for="p-ccy">currency</label><input id="p-ccy" name="currency" value="{{.Code.Currency}}" maxlength="3"></div>
+    <div class="field"><label for="p-from">valid from (YYYY-MM-DD, optional)</label><input id="p-from" name="valid_from" type="date" value="{{with .Code.ValidFrom}}{{.Format "2006-01-02"}}{{end}}"></div>
+    <div class="field"><label for="p-until">valid until (YYYY-MM-DD, optional)</label><input id="p-until" name="valid_until" type="date" value="{{with .Code.ValidUntil}}{{.Format "2006-01-02"}}{{end}}"></div>
+    <div class="field"><label for="p-max">max uses (0 = unlimited)</label><input id="p-max" name="max_uses" type="number" value="{{.Code.MaxUses}}" min="0"></div>
+    <div class="field"><label for="p-percust">per-customer max (0 = unlimited)</label><input id="p-percust" name="per_customer_max" type="number" value="{{.Code.PerCustomerMax}}" min="0"></div>
+    <p class="muted">used so far: {{.Code.UsedCount}}</p>
+    <button type="submit" class="btn">save changes</button>
+    <p class="form__aside"><a href="/admin/promo-codes">&larr; back to promo codes</a></p>
+  </form>
+{{end}}

--- a/backend/layout/tmpl/admin/promo_codes.gohtml
+++ b/backend/layout/tmpl/admin/promo_codes.gohtml
@@ -1,0 +1,66 @@
+{{define "main"}}
+  <h2 class="account-card__title">promo codes</h2>
+
+  {{if .Codes}}
+    <table class="admin-table">
+      <thead>
+        <tr>
+          <th>code</th>
+          <th>kind</th>
+          <th>value</th>
+          <th>valid from</th>
+          <th>valid until</th>
+          <th>uses</th>
+          <th>per customer</th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody>
+        {{range $c := .Codes}}
+          <tr>
+            <td><code>{{$c.CodeText}}</code></td>
+            <td>{{$c.KindDisplay}}</td>
+            <td>{{$c.ValueDisplay}}</td>
+            <td>{{with $c.ValidFrom}}{{.Format "2006-01-02"}}{{else}}—{{end}}</td>
+            <td>{{with $c.ValidUntil}}{{.Format "2006-01-02"}}{{else}}—{{end}}</td>
+            <td>{{$c.UsedCount}}{{if gt $c.MaxUses 0}} / {{$c.MaxUses}}{{else}} / ∞{{end}}</td>
+            <td>{{if gt $c.PerCustomerMax 0}}{{$c.PerCustomerMax}}{{else}}∞{{end}}</td>
+            <td class="admin-table__actions">
+              <a href="/admin/promo-codes/{{$c.CodeText}}/edit">edit</a>
+              <form method="post" action="/admin/promo-codes/{{$c.CodeText}}/delete"
+                    onsubmit="return confirm('Delete this promo code? Past redemptions stay on the orders but the code cannot be re-used.');">
+                <input type="hidden" name="csrf_token" value="{{$.CSRFToken}}">
+                <button type="submit" class="linkbtn linkbtn--danger">delete</button>
+              </form>
+            </td>
+          </tr>
+        {{end}}
+      </tbody>
+    </table>
+  {{else}}
+    <p class="muted">no promo codes yet.</p>
+  {{end}}
+
+  <section class="admin-form">
+    <h3 class="account-card__title">create a promo code</h3>
+    <form class="form" method="post" action="/admin/promo-codes">
+      <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
+      <div class="field"><label for="p-code">code</label><input id="p-code" name="code" required maxlength="64" placeholder="SAVE10"></div>
+      <div class="field">
+        <label for="p-kind">kind</label>
+        <select id="p-kind" name="kind">
+          <option value="percent">percent (1..100)</option>
+          <option value="fixed">fixed amount (minor units)</option>
+          <option value="free_shipping">free shipping</option>
+        </select>
+      </div>
+      <div class="field"><label for="p-value">value</label><input id="p-value" name="value" type="number" value="0" min="0"></div>
+      <div class="field"><label for="p-ccy">currency</label><input id="p-ccy" name="currency" value="USD" maxlength="3"></div>
+      <div class="field"><label for="p-from">valid from (YYYY-MM-DD, optional)</label><input id="p-from" name="valid_from" type="date"></div>
+      <div class="field"><label for="p-until">valid until (YYYY-MM-DD, optional)</label><input id="p-until" name="valid_until" type="date"></div>
+      <div class="field"><label for="p-max">max uses (0 = unlimited)</label><input id="p-max" name="max_uses" type="number" value="0" min="0"></div>
+      <div class="field"><label for="p-percust">per-customer max (0 = unlimited)</label><input id="p-percust" name="per_customer_max" type="number" value="1" min="0"></div>
+      <button type="submit" class="btn">create promo code</button>
+    </form>
+  </section>
+{{end}}

--- a/backend/layout/tmpl/admin/reviews.gohtml
+++ b/backend/layout/tmpl/admin/reviews.gohtml
@@ -1,0 +1,37 @@
+{{define "main"}}
+  <h2 class="account-card__title">reviews</h2>
+
+  {{if .Rows}}
+    <table class="admin-table">
+      <thead>
+        <tr>
+          <th>product</th>
+          <th>customer</th>
+          <th>rating</th>
+          <th>created</th>
+          <th>body</th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody>
+        {{range $row := .Rows}}
+          <tr>
+            <td><a href="/product/{{$row.ProductID}}">{{$row.ProductName}}</a></td>
+            <td>{{$row.Review.CustomerID}}</td>
+            <td>{{$row.Review.Rating}} / 5</td>
+            <td>{{$row.Review.CreatedAt.Format "Jan 2, 2006 15:04"}}</td>
+            <td>{{$row.Review.Body}}</td>
+            <td>
+              <form method="post" action="/admin/reviews/{{$row.Review.ID}}/delete">
+                <input type="hidden" name="csrf_token" value="{{$.CSRFToken}}">
+                <button type="submit" class="btn btn--danger">delete</button>
+              </form>
+            </td>
+          </tr>
+        {{end}}
+      </tbody>
+    </table>
+  {{else}}
+    <p class="muted">no reviews yet.</p>
+  {{end}}
+{{end}}

--- a/backend/layout/tmpl/cart/show.gohtml
+++ b/backend/layout/tmpl/cart/show.gohtml
@@ -19,15 +19,15 @@
           <tr>
             <td><a href="/product/{{$item.Product.ID}}">{{$item.Product.Name}}</a></td>
             <td class="col-qty">{{$item.Quantity}}</td>
-            <td class="col-price">{{$item.Product.Price.Display}} {{$item.Product.Price.Currency}}</td>
-            <td class="col-total">{{$item.Product.Price.Display}} {{$item.Product.Price.Currency}}</td>
+            <td class="col-price">{{ money $item.Product.Price.Amount }}</td>
+            <td class="col-total">{{ money $item.Product.Price.Amount }}</td>
           </tr>
         {{end}}
       </tbody>
       <tfoot>
         <tr>
           <td colspan="3">total</td>
-          <td class="col-total">{{.Cart.TotalPrice.Display}} {{.Cart.TotalPrice.Currency}}</td>
+          <td class="col-total">{{ money .Cart.TotalPrice.Amount }}</td>
         </tr>
       </tfoot>
     </table>

--- a/backend/layout/tmpl/checkout/show.gohtml
+++ b/backend/layout/tmpl/checkout/show.gohtml
@@ -39,6 +39,16 @@
 
       <form class="form" method="post" action="/checkout">
         <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
+
+        <fieldset class="fieldset">
+          <legend class="fieldset__legend">promo code</legend>
+          <p class="muted checkout__note">have a code? enter it here — anonymous customers must sign in to redeem.</p>
+          <div class="field">
+            <label for="promo-code">code</label>
+            <input id="promo-code" type="text" name="promo_code" autocomplete="off" placeholder="SAVE10" value="{{with .PromoCode}}{{.}}{{end}}">
+          </div>
+        </fieldset>
+
         <fieldset class="fieldset">
           <legend class="fieldset__legend">shipping method</legend>
           {{range .ShippingMethods}}

--- a/backend/layout/tmpl/checkout/show.gohtml
+++ b/backend/layout/tmpl/checkout/show.gohtml
@@ -20,17 +20,25 @@
             <tr>
               <td>{{$item.Product.Name}}</td>
               <td class="col-qty">{{$item.Quantity}}</td>
-              <td class="col-total">{{$item.Product.Price.Display}} {{$item.Product.Price.Currency}}</td>
+              <td class="col-total">{{ money $item.Product.Price.Amount }}</td>
             </tr>
           {{end}}
         </tbody>
         <tfoot>
           <tr>
             <td colspan="2">total</td>
-            <td class="col-total">{{.Cart.TotalPrice.Display}} {{.Cart.TotalPrice.Currency}}</td>
+            <td class="col-total">{{ money .Cart.TotalPrice.Amount }}</td>
           </tr>
         </tfoot>
       </table>
+      {{/*
+        Display-only disclosure: shoppers viewing the cart in a non-USD
+        currency need to know the charge is still in USD. The note stays
+        understated (.muted) so it doesn't drown the summary.
+      */}}
+      {{if ne .Currency "USD"}}
+        <p class="muted checkout__note">Prices shown in {{.Currency}}; orders are placed in USD.</p>
+      {{end}}
     </section>
 
     <section class="checkout__payment">
@@ -55,7 +63,7 @@
             <label class="radio">
               <input type="radio" name="ship_method" value="{{.Code}}" {{if eq .Code "flat"}}checked{{end}}>
               <span class="radio__label">{{.Label}}</span>
-              <span class="radio__cost muted">{{.CostDisplay}} {{$.Cart.TotalPrice.Currency}}</span>
+              <span class="radio__cost muted">{{ money .Cost }}</span>
             </label>
           {{end}}
         </fieldset>

--- a/backend/layout/tmpl/emails/order_confirmation.html.tmpl
+++ b/backend/layout/tmpl/emails/order_confirmation.html.tmpl
@@ -32,6 +32,12 @@
         <td colspan="3" style="text-align: right;">Subtotal</td>
         <td style="text-align: right;">{{.Order.SubtotalDisplay}} {{.Order.TotalCurrency}}</td>
       </tr>
+      {{if or (gt .Order.DiscountAmount 0) .Order.DiscountCode}}
+        <tr>
+          <td colspan="3" style="text-align: right;">Discount{{with .Order.DiscountCode}} ({{.}}){{end}}</td>
+          <td style="text-align: right;">{{if gt .Order.DiscountAmount 0}}-{{.Order.DiscountDisplay}} {{.Order.TotalCurrency}}{{else}}free shipping{{end}}</td>
+        </tr>
+      {{end}}
       {{if not .Order.ShippingMethod.IsZero}}
         <tr>
           <td colspan="3" style="text-align: right;">Shipping &middot; {{.Order.ShippingMethod.Label}}</td>

--- a/backend/layout/tmpl/emails/order_confirmation.html.tmpl
+++ b/backend/layout/tmpl/emails/order_confirmation.html.tmpl
@@ -1,3 +1,8 @@
+{{/*
+  Order confirmation always renders the stored order amount (USD).
+  The storefront's display-only multi-currency picker does NOT apply
+  here — the email reflects the actual amount charged.
+*/ -}}
 <!doctype html>
 <html lang="en">
 <head>

--- a/backend/layout/tmpl/emails/order_confirmation.txt.tmpl
+++ b/backend/layout/tmpl/emails/order_confirmation.txt.tmpl
@@ -1,3 +1,8 @@
+{{/*
+  Order confirmation always renders the stored order amount (USD).
+  The storefront's display-only multi-currency picker does NOT apply
+  here — the email reflects the actual amount charged.
+*/ -}}
 Thanks for your order.
 
 Order {{.Order.ID}} - placed {{.Order.PlacedAt.Format "Jan 2, 2006 15:04 MST"}}

--- a/backend/layout/tmpl/emails/order_confirmation.txt.tmpl
+++ b/backend/layout/tmpl/emails/order_confirmation.txt.tmpl
@@ -6,7 +6,8 @@ Items:
 {{range $line := .Order.Items}}- {{$line.ProductName}} x {{$line.Quantity}} @ {{$line.PriceDisplay}} {{$line.PriceCurrency}} = {{$line.LineTotalDisplay}} {{$line.PriceCurrency}}
 {{end}}
 Subtotal: {{.Order.SubtotalDisplay}} {{.Order.TotalCurrency}}
-{{if not .Order.ShippingMethod.IsZero}}Shipping ({{.Order.ShippingMethod.Label}}): {{.Order.ShippingCostDisplay}} {{.Order.TotalCurrency}}
+{{if or (gt .Order.DiscountAmount 0) .Order.DiscountCode}}Discount{{with .Order.DiscountCode}} ({{.}}){{end}}: {{if gt .Order.DiscountAmount 0}}-{{.Order.DiscountDisplay}} {{.Order.TotalCurrency}}{{else}}free shipping{{end}}
+{{end}}{{if not .Order.ShippingMethod.IsZero}}Shipping ({{.Order.ShippingMethod.Label}}): {{.Order.ShippingCostDisplay}} {{.Order.TotalCurrency}}
 {{end}}Total: {{.Order.TotalDisplay}} {{.Order.TotalCurrency}}
 
 {{if not .Order.PaymentMethod.IsZero}}Payment: {{.Order.PaymentMethod.Label}}

--- a/backend/layout/tmpl/home.gohtml
+++ b/backend/layout/tmpl/home.gohtml
@@ -19,7 +19,7 @@
                  width="800" height="800">
           {{end}}
           <h2 class="product-card__name">{{.Name}}</h2>
-          <p class="product-card__price">{{if .HasPriceRange}}from {{end}}{{.PriceFrom.Display}} {{.PriceFrom.Currency}}</p>
+          <p class="product-card__price">{{if .HasPriceRange}}from {{end}}{{ money .PriceFrom.Amount }}</p>
         </a>
       {{end}}
     </div>

--- a/backend/layout/tmpl/layout.gohtml
+++ b/backend/layout/tmpl/layout.gohtml
@@ -57,6 +57,24 @@
                  hx-swap="innerHTML"
                  hx-include="[name=category]">
         </form>
+        {{/*
+          Display-only currency picker. Only renders when the operator
+          configured more than one currency — otherwise the only option
+          is the default and the form would be a no-op. The select
+          submits its parent form on change so the customer never needs
+          to hunt for a separate "go" button. Conversion is a render
+          transformation: orders are placed in the storage currency
+          (USD); see internal/fx.
+        */}}
+        {{if gt (len .Currencies) 1}}
+          <form class="currency-switch" method="post" action="/currency">
+            <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
+            <label for="currency-select" class="visually-hidden">Currency</label>
+            <select id="currency-select" name="currency" onchange="this.form.submit()">
+              {{range .Currencies}}<option value="{{.}}"{{if eq . $.Currency}} selected{{end}}>{{.}}</option>{{end}}
+            </select>
+          </form>
+        {{end}}
         <nav aria-label="Primary">
           <ul class="nav">
             <li><a href="/products">shop</a></li>

--- a/backend/layout/tmpl/order/index.gohtml
+++ b/backend/layout/tmpl/order/index.gohtml
@@ -20,7 +20,7 @@
             </td>
             <td class="muted">{{$order.PlacedAt.Format "Jan 2, 2006"}}</td>
             <td><span class="order-status order-status--{{$order.Status}}">{{$order.Status}}</span></td>
-            <td class="col-total">{{$order.TotalDisplay}} {{$order.TotalCurrency}}</td>
+            <td class="col-total">{{ money $order.TotalAmount }}</td>
           </tr>
         {{end}}
       </tbody>

--- a/backend/layout/tmpl/order/show.gohtml
+++ b/backend/layout/tmpl/order/show.gohtml
@@ -38,44 +38,54 @@
           <tr>
             <td>{{$line.ProductName}}</td>
             <td class="col-qty">{{$line.Quantity}}</td>
-            <td class="col-price">{{$line.PriceDisplay}} {{$line.PriceCurrency}}</td>
-            <td class="col-total">{{$line.LineTotalDisplay}} {{$line.PriceCurrency}}</td>
+            <td class="col-price">{{ money $line.PriceAmount }}</td>
+            <td class="col-total">{{ money $line.LineTotal }}</td>
           </tr>
         {{end}}
       </tbody>
       <tfoot>
         <tr>
           <td colspan="3">subtotal</td>
-          <td class="col-total">{{.Order.SubtotalDisplay}} {{.Order.TotalCurrency}}</td>
+          <td class="col-total">{{ money .Order.Subtotal }}</td>
         </tr>
         {{if or (gt .Order.DiscountAmount 0) .Order.DiscountCode}}
           <tr>
             <td colspan="3">discount{{with .Order.DiscountCode}} &middot; <code>{{.}}</code>{{end}}</td>
             <td class="col-total">
-              {{if gt .Order.DiscountAmount 0}}-{{.Order.DiscountDisplay}} {{.Order.TotalCurrency}}{{else}}free shipping{{end}}
+              {{if gt .Order.DiscountAmount 0}}-{{ money .Order.DiscountAmount }}{{else}}free shipping{{end}}
             </td>
           </tr>
         {{end}}
         {{if gt .Order.TaxAmount 0}}
           <tr>
             <td colspan="3">tax</td>
-            <td class="col-total">{{.Order.TaxDisplay}} {{.Order.TotalCurrency}}</td>
+            <td class="col-total">{{ money .Order.TaxAmount }}</td>
           </tr>
         {{end}}
         {{if not .Order.ShippingMethod.IsZero}}
           <tr>
             <td colspan="3">shipping &middot; {{.Order.ShippingMethod.Label}}</td>
             <td class="col-total">
-              {{if eq .Order.ShippingCost 0}}free{{else}}{{.Order.ShippingCostDisplay}} {{.Order.TotalCurrency}}{{end}}
+              {{if eq .Order.ShippingCost 0}}free{{else}}{{ money .Order.ShippingCost }}{{end}}
             </td>
           </tr>
         {{end}}
         <tr>
           <td colspan="3">total charged</td>
-          <td class="col-total">{{.Order.TotalDisplay}} {{.Order.TotalCurrency}}</td>
+          <td class="col-total">{{ money .Order.TotalAmount }}</td>
         </tr>
       </tfoot>
     </table>
+
+    {{/*
+      Display-only currency disclosure. Renders when the customer is
+      viewing the order in a non-default currency. The order itself was
+      placed in USD; we make that clear so the totals row isn't
+      misread as the amount actually charged.
+    */}}
+    {{if ne .Currency "USD"}}
+      <p class="order__hint muted">Prices shown in {{.Currency}}; orders are placed in USD.</p>
+    {{end}}
 
     {{if eq .Order.ShippingMethod.Code "pickup"}}
       <section class="order__ship">

--- a/backend/layout/tmpl/order/show.gohtml
+++ b/backend/layout/tmpl/order/show.gohtml
@@ -48,6 +48,14 @@
           <td colspan="3">subtotal</td>
           <td class="col-total">{{.Order.SubtotalDisplay}} {{.Order.TotalCurrency}}</td>
         </tr>
+        {{if or (gt .Order.DiscountAmount 0) .Order.DiscountCode}}
+          <tr>
+            <td colspan="3">discount{{with .Order.DiscountCode}} &middot; <code>{{.}}</code>{{end}}</td>
+            <td class="col-total">
+              {{if gt .Order.DiscountAmount 0}}-{{.Order.DiscountDisplay}} {{.Order.TotalCurrency}}{{else}}free shipping{{end}}
+            </td>
+          </tr>
+        {{end}}
         {{if gt .Order.TaxAmount 0}}
           <tr>
             <td colspan="3">tax</td>

--- a/backend/layout/tmpl/partials/account-nav.gohtml
+++ b/backend/layout/tmpl/partials/account-nav.gohtml
@@ -3,6 +3,7 @@
   <a href="/account" class="account-nav__link {{if eq .Active "overview"}}is-active{{end}}">overview</a>
   <a href="/account/orders" class="account-nav__link {{if eq .Active "orders"}}is-active{{end}}">orders</a>
   <a href="/account/addresses" class="account-nav__link {{if eq .Active "addresses"}}is-active{{end}}">addresses</a>
+  <a href="/account/wishlist" class="account-nav__link {{if eq .Active "wishlist"}}is-active{{end}}">wishlist</a>
   <a href="/account/details" class="account-nav__link {{if eq .Active "details"}}is-active{{end}}">account details</a>
   <span class="account-nav__rule"></span>
   <a href="/auth/logout" class="account-nav__link account-nav__link--muted">sign out</a>

--- a/backend/layout/tmpl/partials/admin-nav.gohtml
+++ b/backend/layout/tmpl/partials/admin-nav.gohtml
@@ -7,6 +7,7 @@
   <a href="/admin/attribute-sets" class="admin-nav__link {{if eq .Active "attribute-sets"}}is-active{{end}}">attribute sets</a>
   <a href="/admin/orders" class="admin-nav__link {{if eq .Active "orders"}}is-active{{end}}">orders</a>
   <a href="/admin/inventory" class="admin-nav__link {{if eq .Active "inventory"}}is-active{{end}}">inventory</a>
+  <a href="/admin/reviews" class="admin-nav__link {{if eq .Active "reviews"}}is-active{{end}}">reviews</a>
   <span class="admin-nav__rule"></span>
   <a href="/" class="admin-nav__link admin-nav__link--muted">back to store</a>
 </nav>

--- a/backend/layout/tmpl/partials/admin-nav.gohtml
+++ b/backend/layout/tmpl/partials/admin-nav.gohtml
@@ -8,6 +8,7 @@
   <a href="/admin/orders" class="admin-nav__link {{if eq .Active "orders"}}is-active{{end}}">orders</a>
   <a href="/admin/inventory" class="admin-nav__link {{if eq .Active "inventory"}}is-active{{end}}">inventory</a>
   <a href="/admin/reviews" class="admin-nav__link {{if eq .Active "reviews"}}is-active{{end}}">reviews</a>
+  <a href="/admin/promo-codes" class="admin-nav__link {{if eq .Active "promo-codes"}}is-active{{end}}">promo codes</a>
   <span class="admin-nav__rule"></span>
   <a href="/" class="admin-nav__link admin-nav__link--muted">back to store</a>
 </nav>

--- a/backend/layout/tmpl/partials/variant-box.gohtml
+++ b/backend/layout/tmpl/partials/variant-box.gohtml
@@ -19,6 +19,13 @@
     {{else}}
       <p class="stock stock--out">out of stock</p>
     {{end}}
+    {{- /* The wishlist toggle lives inside variant-box so it follows the
+           currently-selected variant: each time the variant selects fire,
+           the variant-response partial re-renders this whole box and the
+           heart reflects the new variant's saved state. We synthesise the
+           partial's dot via dict so the partial's keys (VariantID /
+           InWishlist / LoggedIn) come from the variant + parent context. */ -}}
+    {{template "wishlist-button" (dict "VariantID" .Variant.ID "InWishlist" .InWishlist "LoggedIn" .LoggedIn)}}
   {{end}}
 </div>
 {{end}}

--- a/backend/layout/tmpl/partials/variant-box.gohtml
+++ b/backend/layout/tmpl/partials/variant-box.gohtml
@@ -3,7 +3,7 @@
   {{if .Variant.IsZero}}
     <p class="product__price muted">that combination isn't available</p>
   {{else}}
-    <p class="product__price">{{.Variant.Price.Display}} {{.Variant.Price.Currency}}</p>
+    <p class="product__price">{{ money .Variant.Price.Amount }}</p>
     {{if .Variant.InStock}}
       {{if .Variant.LowStock}}
         <p class="stock stock--low">only {{.Variant.Stock}} left</p>

--- a/backend/layout/tmpl/partials/wishlist-button.gohtml
+++ b/backend/layout/tmpl/partials/wishlist-button.gohtml
@@ -1,0 +1,39 @@
+{{define "wishlist-button"}}
+{{- /*
+  Heart toggle rendered next to the add-to-cart button.
+  Render states:
+    * not logged in:           a small link to /auth/login (no toggle, no POST)
+    * logged in, NOT saved:    an outline-heart "save" button
+    * logged in, in wishlist:  a filled-heart "remove" button
+  The button POSTs to /wishlist/{VariantID}/toggle with hx-swap="outerHTML";
+  the handler responds with this same template re-rendered in the new state.
+  X-CSRF-Token is auto-stamped by the htmx:configRequest hook in layout.gohtml.
+
+  The dot is always a flat map carrying VariantID, InWishlist, LoggedIn —
+  produced either by the WishlistToggle HTTP handler or by variant-box's
+  `dict` invocation.
+*/ -}}
+{{if .LoggedIn}}
+  {{if .InWishlist}}
+    <button class="btn btn--ghost wishlist-toggle wishlist-toggle--on"
+            hx-post="/wishlist/{{.VariantID}}/toggle"
+            hx-swap="outerHTML"
+            aria-label="remove from wishlist"
+            title="remove from wishlist">
+      <span aria-hidden="true">&#9829;</span> saved
+    </button>
+  {{else}}
+    <button class="btn btn--ghost wishlist-toggle wishlist-toggle--off"
+            hx-post="/wishlist/{{.VariantID}}/toggle"
+            hx-swap="outerHTML"
+            aria-label="save to wishlist"
+            title="save to wishlist">
+      <span aria-hidden="true">&#9825;</span> save
+    </button>
+  {{end}}
+{{else}}
+  <a class="wishlist-toggle wishlist-toggle--anon muted" href="/auth/login">
+    <span aria-hidden="true">&#9825;</span> log in to save
+  </a>
+{{end}}
+{{end}}

--- a/backend/layout/tmpl/productCatalog/allProducts.gohtml
+++ b/backend/layout/tmpl/productCatalog/allProducts.gohtml
@@ -10,7 +10,7 @@
                width="800" height="800">
         {{end}}
         <h2 class="product-card__name">{{.Name}}</h2>
-        <p class="product-card__price">{{if .HasPriceRange}}from {{end}}{{.PriceFrom.Display}} {{.PriceFrom.Currency}}</p>
+        <p class="product-card__price">{{if .HasPriceRange}}from {{end}}{{ money .PriceFrom.Amount }}</p>
       </a>
     {{end}}
   </div>

--- a/backend/layout/tmpl/productCatalog/show.gohtml
+++ b/backend/layout/tmpl/productCatalog/show.gohtml
@@ -17,6 +17,12 @@
 
     <div class="product__body">
       <h1 class="product__name">{{.Product.Name}}</h1>
+      {{if gt .Aggregate.Count 0}}
+        <p class="product__rating muted">
+          rating: {{printf "%.1f" .Aggregate.Average}} / 5
+          ({{.Aggregate.Count}} review{{if ne .Aggregate.Count 1}}s{{end}})
+        </p>
+      {{end}}
       <p class="product__description">{{.Product.Description}}</p>
 
       {{if .Product.HasOptions}}
@@ -63,4 +69,52 @@
       <p class="product__hint muted">added to your cart without a page reload.</p>
     </div>
   </article>
+
+  <section id="reviews" class="product-reviews">
+    <h2 class="product-reviews__title">reviews</h2>
+
+    {{if .Reviews}}
+      <ul class="product-reviews__list">
+        {{range $r := .Reviews}}
+          <li class="product-review">
+            <p class="product-review__head">
+              <span class="product-review__rating">{{$r.Rating}} / 5</span>
+              <span class="muted"> &middot; {{$r.CreatedAt.Format "Jan 2, 2006"}}</span>
+              <span class="muted"> &middot; {{$r.CustomerID}}</span>
+            </p>
+            <p class="product-review__body">{{$r.Body}}</p>
+          </li>
+        {{end}}
+      </ul>
+    {{else}}
+      <p class="muted">no reviews yet.</p>
+    {{end}}
+
+    {{if and .LoggedIn .CanReview (not .AlreadyReviewed)}}
+      <form class="product-review__form" method="post" action="/product/{{.Product.ID}}/review">
+        <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
+        <div class="field">
+          <label for="review-rating">rating</label>
+          <select id="review-rating" name="rating" required>
+            <option value="5">5 — excellent</option>
+            <option value="4">4 — good</option>
+            <option value="3">3 — okay</option>
+            <option value="2">2 — poor</option>
+            <option value="1">1 — bad</option>
+          </select>
+        </div>
+        <div class="field">
+          <label for="review-body">your review</label>
+          <textarea id="review-body" name="body" rows="4" required maxlength="4000"></textarea>
+        </div>
+        <button type="submit" class="btn">submit review</button>
+      </form>
+    {{else if and .LoggedIn .AlreadyReviewed}}
+      <p class="muted">you have already reviewed this product.</p>
+    {{else if .LoggedIn}}
+      <p class="muted">only verified buyers can leave a review.</p>
+    {{else}}
+      <p class="muted"><a href="/auth/login">log in</a> to leave a review.</p>
+    {{end}}
+  </section>
 {{end}}

--- a/backend/promo/adapter/inmemory.go
+++ b/backend/promo/adapter/inmemory.go
@@ -1,0 +1,148 @@
+// Package adapter holds the promo storage adapters. The in-memory adapter
+// mirrors the postgres adapter's contract; both implement promo/app.Storage.
+package adapter
+
+import (
+	"context"
+	"sort"
+	"sync"
+
+	"github.com/bkielbasa/go-ecommerce/backend/promo/app"
+	"github.com/bkielbasa/go-ecommerce/backend/promo/domain"
+)
+
+// InMemory is the test-friendly Storage. A single mutex protects the
+// catalogue + ledger so the atomic "check + insert + increment" Redeem
+// step matches the postgres SELECT FOR UPDATE semantics.
+type InMemory struct {
+	mu          sync.Mutex
+	codes       map[string]domain.Code
+	redemptions []app.Redemption
+}
+
+// NewInMemory builds an empty in-memory store.
+func NewInMemory() *InMemory {
+	return &InMemory{codes: map[string]domain.Code{}}
+}
+
+// Create inserts a new code. A duplicate (PK collision) is reported as
+// ErrCodeAlreadyExists to match the postgres adapter's unique-violation
+// mapping.
+func (m *InMemory) Create(_ context.Context, c domain.Code) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if _, ok := m.codes[c.CodeText()]; ok {
+		return app.ErrCodeAlreadyExists
+	}
+	m.codes[c.CodeText()] = c
+	return nil
+}
+
+// Update replaces an existing code. used_count is preserved (callers must
+// not rebuild it on the fly because the admin form doesn't surface it).
+func (m *InMemory) Update(_ context.Context, c domain.Code) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	existing, ok := m.codes[c.CodeText()]
+	if !ok {
+		return app.ErrCodeNotFound
+	}
+	// Carry the running redemption tally across the edit.
+	merged := domain.RebuildCode(
+		c.CodeText(), c.Kind(), c.ValueMinor(), c.Currency(),
+		c.ValidFrom(), c.ValidUntil(), c.MaxUses(), c.PerCustomerMax(),
+		existing.UsedCount(), existing.CreatedAt(),
+	)
+	m.codes[c.CodeText()] = merged
+	return nil
+}
+
+// Delete removes the code; the in-memory ledger keeps any old redemptions
+// (postgres CASCADEs them, but the only consumer here is the service
+// tests so the difference is academic).
+func (m *InMemory) Delete(_ context.Context, code string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if _, ok := m.codes[code]; !ok {
+		return app.ErrCodeNotFound
+	}
+	delete(m.codes, code)
+	return nil
+}
+
+// Find returns the catalogue row by code text.
+func (m *InMemory) Find(_ context.Context, code string) (domain.Code, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	c, ok := m.codes[code]
+	if !ok {
+		return domain.Code{}, app.ErrCodeNotFound
+	}
+	return c, nil
+}
+
+// ListAll returns every code newest-first.
+func (m *InMemory) ListAll(_ context.Context) ([]domain.Code, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]domain.Code, 0, len(m.codes))
+	for _, c := range m.codes {
+		out = append(out, c)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].CreatedAt().After(out[j].CreatedAt()) })
+	return out, nil
+}
+
+// CountRedemptionsByCustomer returns the per-(code,customer) tally.
+func (m *InMemory) CountRedemptionsByCustomer(_ context.Context, code, customerID string) (int, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	n := 0
+	for _, r := range m.redemptions {
+		if r.Code == code && r.CustomerID == customerID {
+			n++
+		}
+	}
+	return n, nil
+}
+
+// Redeem mirrors the postgres atomic check: under the single mutex we
+// re-verify the code, the max_uses cap and the per-customer cap, insert
+// the redemption (idempotent on the (code, order_id) PK), and bump
+// used_count.
+func (m *InMemory) Redeem(_ context.Context, r app.Redemption) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	c, ok := m.codes[r.Code]
+	if !ok {
+		return app.ErrCodeNotFound
+	}
+	// Idempotency: the same order being redeemed twice is a no-op.
+	for _, existing := range m.redemptions {
+		if existing.Code == r.Code && existing.OrderID == r.OrderID {
+			return nil
+		}
+	}
+	if c.MaxUsesReached() {
+		return app.ErrCodeMaxUsesReached
+	}
+	if c.PerCustomerMax() > 0 {
+		n := 0
+		for _, existing := range m.redemptions {
+			if existing.Code == r.Code && existing.CustomerID == r.CustomerID {
+				n++
+			}
+		}
+		if n >= c.PerCustomerMax() {
+			return app.ErrCodeCustomerLimit
+		}
+	}
+	m.redemptions = append(m.redemptions, r)
+	// Bump used_count by rebuilding the value object with the new tally.
+	m.codes[r.Code] = domain.RebuildCode(
+		c.CodeText(), c.Kind(), c.ValueMinor(), c.Currency(),
+		c.ValidFrom(), c.ValidUntil(), c.MaxUses(), c.PerCustomerMax(),
+		c.UsedCount()+1, c.CreatedAt(),
+	)
+	return nil
+}

--- a/backend/promo/adapter/postgres.go
+++ b/backend/promo/adapter/postgres.go
@@ -1,0 +1,265 @@
+package adapter
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/bkielbasa/go-ecommerce/backend/promo/app"
+	"github.com/bkielbasa/go-ecommerce/backend/promo/domain"
+	"github.com/lib/pq"
+)
+
+// pgUniqueViolation is the SQLSTATE postgres returns on a primary-key /
+// unique-constraint conflict; used to map duplicate-code creates to a
+// dedicated app-level error and to swallow the (code, order_id) PK on the
+// redemption table for idempotency.
+const pgUniqueViolation = "23505"
+
+// Postgres is the production Storage adapter. Atomicity of Redeem is the
+// load-bearing piece: it runs the read-and-mutate inside a single
+// transaction with SELECT ... FOR UPDATE on the promo_code row.
+type Postgres struct {
+	db *sql.DB
+}
+
+// NewPostgres binds the adapter to the shared *sql.DB.
+func NewPostgres(db *sql.DB) *Postgres {
+	return &Postgres{db: db}
+}
+
+// Create inserts a new catalogue row. A duplicate code text (PK) maps to
+// app.ErrCodeAlreadyExists so the admin handler can flash a useful
+// message.
+func (p *Postgres) Create(ctx context.Context, c domain.Code) error {
+	_, err := p.db.ExecContext(ctx, `
+		INSERT INTO promo_code
+			(code, kind, value_minor, currency, valid_from, valid_until,
+			 max_uses, per_customer_max, used_count, created_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+	`,
+		c.CodeText(), string(c.Kind()), c.ValueMinor(), c.Currency(),
+		nullableTime(c.ValidFrom()), nullableTime(c.ValidUntil()),
+		c.MaxUses(), c.PerCustomerMax(), c.UsedCount(), c.CreatedAt(),
+	)
+	if err != nil {
+		var pqErr *pq.Error
+		if errors.As(err, &pqErr) && string(pqErr.Code) == pgUniqueViolation {
+			return app.ErrCodeAlreadyExists
+		}
+		return fmt.Errorf("insert promo_code: %w", err)
+	}
+	return nil
+}
+
+// Update replaces every editable field on the catalogue row. used_count
+// and created_at are intentionally left untouched — the admin form does
+// not surface either.
+func (p *Postgres) Update(ctx context.Context, c domain.Code) error {
+	res, err := p.db.ExecContext(ctx, `
+		UPDATE promo_code SET
+			kind = $2,
+			value_minor = $3,
+			currency = $4,
+			valid_from = $5,
+			valid_until = $6,
+			max_uses = $7,
+			per_customer_max = $8
+		WHERE code = $1
+	`,
+		c.CodeText(), string(c.Kind()), c.ValueMinor(), c.Currency(),
+		nullableTime(c.ValidFrom()), nullableTime(c.ValidUntil()),
+		c.MaxUses(), c.PerCustomerMax(),
+	)
+	if err != nil {
+		return fmt.Errorf("update promo_code: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return app.ErrCodeNotFound
+	}
+	return nil
+}
+
+// Delete drops the catalogue row; the FK on promo_redemption cascades.
+func (p *Postgres) Delete(ctx context.Context, code string) error {
+	res, err := p.db.ExecContext(ctx, `DELETE FROM promo_code WHERE code = $1`, code)
+	if err != nil {
+		return fmt.Errorf("delete promo_code: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return app.ErrCodeNotFound
+	}
+	return nil
+}
+
+// Find loads a single catalogue row by code text.
+func (p *Postgres) Find(ctx context.Context, code string) (domain.Code, error) {
+	var kindStr, currency string
+	var valueMinor int64
+	var maxUses, perCustomerMax, usedCount int
+	var validFrom, validUntil sql.NullTime
+	var createdAt time.Time
+	err := p.db.QueryRowContext(ctx, `
+		SELECT kind::text, value_minor, currency, valid_from, valid_until,
+		       max_uses, per_customer_max, used_count, created_at
+		FROM promo_code WHERE code = $1
+	`, code).Scan(&kindStr, &valueMinor, &currency, &validFrom, &validUntil,
+		&maxUses, &perCustomerMax, &usedCount, &createdAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return domain.Code{}, app.ErrCodeNotFound
+	}
+	if err != nil {
+		return domain.Code{}, fmt.Errorf("select promo_code: %w", err)
+	}
+	return domain.RebuildCode(
+		code, domain.Kind(kindStr), valueMinor, currency,
+		nullableTimePtr(validFrom), nullableTimePtr(validUntil),
+		maxUses, perCustomerMax, usedCount, createdAt,
+	), nil
+}
+
+// ListAll returns the catalogue newest-first.
+func (p *Postgres) ListAll(ctx context.Context) ([]domain.Code, error) {
+	rows, err := p.db.QueryContext(ctx, `
+		SELECT code, kind::text, value_minor, currency, valid_from, valid_until,
+		       max_uses, per_customer_max, used_count, created_at
+		FROM promo_code
+		ORDER BY created_at DESC
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("list promo_code: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []domain.Code
+	for rows.Next() {
+		var code, kindStr, currency string
+		var valueMinor int64
+		var maxUses, perCustomerMax, usedCount int
+		var validFrom, validUntil sql.NullTime
+		var createdAt time.Time
+		if err := rows.Scan(&code, &kindStr, &valueMinor, &currency, &validFrom, &validUntil,
+			&maxUses, &perCustomerMax, &usedCount, &createdAt); err != nil {
+			return nil, fmt.Errorf("scan promo_code: %w", err)
+		}
+		out = append(out, domain.RebuildCode(
+			code, domain.Kind(kindStr), valueMinor, currency,
+			nullableTimePtr(validFrom), nullableTimePtr(validUntil),
+			maxUses, perCustomerMax, usedCount, createdAt,
+		))
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("rows: %w", err)
+	}
+	return out, nil
+}
+
+// CountRedemptionsByCustomer returns the per-(code,customer) tally for
+// the per-customer-max check at Resolve time.
+func (p *Postgres) CountRedemptionsByCustomer(ctx context.Context, code, customerID string) (int, error) {
+	var n int
+	err := p.db.QueryRowContext(ctx, `
+		SELECT COUNT(*) FROM promo_redemption
+		WHERE code = $1 AND customer_id = $2
+	`, code, customerID).Scan(&n)
+	if err != nil {
+		return 0, fmt.Errorf("count promo_redemption: %w", err)
+	}
+	return n, nil
+}
+
+// Redeem runs the atomic redemption flow: take a row-level lock on the
+// promo_code row, re-check the caps (max_uses + per_customer_max), insert
+// the redemption (idempotent on the (code, order_id) PK), and increment
+// used_count. The transaction commits as a single unit, so concurrent
+// checkouts cannot oversubscribe a limited code.
+func (p *Postgres) Redeem(ctx context.Context, r app.Redemption) error {
+	tx, err := p.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin redeem tx: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+
+	var maxUses, perCustomerMax, usedCount int
+	err = tx.QueryRowContext(ctx, `
+		SELECT max_uses, per_customer_max, used_count
+		FROM promo_code WHERE code = $1
+		FOR UPDATE
+	`, r.Code).Scan(&maxUses, &perCustomerMax, &usedCount)
+	if errors.Is(err, sql.ErrNoRows) {
+		return app.ErrCodeNotFound
+	}
+	if err != nil {
+		return fmt.Errorf("lock promo_code: %w", err)
+	}
+	if maxUses > 0 && usedCount >= maxUses {
+		return app.ErrCodeMaxUsesReached
+	}
+	if perCustomerMax > 0 {
+		var n int
+		if err := tx.QueryRowContext(ctx, `
+			SELECT COUNT(*) FROM promo_redemption
+			WHERE code = $1 AND customer_id = $2
+		`, r.Code, r.CustomerID).Scan(&n); err != nil {
+			return fmt.Errorf("count redemptions: %w", err)
+		}
+		if n >= perCustomerMax {
+			return app.ErrCodeCustomerLimit
+		}
+	}
+
+	_, err = tx.ExecContext(ctx, `
+		INSERT INTO promo_redemption
+			(code, order_id, customer_id, discount_amount_minor, currency)
+		VALUES ($1, $2, $3, $4, $5)
+	`, r.Code, r.OrderID, r.CustomerID, r.AmountMinor, r.Currency)
+	if err != nil {
+		var pqErr *pq.Error
+		if errors.As(err, &pqErr) && string(pqErr.Code) == pgUniqueViolation {
+			// The same order was already redeemed — idempotent retry,
+			// commit nothing and return success.
+			return tx.Rollback()
+		}
+		return fmt.Errorf("insert promo_redemption: %w", err)
+	}
+
+	if _, err = tx.ExecContext(ctx, `
+		UPDATE promo_code SET used_count = used_count + 1 WHERE code = $1
+	`, r.Code); err != nil {
+		return fmt.Errorf("bump used_count: %w", err)
+	}
+
+	if err = tx.Commit(); err != nil {
+		return fmt.Errorf("commit redeem: %w", err)
+	}
+	committed = true
+	return nil
+}
+
+// nullableTime converts a *time.Time into a sql.NullTime so optional
+// validity bounds can be persisted as NULL rather than the zero value.
+func nullableTime(t *time.Time) sql.NullTime {
+	if t == nil {
+		return sql.NullTime{}
+	}
+	return sql.NullTime{Time: *t, Valid: true}
+}
+
+// nullableTimePtr is the inverse: a *time.Time the domain layer keeps for
+// optional bounds.
+func nullableTimePtr(t sql.NullTime) *time.Time {
+	if !t.Valid {
+		return nil
+	}
+	v := t.Time
+	return &v
+}

--- a/backend/promo/app/service.go
+++ b/backend/promo/app/service.go
@@ -1,0 +1,169 @@
+// Package app is the application layer for the promo bounded context: it
+// orchestrates the Storage port with the domain value objects to support
+// admin CRUD and the checkout-side Resolve/Redeem flow.
+//
+// The checkout context never touches Storage directly — it goes through
+// Service.Resolve / Service.Redeem which apply the business rules
+// (validity, max uses, per-customer limits) and reject anonymous customers
+// outright. Anonymous rejection is deliberate: per-customer caps need a
+// stable identity to be meaningful, so rather than invent a fragile
+// "anonymous bucket" we tell the user to log in. See ErrCodeAnonymous.
+package app
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/bkielbasa/go-ecommerce/backend/promo/domain"
+)
+
+// Storage is the persistence port. Implementations live in promo/adapter
+// (postgres for the real wiring, in-memory for tests). Redeem MUST be
+// atomic: it re-reads the code under lock, checks max_uses and the
+// per-customer count, inserts the redemption row, and increments
+// used_count — all in a single transaction. The (code, order_id) PK on
+// promo_redemption gives free idempotency on retries.
+type Storage interface {
+	Create(ctx context.Context, c domain.Code) error
+	Update(ctx context.Context, c domain.Code) error
+	Delete(ctx context.Context, code string) error
+	Find(ctx context.Context, code string) (domain.Code, error)
+	ListAll(ctx context.Context) ([]domain.Code, error)
+	CountRedemptionsByCustomer(ctx context.Context, code, customerID string) (int, error)
+	Redeem(ctx context.Context, r Redemption) error
+}
+
+// Redemption is the per-order ledger entry written to promo_redemption.
+type Redemption struct {
+	Code        string
+	OrderID     string
+	CustomerID  string
+	AmountMinor int64
+	Currency    string
+}
+
+var (
+	// ErrCodeNotFound is returned when the supplied code does not match a
+	// catalogue row. The checkout handler maps it to a flash message.
+	ErrCodeNotFound = errors.New("promo code not found")
+	// ErrCodeExpired covers both ends of the validity window (before
+	// valid_from or after valid_until).
+	ErrCodeExpired = errors.New("promo code is not active")
+	// ErrCodeMaxUsesReached is the global cap.
+	ErrCodeMaxUsesReached = errors.New("promo code is no longer available")
+	// ErrCodeCustomerLimit is the per-customer cap.
+	ErrCodeCustomerLimit = errors.New("promo code already used")
+	// ErrCodeAnonymous is returned when a logged-out customer submits a
+	// promo code. The decision is documented at the top of the package —
+	// we keep it simple and require a real account.
+	ErrCodeAnonymous = errors.New("please sign in to use a promo code")
+	// ErrCodeAlreadyExists is returned by Create when the code text
+	// collides with an existing row.
+	ErrCodeAlreadyExists = errors.New("promo code already exists")
+)
+
+// Service is the application facade.
+type Service struct {
+	storage Storage
+	now     func() time.Time
+}
+
+// NewService wires the service against a Storage port. now is overridable
+// for tests; the production wiring uses time.Now.
+func NewService(storage Storage) *Service {
+	return &Service{storage: storage, now: func() time.Time { return time.Now().UTC() }}
+}
+
+// WithClock injects a deterministic time source — used by unit tests to
+// pin the validity-window checks.
+func (s *Service) WithClock(now func() time.Time) *Service {
+	s.now = now
+	return s
+}
+
+// Create persists a new promo code. Validation lives in domain.NewCode;
+// the service just routes the call.
+func (s *Service) Create(ctx context.Context, c domain.Code) error {
+	return s.storage.Create(ctx, c)
+}
+
+// Update replaces every field of an existing code (the admin edit form
+// always submits the full row).
+func (s *Service) Update(ctx context.Context, c domain.Code) error {
+	return s.storage.Update(ctx, c)
+}
+
+// Delete removes the catalogue row; the ON DELETE CASCADE on
+// promo_redemption keeps the ledger consistent.
+func (s *Service) Delete(ctx context.Context, code string) error {
+	return s.storage.Delete(ctx, code)
+}
+
+// Find returns a single catalogue row by code text.
+func (s *Service) Find(ctx context.Context, code string) (domain.Code, error) {
+	return s.storage.Find(ctx, code)
+}
+
+// ListAll returns every code newest-first for the admin list page.
+func (s *Service) ListAll(ctx context.Context) ([]domain.Code, error) {
+	return s.storage.ListAll(ctx)
+}
+
+// Resolve looks up the code, runs every business rule, and returns the
+// computed Discount the checkout pricing math can consume. The order is:
+//   - non-empty code text
+//   - customer must be signed in (anonymous use is rejected)
+//   - code exists in the catalogue
+//   - code is currently within its validity window
+//   - global max_uses not exceeded
+//   - per_customer_max not exceeded
+//   - finally, apply the code to the supplied subtotal / shipping
+func (s *Service) Resolve(ctx context.Context, code, customerID string, subtotal, shippingCost int64) (domain.Discount, error) {
+	code = strings.TrimSpace(code)
+	if code == "" {
+		return domain.Discount{}, ErrCodeNotFound
+	}
+	if strings.TrimSpace(customerID) == "" {
+		return domain.Discount{}, ErrCodeAnonymous
+	}
+
+	c, err := s.storage.Find(ctx, code)
+	if err != nil {
+		return domain.Discount{}, err
+	}
+	if !c.IsActiveAt(s.now()) {
+		return domain.Discount{}, ErrCodeExpired
+	}
+	if c.MaxUsesReached() {
+		return domain.Discount{}, ErrCodeMaxUsesReached
+	}
+	if c.PerCustomerMax() > 0 {
+		used, err := s.storage.CountRedemptionsByCustomer(ctx, c.CodeText(), customerID)
+		if err != nil {
+			return domain.Discount{}, err
+		}
+		if used >= c.PerCustomerMax() {
+			return domain.Discount{}, ErrCodeCustomerLimit
+		}
+	}
+	return c.Apply(subtotal, shippingCost), nil
+}
+
+// Redeem persists the per-order redemption row and bumps used_count. The
+// PK on promo_redemption makes Storage.Redeem idempotent on the same
+// (code, order_id) so a checkout retry that re-runs after the order was
+// already redeemed is a safe no-op.
+func (s *Service) Redeem(ctx context.Context, code, orderID, customerID string, d domain.Discount) error {
+	if strings.TrimSpace(code) == "" {
+		return nil
+	}
+	return s.storage.Redeem(ctx, Redemption{
+		Code:        code,
+		OrderID:     orderID,
+		CustomerID:  customerID,
+		AmountMinor: d.AmountMinor(),
+		Currency:    d.Currency(),
+	})
+}

--- a/backend/promo/app/service_test.go
+++ b/backend/promo/app/service_test.go
@@ -1,0 +1,149 @@
+package app_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/bkielbasa/go-ecommerce/backend/promo/adapter"
+	"github.com/bkielbasa/go-ecommerce/backend/promo/app"
+	"github.com/bkielbasa/go-ecommerce/backend/promo/domain"
+)
+
+func newService(t *testing.T) (*app.Service, *adapter.InMemory) {
+	t.Helper()
+	store := adapter.NewInMemory()
+	srv := app.NewService(store).WithClock(func() time.Time {
+		return time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	})
+	return srv, store
+}
+
+func mustCode(t *testing.T, code string, kind domain.Kind, value int64, ccy string, from, until *time.Time, max, perCustomer int) domain.Code {
+	t.Helper()
+	c, err := domain.NewCode(code, kind, value, ccy, from, until, max, perCustomer)
+	if err != nil {
+		t.Fatalf("NewCode: %v", err)
+	}
+	return c
+}
+
+func TestResolve_HappyPath_Percent(t *testing.T) {
+	srv, store := newService(t)
+	ctx := context.Background()
+	if err := store.Create(ctx, mustCode(t, "SAVE10", domain.KindPercent, 10, "USD", nil, nil, 0, 1)); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	d, err := srv.Resolve(ctx, "SAVE10", "jane@example.com", 2500, 500)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if d.AmountMinor() != 250 {
+		t.Errorf("amount = %d, want 250", d.AmountMinor())
+	}
+}
+
+func TestResolve_HappyPath_FreeShipping(t *testing.T) {
+	srv, store := newService(t)
+	ctx := context.Background()
+	if err := store.Create(ctx, mustCode(t, "FREESHIP", domain.KindFreeShipping, 0, "", nil, nil, 0, 1)); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	d, err := srv.Resolve(ctx, "FREESHIP", "jane@example.com", 2500, 1500)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if !d.FreeShipping() || d.AmountMinor() != 0 {
+		t.Errorf("expected free shipping with amount 0, got amount=%d free=%v", d.AmountMinor(), d.FreeShipping())
+	}
+}
+
+func TestResolve_AnonymousRejected(t *testing.T) {
+	srv, store := newService(t)
+	ctx := context.Background()
+	_ = store.Create(ctx, mustCode(t, "X", domain.KindPercent, 5, "USD", nil, nil, 0, 1))
+	if _, err := srv.Resolve(ctx, "X", "", 1000, 0); !errors.Is(err, app.ErrCodeAnonymous) {
+		t.Errorf("err = %v, want ErrCodeAnonymous", err)
+	}
+}
+
+func TestResolve_NotFound(t *testing.T) {
+	srv, _ := newService(t)
+	ctx := context.Background()
+	if _, err := srv.Resolve(ctx, "MISSING", "jane@example.com", 1000, 0); !errors.Is(err, app.ErrCodeNotFound) {
+		t.Errorf("err = %v, want ErrCodeNotFound", err)
+	}
+}
+
+func TestResolve_Expired_BeforeWindow(t *testing.T) {
+	srv, store := newService(t)
+	ctx := context.Background()
+	from := time.Date(2027, 1, 1, 0, 0, 0, 0, time.UTC)
+	if err := store.Create(ctx, mustCode(t, "FUTURE", domain.KindPercent, 5, "USD", &from, nil, 0, 1)); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if _, err := srv.Resolve(ctx, "FUTURE", "jane@example.com", 1000, 0); !errors.Is(err, app.ErrCodeExpired) {
+		t.Errorf("err = %v, want ErrCodeExpired", err)
+	}
+}
+
+func TestResolve_Expired_AfterWindow(t *testing.T) {
+	srv, store := newService(t)
+	ctx := context.Background()
+	until := time.Date(2025, 12, 31, 0, 0, 0, 0, time.UTC)
+	if err := store.Create(ctx, mustCode(t, "PAST", domain.KindPercent, 5, "USD", nil, &until, 0, 1)); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if _, err := srv.Resolve(ctx, "PAST", "jane@example.com", 1000, 0); !errors.Is(err, app.ErrCodeExpired) {
+		t.Errorf("err = %v, want ErrCodeExpired", err)
+	}
+}
+
+func TestResolve_MaxUsesReached(t *testing.T) {
+	srv, store := newService(t)
+	ctx := context.Background()
+	c := domain.RebuildCode("CAP", domain.KindPercent, 5, "USD", nil, nil, 1, 1, 1, time.Now())
+	if err := store.Create(ctx, c); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if _, err := srv.Resolve(ctx, "CAP", "jane@example.com", 1000, 0); !errors.Is(err, app.ErrCodeMaxUsesReached) {
+		t.Errorf("err = %v, want ErrCodeMaxUsesReached", err)
+	}
+}
+
+func TestResolve_CustomerLimit(t *testing.T) {
+	srv, store := newService(t)
+	ctx := context.Background()
+	if err := store.Create(ctx, mustCode(t, "ONEPER", domain.KindPercent, 5, "USD", nil, nil, 0, 1)); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if err := srv.Redeem(ctx, "ONEPER", "ord-1", "jane@example.com", domain.NewDiscount("ONEPER", domain.KindPercent, 50, "USD", false)); err != nil {
+		t.Fatalf("first redeem: %v", err)
+	}
+	if _, err := srv.Resolve(ctx, "ONEPER", "jane@example.com", 1000, 0); !errors.Is(err, app.ErrCodeCustomerLimit) {
+		t.Errorf("err = %v, want ErrCodeCustomerLimit", err)
+	}
+}
+
+func TestRedeem_IdempotentOnSameOrder(t *testing.T) {
+	srv, store := newService(t)
+	ctx := context.Background()
+	if err := store.Create(ctx, mustCode(t, "DUP", domain.KindPercent, 5, "USD", nil, nil, 1, 0)); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	d := domain.NewDiscount("DUP", domain.KindPercent, 50, "USD", false)
+	if err := srv.Redeem(ctx, "DUP", "ord-1", "jane@example.com", d); err != nil {
+		t.Fatalf("first redeem: %v", err)
+	}
+	if err := srv.Redeem(ctx, "DUP", "ord-1", "jane@example.com", d); err != nil {
+		t.Errorf("idempotent redeem err = %v, want nil", err)
+	}
+	got, err := store.Find(ctx, "DUP")
+	if err != nil {
+		t.Fatalf("Find: %v", err)
+	}
+	if got.UsedCount() != 1 {
+		t.Errorf("used_count = %d, want 1 (idempotent retry must not double-count)", got.UsedCount())
+	}
+}

--- a/backend/promo/bounded_context.go
+++ b/backend/promo/bounded_context.go
@@ -1,0 +1,26 @@
+// Package promo is the composition root for the promo (discount codes)
+// bounded context. The context owns its data wholly (promo_code +
+// promo_redemption from migration 000026); the only outward dependency is
+// at the checkout boundary, where Service.Resolve / Service.Redeem are
+// invoked. See backend/checkout/app/checkout.go for the integration.
+package promo
+
+import (
+	"database/sql"
+
+	"github.com/bkielbasa/go-ecommerce/backend/internal/application"
+	"github.com/bkielbasa/go-ecommerce/backend/promo/adapter"
+	"github.com/bkielbasa/go-ecommerce/backend/promo/app"
+)
+
+// New wires the production storage adapter and returns both the
+// application.BoundedContext envelope and the concrete *app.Service so the
+// layout package can declare a narrow interface against its public methods
+// without leaking the storage type.
+func New(db *sql.DB) (application.BoundedContext, *app.Service) {
+	storage := adapter.NewPostgres(db)
+	srv := app.NewService(storage)
+	return &boundedContext{}, srv
+}
+
+type boundedContext struct{}

--- a/backend/promo/domain/code.go
+++ b/backend/promo/domain/code.go
@@ -1,0 +1,281 @@
+// Package domain holds the promo bounded context's value objects: the
+// catalogue Code (an admin-created discount entry) and the resolved Discount
+// (the per-order, per-subtotal amount actually applied at checkout). The
+// math lives on Code.Apply so the same calculation drives both the live
+// checkout and any later replay / preview.
+package domain
+
+import (
+	"errors"
+	"math"
+	"strings"
+	"time"
+)
+
+// Kind is the discount mechanic. The three values map 1:1 to the
+// `promo_kind` enum in migration 000026_promo_codes.
+type Kind string
+
+const (
+	// KindPercent reduces the subtotal by a whole-percent value in [1, 100].
+	KindPercent Kind = "percent"
+	// KindFixed subtracts a fixed amount (in minor units) from the
+	// subtotal, capped so the discounted subtotal is never below zero.
+	KindFixed Kind = "fixed"
+	// KindFreeShipping zeroes the shipping cost regardless of the
+	// configured free-shipping threshold; it never touches the subtotal.
+	KindFreeShipping Kind = "free_shipping"
+)
+
+// MaxCodeLength bounds the user-facing code text. Postgres has no length
+// limit on `text`, but a sensible cap stops the form from accepting
+// pathologically long inputs and keeps the admin list table tidy.
+const MaxCodeLength = 64
+
+// ErrInvalidCode is returned by NewCode when the supplied parameters fail
+// validation (empty code, out-of-range percent, etc.).
+var ErrInvalidCode = errors.New("invalid promo code")
+
+// Code is a catalogue entry an admin created. The fields cover the three
+// supported discount mechanics plus the validity window and the per-code /
+// per-customer usage limits.
+type Code struct {
+	code           string
+	kind           Kind
+	valueMinor     int64
+	currency       string
+	validFrom      *time.Time
+	validUntil     *time.Time
+	maxUses        int
+	perCustomerMax int
+	usedCount      int
+	createdAt      time.Time
+}
+
+// NewCode validates and constructs a freshly minted Code (used_count
+// defaults to 0, created_at defaults to time.Now). validFrom/validUntil
+// may both be nil — that is "always valid". maxUses=0 and perCustomerMax=0
+// each mean "unlimited"; the default per-customer cap chosen by the caller
+// is documented in the admin UI as "1".
+func NewCode(code string, kind Kind, valueMinor int64, currency string, validFrom, validUntil *time.Time, maxUses, perCustomerMax int) (Code, error) {
+	trimmed := strings.TrimSpace(code)
+	if trimmed == "" {
+		return Code{}, ErrInvalidCode
+	}
+	if len(trimmed) > MaxCodeLength {
+		return Code{}, ErrInvalidCode
+	}
+	switch kind {
+	case KindPercent:
+		if valueMinor < 1 || valueMinor > 100 {
+			return Code{}, ErrInvalidCode
+		}
+	case KindFixed:
+		if valueMinor <= 0 {
+			return Code{}, ErrInvalidCode
+		}
+		if strings.TrimSpace(currency) == "" {
+			return Code{}, ErrInvalidCode
+		}
+	case KindFreeShipping:
+		// value/currency are ignored — normalise them so the persisted
+		// row is consistent regardless of what the admin entered.
+		valueMinor = 0
+	default:
+		return Code{}, ErrInvalidCode
+	}
+	if maxUses < 0 || perCustomerMax < 0 {
+		return Code{}, ErrInvalidCode
+	}
+	if validFrom != nil && validUntil != nil && validUntil.Before(*validFrom) {
+		return Code{}, ErrInvalidCode
+	}
+	if strings.TrimSpace(currency) == "" {
+		currency = "USD"
+	}
+	return Code{
+		code:           trimmed,
+		kind:           kind,
+		valueMinor:     valueMinor,
+		currency:       strings.ToUpper(strings.TrimSpace(currency)),
+		validFrom:      validFrom,
+		validUntil:     validUntil,
+		maxUses:        maxUses,
+		perCustomerMax: perCustomerMax,
+		createdAt:      time.Now().UTC(),
+	}, nil
+}
+
+// RebuildCode reconstructs a Code from storage. It bypasses validation so
+// adapters can hydrate exactly what the database returned (including legacy
+// rows that pre-date a tightened invariant).
+func RebuildCode(code string, kind Kind, valueMinor int64, currency string, validFrom, validUntil *time.Time, maxUses, perCustomerMax, usedCount int, createdAt time.Time) Code {
+	return Code{
+		code:           code,
+		kind:           kind,
+		valueMinor:     valueMinor,
+		currency:       currency,
+		validFrom:      validFrom,
+		validUntil:     validUntil,
+		maxUses:        maxUses,
+		perCustomerMax: perCustomerMax,
+		usedCount:      usedCount,
+		createdAt:      createdAt,
+	}
+}
+
+// Getters — value object, fields are immutable from the outside.
+func (c Code) CodeText() string         { return c.code }
+func (c Code) Kind() Kind               { return c.kind }
+func (c Code) ValueMinor() int64        { return c.valueMinor }
+func (c Code) Currency() string         { return c.currency }
+func (c Code) ValidFrom() *time.Time    { return c.validFrom }
+func (c Code) ValidUntil() *time.Time   { return c.validUntil }
+func (c Code) MaxUses() int             { return c.maxUses }
+func (c Code) PerCustomerMax() int      { return c.perCustomerMax }
+func (c Code) UsedCount() int           { return c.usedCount }
+func (c Code) CreatedAt() time.Time     { return c.createdAt }
+
+// KindDisplay returns a human-friendly label for the admin list.
+func (c Code) KindDisplay() string {
+	switch c.kind {
+	case KindPercent:
+		return "percent"
+	case KindFixed:
+		return "fixed"
+	case KindFreeShipping:
+		return "free shipping"
+	default:
+		return string(c.kind)
+	}
+}
+
+// ValueDisplay renders the value column in the admin list according to the
+// code's kind: "10%" for percent, "5.00 USD" for fixed, and "—" for free
+// shipping.
+func (c Code) ValueDisplay() string {
+	switch c.kind {
+	case KindPercent:
+		return itoa(c.valueMinor) + "%"
+	case KindFixed:
+		return money(c.valueMinor) + " " + c.currency
+	default:
+		return "—"
+	}
+}
+
+// IsActiveAt reports whether the code is currently within its validity
+// window. nil bounds are open (a one-sided window is allowed).
+func (c Code) IsActiveAt(t time.Time) bool {
+	if c.validFrom != nil && t.Before(*c.validFrom) {
+		return false
+	}
+	if c.validUntil != nil && t.After(*c.validUntil) {
+		return false
+	}
+	return true
+}
+
+// MaxUsesReached reports whether the global redemption cap is hit. A
+// maxUses of 0 means unlimited.
+func (c Code) MaxUsesReached() bool {
+	return c.maxUses > 0 && c.usedCount >= c.maxUses
+}
+
+// Discount is the resolved discount for a specific subtotal + shipping
+// cost. It is the output of Code.Apply and the input the checkout pricing
+// math reads.
+type Discount struct {
+	code         string
+	kind         Kind
+	amountMinor  int64
+	currency     string
+	freeShipping bool
+}
+
+// NewDiscount is exported so the app service can construct an "empty" no-op
+// discount (no code applied) when the checkout call did not carry one.
+func NewDiscount(code string, kind Kind, amountMinor int64, currency string, freeShipping bool) Discount {
+	return Discount{code: code, kind: kind, amountMinor: amountMinor, currency: currency, freeShipping: freeShipping}
+}
+
+// Code returns the literal code text (empty when no discount was applied).
+func (d Discount) Code() string         { return d.code }
+func (d Discount) Kind() Kind           { return d.kind }
+func (d Discount) AmountMinor() int64   { return d.amountMinor }
+func (d Discount) Currency() string     { return d.currency }
+func (d Discount) FreeShipping() bool   { return d.freeShipping }
+func (d Discount) Empty() bool          { return d.code == "" && d.amountMinor == 0 && !d.freeShipping }
+
+// Apply derives a Discount for the given subtotal/shipping. The math is
+// pure and stays in the domain so it can be replayed deterministically
+// from the event log.
+//
+//   - percent: amount = round(subtotal * value / 100), freeShipping=false
+//   - fixed: amount = min(value, subtotal) so the subtotal is never negative
+//   - free_shipping: amount = 0, freeShipping=true (shipping is zeroed by
+//     the checkout pricing math when this flag is set)
+func (c Code) Apply(subtotal int64, shippingCost int64) Discount {
+	d := Discount{code: c.code, kind: c.kind, currency: c.currency}
+	switch c.kind {
+	case KindPercent:
+		if subtotal <= 0 {
+			return d
+		}
+		d.amountMinor = int64(math.Round(float64(subtotal) * float64(c.valueMinor) / 100.0))
+	case KindFixed:
+		if subtotal <= 0 {
+			return d
+		}
+		amt := c.valueMinor
+		if amt > subtotal {
+			amt = subtotal
+		}
+		d.amountMinor = amt
+	case KindFreeShipping:
+		d.freeShipping = true
+		// shippingCost is reported for symmetry with the other cases —
+		// the checkout pricing math is the actual seat of the
+		// "shipping = 0" decision.
+		_ = shippingCost
+	}
+	return d
+}
+
+// money formats an amount in minor units as "X.YY". Local copy avoids a
+// dependency on the checkout package; the format is identical.
+func money(amount int64) string {
+	if amount < 0 {
+		amount = -amount
+	}
+	return itoa(amount/100) + "." + pad2(amount%100)
+}
+
+func pad2(n int64) string {
+	if n < 10 {
+		return "0" + itoa(n)
+	}
+	return itoa(n)
+}
+
+func itoa(n int64) string {
+	if n == 0 {
+		return "0"
+	}
+	negative := n < 0
+	if negative {
+		n = -n
+	}
+	var buf [20]byte
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	if negative {
+		i--
+		buf[i] = '-'
+	}
+	return string(buf[i:])
+}

--- a/backend/promo/domain/code_test.go
+++ b/backend/promo/domain/code_test.go
@@ -1,0 +1,106 @@
+package domain_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/bkielbasa/go-ecommerce/backend/promo/domain"
+)
+
+func TestNewCode_ValidatesKind(t *testing.T) {
+	cases := []struct {
+		name    string
+		code    string
+		kind    domain.Kind
+		value   int64
+		ccy     string
+		wantErr bool
+	}{
+		{"percent ok", "SAVE10", domain.KindPercent, 10, "USD", false},
+		{"percent zero", "ZERO", domain.KindPercent, 0, "USD", true},
+		{"percent over 100", "OVER", domain.KindPercent, 150, "USD", true},
+		{"fixed ok", "FIVE", domain.KindFixed, 500, "USD", false},
+		{"fixed zero", "ZEROFIX", domain.KindFixed, 0, "USD", true},
+		{"fixed missing ccy", "BADCCY", domain.KindFixed, 500, "", true},
+		{"free shipping ok", "FREESHIP", domain.KindFreeShipping, 0, "", false},
+		{"empty code", "  ", domain.KindPercent, 10, "USD", true},
+		{"bad kind", "X", domain.Kind("weird"), 1, "USD", true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			_, err := domain.NewCode(c.code, c.kind, c.value, c.ccy, nil, nil, 0, 1)
+			if c.wantErr {
+				if !errors.Is(err, domain.ErrInvalidCode) {
+					t.Fatalf("want ErrInvalidCode, got %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected err: %v", err)
+			}
+		})
+	}
+}
+
+func TestCode_Apply_Percent(t *testing.T) {
+	c, err := domain.NewCode("SAVE10", domain.KindPercent, 10, "USD", nil, nil, 0, 1)
+	if err != nil {
+		t.Fatalf("NewCode: %v", err)
+	}
+	d := c.Apply(2500, 500)
+	if d.AmountMinor() != 250 {
+		t.Errorf("amount = %d, want 250", d.AmountMinor())
+	}
+	if d.FreeShipping() {
+		t.Errorf("percent should not flag free shipping")
+	}
+	if d.Code() != "SAVE10" {
+		t.Errorf("code text lost: %q", d.Code())
+	}
+}
+
+func TestCode_Apply_FixedCapsAtSubtotal(t *testing.T) {
+	c, err := domain.NewCode("BIG", domain.KindFixed, 10000, "USD", nil, nil, 0, 1)
+	if err != nil {
+		t.Fatalf("NewCode: %v", err)
+	}
+	// subtotal smaller than discount: amount caps at subtotal so the
+	// discounted subtotal never goes negative.
+	d := c.Apply(500, 0)
+	if d.AmountMinor() != 500 {
+		t.Errorf("amount = %d, want 500", d.AmountMinor())
+	}
+}
+
+func TestCode_Apply_FreeShipping(t *testing.T) {
+	c, err := domain.NewCode("FREESHIP", domain.KindFreeShipping, 0, "", nil, nil, 0, 1)
+	if err != nil {
+		t.Fatalf("NewCode: %v", err)
+	}
+	d := c.Apply(2500, 500)
+	if d.AmountMinor() != 0 {
+		t.Errorf("amount = %d, want 0", d.AmountMinor())
+	}
+	if !d.FreeShipping() {
+		t.Errorf("free shipping flag not set")
+	}
+}
+
+func TestCode_IsActiveAt(t *testing.T) {
+	from := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	until := time.Date(2026, 12, 31, 23, 59, 59, 0, time.UTC)
+	c, err := domain.NewCode("WIN", domain.KindPercent, 5, "USD", &from, &until, 0, 1)
+	if err != nil {
+		t.Fatalf("NewCode: %v", err)
+	}
+	if c.IsActiveAt(time.Date(2025, 12, 31, 23, 0, 0, 0, time.UTC)) {
+		t.Errorf("before window: should not be active")
+	}
+	if !c.IsActiveAt(time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)) {
+		t.Errorf("inside window: should be active")
+	}
+	if c.IsActiveAt(time.Date(2027, 1, 2, 0, 0, 0, 0, time.UTC)) {
+		t.Errorf("after window: should not be active")
+	}
+}

--- a/backend/reviews/adapter/inmemory.go
+++ b/backend/reviews/adapter/inmemory.go
@@ -1,0 +1,133 @@
+package adapter
+
+import (
+	"context"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/bkielbasa/go-ecommerce/backend/reviews/app"
+	"github.com/bkielbasa/go-ecommerce/backend/reviews/domain"
+)
+
+// InMemory is the test-friendly Storage adapter. It mirrors the postgres
+// adapter's contract: the unique-index conflict is surfaced as
+// app.ErrDuplicateReview; soft-deleted rows are excluded from ByProduct,
+// AggregateForProducts and HasReviewed.
+type InMemory struct {
+	mu      sync.Mutex
+	reviews []domain.Review
+}
+
+// NewInMemory builds an empty in-memory store, used by the service-level
+// unit tests.
+func NewInMemory() *InMemory {
+	return &InMemory{}
+}
+
+// Insert mirrors the postgres unique-index conflict: a second active review
+// from the same customer for the same product is rejected with
+// app.ErrDuplicateReview.
+func (m *InMemory) Insert(ctx context.Context, r domain.Review) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, existing := range m.reviews {
+		if existing.IsDeleted() {
+			continue
+		}
+		if existing.ProductID() == r.ProductID() && existing.CustomerID() == r.CustomerID() {
+			return app.ErrDuplicateReview
+		}
+	}
+	m.reviews = append(m.reviews, r)
+	return nil
+}
+
+// SoftDelete stamps deleted_at on the matching review. Missing ids are a
+// no-op (mirroring the postgres UPDATE that simply affects 0 rows).
+func (m *InMemory) SoftDelete(ctx context.Context, id string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	now := time.Now()
+	for i, r := range m.reviews {
+		if r.ID() != id || r.IsDeleted() {
+			continue
+		}
+		m.reviews[i] = domain.RebuildReview(r.ID(), r.ProductID(), r.CustomerID(), r.Body(), r.Rating(), r.CreatedAt(), &now)
+		return nil
+	}
+	return nil
+}
+
+// ByProduct returns the active reviews for a product, newest-first, capped
+// at limit.
+func (m *InMemory) ByProduct(ctx context.Context, productID string, limit int) ([]domain.Review, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	var out []domain.Review
+	for _, r := range m.reviews {
+		if r.IsDeleted() || r.ProductID() != productID {
+			continue
+		}
+		out = append(out, r)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].CreatedAt().After(out[j].CreatedAt()) })
+	if limit > 0 && len(out) > limit {
+		out = out[:limit]
+	}
+	return out, nil
+}
+
+// AggregateForProducts returns one Aggregate per product id that has at
+// least one active review.
+func (m *InMemory) AggregateForProducts(ctx context.Context, productIDs []string) (map[string]domain.Aggregate, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	wanted := make(map[string]bool, len(productIDs))
+	for _, id := range productIDs {
+		wanted[id] = true
+	}
+
+	type acc struct {
+		sum   int
+		count int
+	}
+	totals := map[string]*acc{}
+	for _, r := range m.reviews {
+		if r.IsDeleted() {
+			continue
+		}
+		if !wanted[r.ProductID()] {
+			continue
+		}
+		a, ok := totals[r.ProductID()]
+		if !ok {
+			a = &acc{}
+			totals[r.ProductID()] = a
+		}
+		a.sum += r.Rating()
+		a.count++
+	}
+	out := make(map[string]domain.Aggregate, len(totals))
+	for pid, a := range totals {
+		out[pid] = domain.RebuildAggregate(pid, float64(a.sum)/float64(a.count), a.count)
+	}
+	return out, nil
+}
+
+// HasReviewed reports whether an active review by this customer exists for
+// the product.
+func (m *InMemory) HasReviewed(ctx context.Context, productID, customerID string) (bool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, r := range m.reviews {
+		if r.IsDeleted() {
+			continue
+		}
+		if r.ProductID() == productID && r.CustomerID() == customerID {
+			return true, nil
+		}
+	}
+	return false, nil
+}

--- a/backend/reviews/adapter/postgres.go
+++ b/backend/reviews/adapter/postgres.go
@@ -1,0 +1,147 @@
+package adapter
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/bkielbasa/go-ecommerce/backend/reviews/app"
+	"github.com/bkielbasa/go-ecommerce/backend/reviews/domain"
+	"github.com/lib/pq"
+)
+
+// pgUniqueViolation is the SQLSTATE code postgres returns when a write
+// hits a unique index conflict (the partial unique index on
+// (product_id, customer_id) WHERE deleted_at IS NULL). We map it to
+// app.ErrDuplicateReview so callers can branch on the sentinel without
+// reaching for pq.Error themselves.
+const pgUniqueViolation = "23505"
+
+// Postgres is the production Storage adapter. It uses parameterised SQL
+// throughout — the only "user input" interpolated into the statement string
+// is the placeholder index, never a value.
+type Postgres struct {
+	db *sql.DB
+}
+
+// NewPostgres builds the production adapter bound to the supplied database
+// connection (the same *sql.DB the rest of the app shares).
+func NewPostgres(db *sql.DB) *Postgres {
+	return &Postgres{db: db}
+}
+
+// Insert writes a fresh review. A unique-index conflict (the partial unique
+// index that ignores soft-deleted rows) is surfaced as ErrDuplicateReview so
+// callers can render a friendly message.
+func (p *Postgres) Insert(ctx context.Context, r domain.Review) error {
+	_, err := p.db.ExecContext(ctx, `
+		INSERT INTO reviews_review (id, product_id, customer_id, rating, body, created_at)
+		VALUES ($1, $2, $3, $4, $5, $6)
+	`, r.ID(), r.ProductID(), r.CustomerID(), r.Rating(), r.Body(), r.CreatedAt())
+	if err != nil {
+		var pqErr *pq.Error
+		if errors.As(err, &pqErr) && string(pqErr.Code) == pgUniqueViolation {
+			return app.ErrDuplicateReview
+		}
+		return fmt.Errorf("insert review: %w", err)
+	}
+	return nil
+}
+
+// SoftDelete stamps deleted_at = now() on the matching row. Already-deleted
+// reviews are left untouched.
+func (p *Postgres) SoftDelete(ctx context.Context, id string) error {
+	_, err := p.db.ExecContext(ctx, `
+		UPDATE reviews_review SET deleted_at = now()
+		WHERE id = $1 AND deleted_at IS NULL
+	`, id)
+	if err != nil {
+		return fmt.Errorf("soft-delete review: %w", err)
+	}
+	return nil
+}
+
+// ByProduct returns the active reviews for a product, newest-first, capped
+// at limit. The DB query relies on the (product_id, created_at DESC) partial
+// index for ordering.
+func (p *Postgres) ByProduct(ctx context.Context, productID string, limit int) ([]domain.Review, error) {
+	rows, err := p.db.QueryContext(ctx, `
+		SELECT id, product_id, customer_id, rating, body, created_at
+		FROM reviews_review
+		WHERE product_id = $1 AND deleted_at IS NULL
+		ORDER BY created_at DESC
+		LIMIT $2
+	`, productID, limit)
+	if err != nil {
+		return nil, fmt.Errorf("query reviews: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []domain.Review
+	for rows.Next() {
+		var id, productID, customerID, body string
+		var rating int
+		var createdAt time.Time
+		if err := rows.Scan(&id, &productID, &customerID, &rating, &body, &createdAt); err != nil {
+			return nil, fmt.Errorf("scan review: %w", err)
+		}
+		out = append(out, domain.RebuildReview(id, productID, customerID, body, rating, createdAt, nil))
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("rows: %w", err)
+	}
+	return out, nil
+}
+
+// AggregateForProducts runs a single grouped query over the requested ids
+// (passed as a pq.Array($1::text[])) so the result set is bounded and
+// ordering doesn't matter — callers index by product id.
+func (p *Postgres) AggregateForProducts(ctx context.Context, productIDs []string) (map[string]domain.Aggregate, error) {
+	if len(productIDs) == 0 {
+		return map[string]domain.Aggregate{}, nil
+	}
+	rows, err := p.db.QueryContext(ctx, `
+		SELECT product_id, AVG(rating)::float8, COUNT(*)
+		FROM reviews_review
+		WHERE product_id = ANY($1) AND deleted_at IS NULL
+		GROUP BY product_id
+	`, pq.Array(productIDs))
+	if err != nil {
+		return nil, fmt.Errorf("aggregate reviews: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	out := map[string]domain.Aggregate{}
+	for rows.Next() {
+		var pid string
+		var avg float64
+		var count int
+		if err := rows.Scan(&pid, &avg, &count); err != nil {
+			return nil, fmt.Errorf("scan aggregate: %w", err)
+		}
+		out[pid] = domain.RebuildAggregate(pid, avg, count)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("rows: %w", err)
+	}
+	return out, nil
+}
+
+// HasReviewed checks for any active review by the customer on the product.
+func (p *Postgres) HasReviewed(ctx context.Context, productID, customerID string) (bool, error) {
+	var dummy int
+	err := p.db.QueryRowContext(ctx, `
+		SELECT 1 FROM reviews_review
+		WHERE product_id = $1 AND customer_id = $2 AND deleted_at IS NULL
+		LIMIT 1
+	`, productID, customerID).Scan(&dummy)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("has reviewed: %w", err)
+	}
+	return true, nil
+}

--- a/backend/reviews/app/service.go
+++ b/backend/reviews/app/service.go
@@ -1,0 +1,172 @@
+// Package app holds the reviews application service. It enforces the
+// verified-buyer rule (via the VerifiedBuyerChecker port, which the
+// composition root wires to the checkout query side) and the
+// one-review-per-(customer, product) rule (the unique index in storage maps
+// to ErrDuplicateReview). Admin soft-delete is a thin pass-through.
+package app
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/bkielbasa/go-ecommerce/backend/reviews/domain"
+)
+
+// ErrDuplicateReview is returned by Submit when a (customer, product) pair
+// already has an active review. Storage adapters map their underlying
+// uniqueness violation onto this sentinel.
+var ErrDuplicateReview = errors.New("review already exists for this product")
+
+// ErrNotVerifiedBuyer is returned by Submit when the verified-buyer check
+// reports the customer has not purchased the product.
+var ErrNotVerifiedBuyer = errors.New("only verified buyers can leave a review")
+
+// Storage is the persistence port for reviews. Adapters live in
+// reviews/adapter (postgres + in-memory). The unique index on
+// (product_id, customer_id) WHERE deleted_at IS NULL is mapped to
+// ErrDuplicateReview by Insert.
+type Storage interface {
+	Insert(ctx context.Context, r domain.Review) error
+	SoftDelete(ctx context.Context, id string) error
+	ByProduct(ctx context.Context, productID string, limit int) ([]domain.Review, error)
+	AggregateForProducts(ctx context.Context, productIDs []string) (map[string]domain.Aggregate, error)
+	HasReviewed(ctx context.Context, productID, customerID string) (bool, error)
+}
+
+// VerifiedBuyerChecker is the cross-context port used to gate Submit. The
+// composition root wires it to the checkout query side (a thin adapter
+// calling checkoutQry.HasPurchasedProduct).
+type VerifiedBuyerChecker interface {
+	HasPurchased(ctx context.Context, customerID, productID string) (bool, error)
+}
+
+// Service is the application-level facade over Storage + VerifiedBuyerChecker.
+// All cross-cutting concerns (id generation, time, verified-buyer policy) live
+// here so the storage adapters stay dumb and the domain stays free of I/O.
+type Service struct {
+	storage Storage
+	buyers  VerifiedBuyerChecker
+	now     func() time.Time
+	newID   func() string
+}
+
+// NewService wires the service against a Storage and a VerifiedBuyerChecker.
+// Time and id generation default to the standard library; tests can override
+// them with WithClock/WithIDGenerator.
+func NewService(storage Storage, buyers VerifiedBuyerChecker) *Service {
+	return &Service{
+		storage: storage,
+		buyers:  buyers,
+		now:     time.Now,
+		newID:   newRandomID,
+	}
+}
+
+// WithClock overrides the time source — used by tests to pin createdAt.
+func (s *Service) WithClock(now func() time.Time) *Service {
+	s.now = now
+	return s
+}
+
+// WithIDGenerator overrides the id generator — used by tests to make ids
+// predictable.
+func (s *Service) WithIDGenerator(newID func() string) *Service {
+	s.newID = newID
+	return s
+}
+
+// Submit enforces the verified-buyer rule, rejects duplicate reviews up
+// front (so the storefront returns a friendly error before hitting the DB),
+// builds a validated domain.Review and writes it. Duplicate submissions that
+// race past the up-front check are still caught by the unique-index
+// conflict in Insert and returned as ErrDuplicateReview.
+func (s *Service) Submit(ctx context.Context, productID, customerID, body string, rating int) error {
+	productID = strings.TrimSpace(productID)
+	customerID = strings.TrimSpace(customerID)
+	if productID == "" {
+		return fmt.Errorf("%w: product id is required", domain.ErrInvalidReview)
+	}
+	if customerID == "" {
+		return fmt.Errorf("%w: customer id is required", domain.ErrInvalidReview)
+	}
+
+	bought, err := s.buyers.HasPurchased(ctx, customerID, productID)
+	if err != nil {
+		return fmt.Errorf("verified-buyer check: %w", err)
+	}
+	if !bought {
+		return ErrNotVerifiedBuyer
+	}
+
+	already, err := s.storage.HasReviewed(ctx, productID, customerID)
+	if err != nil {
+		return fmt.Errorf("has-reviewed check: %w", err)
+	}
+	if already {
+		return ErrDuplicateReview
+	}
+
+	review, err := domain.NewReview(s.newID(), productID, customerID, body, rating, s.now())
+	if err != nil {
+		return err
+	}
+	return s.storage.Insert(ctx, review)
+}
+
+// Delete soft-deletes a review by id (admin-only at the HTTP layer).
+func (s *Service) Delete(ctx context.Context, id string) error {
+	if strings.TrimSpace(id) == "" {
+		return errors.New("review id is required")
+	}
+	return s.storage.SoftDelete(ctx, id)
+}
+
+// ListForProduct returns the most recent active reviews for a product,
+// newest first, capped at limit. A non-positive limit falls back to a
+// sensible default so callers (templates) can pass 0 to mean "the default
+// page-size".
+func (s *Service) ListForProduct(ctx context.Context, productID string, limit int) ([]domain.Review, error) {
+	if limit <= 0 {
+		limit = 20
+	}
+	return s.storage.ByProduct(ctx, productID, limit)
+}
+
+// AggregateForProducts returns the (avg, count) pair for every requested
+// product id. Products with no active reviews are simply absent from the
+// returned map so the template can render an empty state.
+func (s *Service) AggregateForProducts(ctx context.Context, productIDs []string) (map[string]domain.Aggregate, error) {
+	if len(productIDs) == 0 {
+		return map[string]domain.Aggregate{}, nil
+	}
+	return s.storage.AggregateForProducts(ctx, productIDs)
+}
+
+// HasReviewed reports whether the customer has an active review for the
+// product. Used by the storefront to decide whether to render the review
+// form on the product page.
+func (s *Service) HasReviewed(ctx context.Context, productID, customerID string) (bool, error) {
+	if strings.TrimSpace(productID) == "" || strings.TrimSpace(customerID) == "" {
+		return false, nil
+	}
+	return s.storage.HasReviewed(ctx, productID, customerID)
+}
+
+// newRandomID returns a 16-byte hex string — 128 bits of randomness is well
+// beyond what reviews collisions would ever need; keeping it lib-free avoids
+// pulling in a UUID dep just for this context.
+func newRandomID() string {
+	buf := make([]byte, 16)
+	if _, err := rand.Read(buf); err != nil {
+		// Falling back to a time-based id keeps the service alive even when
+		// the OS RNG hiccups; collisions are still astronomically unlikely
+		// at any realistic review volume.
+		return fmt.Sprintf("rev-%d", time.Now().UnixNano())
+	}
+	return "rev-" + hex.EncodeToString(buf)
+}

--- a/backend/reviews/app/service_test.go
+++ b/backend/reviews/app/service_test.go
@@ -1,0 +1,117 @@
+package app_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/bkielbasa/go-ecommerce/backend/reviews/adapter"
+	"github.com/bkielbasa/go-ecommerce/backend/reviews/app"
+)
+
+// stubBuyers is a fake VerifiedBuyerChecker driven by a static map of
+// (customer, product) -> hasPurchased. It lets each test express the
+// verified-buyer state without spinning up the checkout context.
+type stubBuyers struct {
+	purchases map[string]bool
+}
+
+func (s stubBuyers) HasPurchased(_ context.Context, customerID, productID string) (bool, error) {
+	return s.purchases[customerID+"|"+productID], nil
+}
+
+func newServiceFor(t *testing.T, buyers stubBuyers) (*app.Service, *adapter.InMemory) {
+	t.Helper()
+	storage := adapter.NewInMemory()
+	srv := app.NewService(storage, buyers).
+		WithClock(func() time.Time { return time.Date(2026, 5, 28, 12, 0, 0, 0, time.UTC) })
+	// Deterministic ids so we can spot duplicates by hand if a future
+	// regression starts using the id in equality checks.
+	var n int
+	srv = srv.WithIDGenerator(func() string {
+		n++
+		return "rev-test-" + time.Now().Format("150405") + "-" + string(rune('a'+n-1))
+	})
+	return srv, storage
+}
+
+func TestSubmit_RejectsNonBuyer(t *testing.T) {
+	srv, storage := newServiceFor(t, stubBuyers{purchases: map[string]bool{}})
+
+	err := srv.Submit(context.Background(), "prod-1", "alice@example.com", "great mug", 5)
+	if !errors.Is(err, app.ErrNotVerifiedBuyer) {
+		t.Fatalf("Submit(non-buyer) err = %v, want ErrNotVerifiedBuyer", err)
+	}
+
+	// Storage must remain empty — a rejected submission MUST NOT have
+	// written a review row.
+	list, err := storage.ByProduct(context.Background(), "prod-1", 10)
+	if err != nil {
+		t.Fatalf("ByProduct: %v", err)
+	}
+	if len(list) != 0 {
+		t.Fatalf("expected no reviews in storage after rejected submit; got %d", len(list))
+	}
+}
+
+func TestSubmit_RejectsDuplicate(t *testing.T) {
+	srv, storage := newServiceFor(t, stubBuyers{purchases: map[string]bool{
+		"alice@example.com|prod-1": true,
+	}})
+
+	ctx := context.Background()
+	if err := srv.Submit(ctx, "prod-1", "alice@example.com", "first review", 4); err != nil {
+		t.Fatalf("first Submit: unexpected err: %v", err)
+	}
+	if err := srv.Submit(ctx, "prod-1", "alice@example.com", "second review", 5); !errors.Is(err, app.ErrDuplicateReview) {
+		t.Fatalf("second Submit: err = %v, want ErrDuplicateReview", err)
+	}
+
+	list, err := storage.ByProduct(ctx, "prod-1", 10)
+	if err != nil {
+		t.Fatalf("ByProduct: %v", err)
+	}
+	if len(list) != 1 {
+		t.Fatalf("expected exactly one stored review; got %d", len(list))
+	}
+}
+
+func TestSubmit_AcceptsBuyerAndComputesAggregate(t *testing.T) {
+	srv, storage := newServiceFor(t, stubBuyers{purchases: map[string]bool{
+		"alice@example.com|prod-1": true,
+		"bob@example.com|prod-1":   true,
+	}})
+
+	ctx := context.Background()
+	if err := srv.Submit(ctx, "prod-1", "alice@example.com", "alice loved it", 5); err != nil {
+		t.Fatalf("Submit(alice): %v", err)
+	}
+	if err := srv.Submit(ctx, "prod-1", "bob@example.com", "bob was meh", 3); err != nil {
+		t.Fatalf("Submit(bob): %v", err)
+	}
+
+	list, err := storage.ByProduct(ctx, "prod-1", 10)
+	if err != nil {
+		t.Fatalf("ByProduct: %v", err)
+	}
+	if len(list) != 2 {
+		t.Fatalf("expected 2 reviews; got %d", len(list))
+	}
+
+	agg, err := srv.AggregateForProducts(ctx, []string{"prod-1"})
+	if err != nil {
+		t.Fatalf("AggregateForProducts: %v", err)
+	}
+	got, ok := agg["prod-1"]
+	if !ok {
+		t.Fatalf("expected aggregate for prod-1; got %#v", agg)
+	}
+	if got.Count() != 2 {
+		t.Errorf("aggregate Count = %d, want 2", got.Count())
+	}
+	const wantAvg = 4.0
+	if got.Average() != wantAvg {
+		t.Errorf("aggregate Average = %v, want %v", got.Average(), wantAvg)
+	}
+}

--- a/backend/reviews/bounded_context.go
+++ b/backend/reviews/bounded_context.go
@@ -1,0 +1,52 @@
+// Package reviews is the composition root for the reviews bounded context:
+// it wires the postgres storage adapter and a VerifiedBuyerChecker (built
+// from a tiny port the caller satisfies — typically the checkout query
+// side's HasPurchasedProduct) into the application Service. The exported
+// New() returns both the application.BoundedContext envelope and the
+// concrete *app.Service so the layout context can depend on it directly.
+package reviews
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/bkielbasa/go-ecommerce/backend/internal/application"
+	"github.com/bkielbasa/go-ecommerce/backend/reviews/adapter"
+	"github.com/bkielbasa/go-ecommerce/backend/reviews/app"
+)
+
+// VerifiedBuyerSource is the tiny ACL port the composition root satisfies.
+// The caller (cmd/web) passes any value whose HasPurchasedProduct matches
+// this signature — in practice the checkout query service. Keeping the port
+// here (rather than reaching into checkout/query) means the reviews context
+// has no compile-time dependency on checkout.
+type VerifiedBuyerSource interface {
+	HasPurchasedProduct(ctx context.Context, customerID, productID string) (bool, error)
+}
+
+// New wires the production adapter and verified-buyer port. The returned
+// *app.Service is intentionally exposed (not just as an interface) so the
+// layout context can declare a narrow interface against its public methods
+// without leaking the storage type.
+func New(db *sql.DB, buyers VerifiedBuyerSource) (application.BoundedContext, *app.Service) {
+	storage := adapter.NewPostgres(db)
+	checker := verifiedBuyerAdapter{buyers: buyers}
+	srv := app.NewService(storage, checker)
+	return &boundedContext{}, srv
+}
+
+// verifiedBuyerAdapter satisfies app.VerifiedBuyerChecker by delegating to
+// the supplied VerifiedBuyerSource. The parameter order flip
+// (HasPurchased(customerID, productID) -> HasPurchasedProduct(customerID,
+// productID)) is intentional: the reviews port names match the query the
+// checker is answering, while the source signature mirrors the checkout
+// query method.
+type verifiedBuyerAdapter struct {
+	buyers VerifiedBuyerSource
+}
+
+func (a verifiedBuyerAdapter) HasPurchased(ctx context.Context, customerID, productID string) (bool, error) {
+	return a.buyers.HasPurchasedProduct(ctx, customerID, productID)
+}
+
+type boundedContext struct{}

--- a/backend/reviews/domain/review.go
+++ b/backend/reviews/domain/review.go
@@ -1,0 +1,111 @@
+// Package domain holds the reviews bounded-context value objects: a Review
+// (a single rating + body left by a verified buyer) and an Aggregate (average
+// + count used for storefront badges). Reviews are authored once per
+// (customer, product); admins soft-delete (the unique index is partial and
+// ignores deleted rows so a buyer can re-review after a removal).
+package domain
+
+import (
+	"errors"
+	"strings"
+	"time"
+)
+
+// ErrInvalidReview is returned by NewReview when any of its inputs fail
+// validation (empty ids, rating out of range, empty/oversized body).
+var ErrInvalidReview = errors.New("invalid review")
+
+// maxBodyLen caps the body so a single review can't grow without bound
+// (matches the storefront textarea expectations).
+const maxBodyLen = 4000
+
+// Review is the value object persisted in reviews_review. createdAt is set
+// by the application layer at submission time so the in-memory and postgres
+// adapters agree on ordering; deletedAt is nil for active reviews and stamped
+// by SoftDelete.
+type Review struct {
+	id         string
+	productID  string
+	customerID string
+	rating     int
+	body       string
+	createdAt  time.Time
+	deletedAt  *time.Time
+}
+
+// NewReview validates inputs and returns a freshly-built Review. The body is
+// trimmed before length validation so whitespace-only submissions are
+// rejected. The createdAt comes from the caller (the service) so tests can
+// pin time.
+func NewReview(id, productID, customerID, body string, rating int, createdAt time.Time) (Review, error) {
+	if strings.TrimSpace(id) == "" {
+		return Review{}, errors.New("review id cannot be empty")
+	}
+	if strings.TrimSpace(productID) == "" {
+		return Review{}, errors.New("product id cannot be empty")
+	}
+	if strings.TrimSpace(customerID) == "" {
+		return Review{}, errors.New("customer id cannot be empty")
+	}
+	if rating < 1 || rating > 5 {
+		return Review{}, errors.New("rating must be between 1 and 5")
+	}
+	trimmed := strings.TrimSpace(body)
+	if trimmed == "" {
+		return Review{}, errors.New("review body cannot be empty")
+	}
+	if len(trimmed) > maxBodyLen {
+		return Review{}, errors.New("review body is too long")
+	}
+	return Review{
+		id:         id,
+		productID:  productID,
+		customerID: customerID,
+		rating:     rating,
+		body:       trimmed,
+		createdAt:  createdAt,
+	}, nil
+}
+
+// RebuildReview reconstructs a Review from storage rows (skipping validation,
+// since the row has already been validated once). deletedAt may be nil.
+func RebuildReview(id, productID, customerID, body string, rating int, createdAt time.Time, deletedAt *time.Time) Review {
+	return Review{
+		id:         id,
+		productID:  productID,
+		customerID: customerID,
+		rating:     rating,
+		body:       body,
+		createdAt:  createdAt,
+		deletedAt:  deletedAt,
+	}
+}
+
+func (r Review) ID() string            { return r.id }
+func (r Review) ProductID() string     { return r.productID }
+func (r Review) CustomerID() string    { return r.customerID }
+func (r Review) Rating() int           { return r.rating }
+func (r Review) Body() string          { return r.body }
+func (r Review) CreatedAt() time.Time  { return r.createdAt }
+func (r Review) DeletedAt() *time.Time { return r.deletedAt }
+func (r Review) IsDeleted() bool       { return r.deletedAt != nil }
+
+// Aggregate is the per-product summary used on the product page (e.g. the
+// "★★★★☆ 4.2 (12)" badge). Count is the number of active reviews; Average is
+// the mean rating across them. When Count is 0 Average is 0 (the badge is
+// hidden by the template).
+type Aggregate struct {
+	productID string
+	average   float64
+	count     int
+}
+
+// RebuildAggregate reconstructs an Aggregate from a storage row (the avg /
+// count returned by AggregateForProducts).
+func RebuildAggregate(productID string, avg float64, count int) Aggregate {
+	return Aggregate{productID: productID, average: avg, count: count}
+}
+
+func (a Aggregate) ProductID() string { return a.productID }
+func (a Aggregate) Average() float64  { return a.average }
+func (a Aggregate) Count() int        { return a.count }

--- a/backend/wishlist/adapter/inmemory.go
+++ b/backend/wishlist/adapter/inmemory.go
@@ -1,0 +1,79 @@
+package adapter
+
+import (
+	"context"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/bkielbasa/go-ecommerce/backend/wishlist/domain"
+)
+
+// InMemory is the test-friendly Storage adapter. It mirrors the postgres
+// adapter's contract: Add is idempotent on the (customer, variant) key,
+// Remove silently affects zero rows when the entry is missing, and
+// ListByCustomer returns entries newest-first.
+type InMemory struct {
+	mu    sync.Mutex
+	items []domain.Item
+}
+
+// NewInMemory builds an empty in-memory store, used by the service-level
+// unit tests.
+func NewInMemory() *InMemory {
+	return &InMemory{}
+}
+
+// Add stores a new (customer, variant) entry. A duplicate is silently
+// ignored to mirror the postgres ON CONFLICT DO NOTHING.
+func (m *InMemory) Add(ctx context.Context, customerID, variantID string, addedAt time.Time) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, it := range m.items {
+		if it.CustomerID() == customerID && it.VariantID() == variantID {
+			return nil
+		}
+	}
+	m.items = append(m.items, domain.Rebuild(customerID, variantID, addedAt))
+	return nil
+}
+
+// Remove deletes the matching entry. Missing entries are a no-op.
+func (m *InMemory) Remove(ctx context.Context, customerID, variantID string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for i, it := range m.items {
+		if it.CustomerID() == customerID && it.VariantID() == variantID {
+			m.items = append(m.items[:i], m.items[i+1:]...)
+			return nil
+		}
+	}
+	return nil
+}
+
+// ListByCustomer returns the customer's wishlist newest-first.
+func (m *InMemory) ListByCustomer(ctx context.Context, customerID string) ([]domain.Item, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	var out []domain.Item
+	for _, it := range m.items {
+		if it.CustomerID() == customerID {
+			out = append(out, it)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].AddedAt().After(out[j].AddedAt()) })
+	return out, nil
+}
+
+// Contains reports whether the (customer, variant) pair is currently in
+// the wishlist.
+func (m *InMemory) Contains(ctx context.Context, customerID, variantID string) (bool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, it := range m.items {
+		if it.CustomerID() == customerID && it.VariantID() == variantID {
+			return true, nil
+		}
+	}
+	return false, nil
+}

--- a/backend/wishlist/adapter/postgres.go
+++ b/backend/wishlist/adapter/postgres.go
@@ -1,0 +1,115 @@
+// Package adapter holds the wishlist storage adapters. The postgres
+// adapter speaks parameterised SQL against the wishlist_item table; the
+// in-memory adapter mirrors its contract for tests.
+package adapter
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/bkielbasa/go-ecommerce/backend/wishlist/domain"
+	"github.com/lib/pq"
+)
+
+// pgUniqueViolation is the SQLSTATE postgres returns on a primary-key
+// conflict. Add uses ON CONFLICT DO NOTHING, so this is mostly defensive —
+// any future variant of Insert that doesn't carry the clause will still be
+// idempotent thanks to the same mapping.
+const pgUniqueViolation = "23505"
+
+// Postgres is the production Storage adapter. Parameterised SQL throughout;
+// the only "user input" interpolated into the statement string is the
+// placeholder index, never a value.
+type Postgres struct {
+	db *sql.DB
+}
+
+// NewPostgres builds the production adapter bound to the supplied database
+// connection (the same *sql.DB the rest of the app shares).
+func NewPostgres(db *sql.DB) *Postgres {
+	return &Postgres{db: db}
+}
+
+// Add inserts a wishlist entry. ON CONFLICT DO NOTHING makes the call
+// idempotent — a second click on the heart button neither errors nor
+// updates added_at. As a belt-and-braces measure the unique-violation
+// SQLSTATE is also swallowed in case a future migration trades the
+// ON CONFLICT clause for an upsert.
+func (p *Postgres) Add(ctx context.Context, customerID, variantID string, addedAt time.Time) error {
+	_, err := p.db.ExecContext(ctx, `
+		INSERT INTO wishlist_item (customer_id, variant_id, added_at)
+		VALUES ($1, $2, $3)
+		ON CONFLICT (customer_id, variant_id) DO NOTHING
+	`, customerID, variantID, addedAt)
+	if err != nil {
+		var pqErr *pq.Error
+		if errors.As(err, &pqErr) && string(pqErr.Code) == pgUniqueViolation {
+			return nil
+		}
+		return fmt.Errorf("insert wishlist item: %w", err)
+	}
+	return nil
+}
+
+// Remove deletes a wishlist entry. Missing rows are silently a no-op.
+func (p *Postgres) Remove(ctx context.Context, customerID, variantID string) error {
+	_, err := p.db.ExecContext(ctx, `
+		DELETE FROM wishlist_item
+		WHERE customer_id = $1 AND variant_id = $2
+	`, customerID, variantID)
+	if err != nil {
+		return fmt.Errorf("delete wishlist item: %w", err)
+	}
+	return nil
+}
+
+// ListByCustomer returns the customer's wishlist newest-first. The
+// (customer_id, added_at DESC) index from migration 000025 backs the
+// ordering directly.
+func (p *Postgres) ListByCustomer(ctx context.Context, customerID string) ([]domain.Item, error) {
+	rows, err := p.db.QueryContext(ctx, `
+		SELECT customer_id, variant_id, added_at
+		FROM wishlist_item
+		WHERE customer_id = $1
+		ORDER BY added_at DESC
+	`, customerID)
+	if err != nil {
+		return nil, fmt.Errorf("query wishlist: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []domain.Item
+	for rows.Next() {
+		var cid, vid string
+		var addedAt time.Time
+		if err := rows.Scan(&cid, &vid, &addedAt); err != nil {
+			return nil, fmt.Errorf("scan wishlist item: %w", err)
+		}
+		out = append(out, domain.Rebuild(cid, vid, addedAt))
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("rows: %w", err)
+	}
+	return out, nil
+}
+
+// Contains reports whether the (customer, variant) pair is currently in
+// the wishlist.
+func (p *Postgres) Contains(ctx context.Context, customerID, variantID string) (bool, error) {
+	var dummy int
+	err := p.db.QueryRowContext(ctx, `
+		SELECT 1 FROM wishlist_item
+		WHERE customer_id = $1 AND variant_id = $2
+		LIMIT 1
+	`, customerID, variantID).Scan(&dummy)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("contains wishlist item: %w", err)
+	}
+	return true, nil
+}

--- a/backend/wishlist/app/service.go
+++ b/backend/wishlist/app/service.go
@@ -1,0 +1,98 @@
+// Package app holds the wishlist application service. The wishlist
+// bounded context is intentionally tiny — it owns the per-customer set of
+// saved variants and exposes idempotent Add / Remove / Toggle plus a couple
+// of read helpers. Cross-cutting concerns (auth, CSRF, htmx swaps) live in
+// the layout package; the service stays a thin wrapper around Storage.
+package app
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/bkielbasa/go-ecommerce/backend/wishlist/domain"
+)
+
+// Storage is the persistence port for wishlist items. Both Add and Remove
+// are idempotent: Add swallows the (customer_id, variant_id) primary-key
+// conflict (SQLSTATE 23505 in postgres) so a double-click on the heart
+// button is a no-op, and Remove silently affects zero rows when the entry
+// is already gone. ListByCustomer returns entries newest-first.
+type Storage interface {
+	Add(ctx context.Context, customerID, variantID string, addedAt time.Time) error
+	Remove(ctx context.Context, customerID, variantID string) error
+	ListByCustomer(ctx context.Context, customerID string) ([]domain.Item, error)
+	Contains(ctx context.Context, customerID, variantID string) (bool, error)
+}
+
+// Service is the application-level facade over Storage. It is intentionally
+// thin: each operation is a near-direct pass-through, with the current time
+// injected for Add so tests can pin addedAt deterministically.
+type Service struct {
+	storage Storage
+	now     func() time.Time
+}
+
+// NewService wires the service against a Storage. Time defaults to the
+// standard library; tests can override via WithClock.
+func NewService(storage Storage) *Service {
+	return &Service{storage: storage, now: time.Now}
+}
+
+// WithClock overrides the time source — used by tests to pin addedAt.
+func (s *Service) WithClock(now func() time.Time) *Service {
+	s.now = now
+	return s
+}
+
+// Add stores the (customer, variant) bookmark. Idempotent: if the entry
+// already exists the call succeeds without touching addedAt.
+func (s *Service) Add(ctx context.Context, customerID, variantID string) error {
+	return s.storage.Add(ctx, customerID, variantID, s.now())
+}
+
+// Remove deletes the (customer, variant) bookmark. Idempotent: removing an
+// absent entry is a no-op.
+func (s *Service) Remove(ctx context.Context, customerID, variantID string) error {
+	return s.storage.Remove(ctx, customerID, variantID)
+}
+
+// ListByCustomer returns the customer's wishlist, newest-first.
+func (s *Service) ListByCustomer(ctx context.Context, customerID string) ([]domain.Item, error) {
+	if strings.TrimSpace(customerID) == "" {
+		return nil, nil
+	}
+	return s.storage.ListByCustomer(ctx, customerID)
+}
+
+// Contains reports whether (customer, variant) is currently in the
+// wishlist. Used by the product page to decide between the outline heart
+// (add) and the filled heart (remove).
+func (s *Service) Contains(ctx context.Context, customerID, variantID string) (bool, error) {
+	if strings.TrimSpace(customerID) == "" || strings.TrimSpace(variantID) == "" {
+		return false, nil
+	}
+	return s.storage.Contains(ctx, customerID, variantID)
+}
+
+// Toggle flips the (customer, variant) bookmark: it adds the variant if it
+// is not in the wishlist and removes it if it is. The bool returned is the
+// post-call state — true means the variant is now in the wishlist, false
+// means it was removed. The HTTP layer uses this to render the next button
+// state for the htmx outerHTML swap.
+func (s *Service) Toggle(ctx context.Context, customerID, variantID string) (bool, error) {
+	present, err := s.storage.Contains(ctx, customerID, variantID)
+	if err != nil {
+		return false, err
+	}
+	if present {
+		if err := s.storage.Remove(ctx, customerID, variantID); err != nil {
+			return false, err
+		}
+		return false, nil
+	}
+	if err := s.storage.Add(ctx, customerID, variantID, s.now()); err != nil {
+		return false, err
+	}
+	return true, nil
+}

--- a/backend/wishlist/app/service_test.go
+++ b/backend/wishlist/app/service_test.go
@@ -1,0 +1,113 @@
+package app_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/bkielbasa/go-ecommerce/backend/wishlist/adapter"
+	"github.com/bkielbasa/go-ecommerce/backend/wishlist/app"
+)
+
+// newServiceFor builds a Service backed by the in-memory adapter with a
+// pinned clock so addedAt values are deterministic.
+func newServiceFor(t *testing.T) (*app.Service, *adapter.InMemory) {
+	t.Helper()
+	storage := adapter.NewInMemory()
+	srv := app.NewService(storage).
+		WithClock(func() time.Time { return time.Date(2026, 5, 28, 12, 0, 0, 0, time.UTC) })
+	return srv, storage
+}
+
+// TestToggle_FlipsState is the behavioural contract the product-page heart
+// button relies on: clicking on an absent variant adds it (and reports
+// "now present"); clicking again removes it (and reports "now absent").
+// The Storage view must agree with each reported state.
+func TestToggle_FlipsState(t *testing.T) {
+	srv, storage := newServiceFor(t)
+	ctx := context.Background()
+
+	added, err := srv.Toggle(ctx, "alice@example.com", "var-1")
+	if err != nil {
+		t.Fatalf("first Toggle: unexpected err: %v", err)
+	}
+	if !added {
+		t.Fatalf("first Toggle: added = false, want true (item should have been added)")
+	}
+
+	present, err := storage.Contains(ctx, "alice@example.com", "var-1")
+	if err != nil {
+		t.Fatalf("Contains after add: %v", err)
+	}
+	if !present {
+		t.Fatalf("Contains after add = false, want true")
+	}
+
+	added, err = srv.Toggle(ctx, "alice@example.com", "var-1")
+	if err != nil {
+		t.Fatalf("second Toggle: unexpected err: %v", err)
+	}
+	if added {
+		t.Fatalf("second Toggle: added = true, want false (item should have been removed)")
+	}
+
+	present, err = storage.Contains(ctx, "alice@example.com", "var-1")
+	if err != nil {
+		t.Fatalf("Contains after remove: %v", err)
+	}
+	if present {
+		t.Fatalf("Contains after remove = true, want false")
+	}
+}
+
+// TestAdd_IsIdempotent guards the postgres ON CONFLICT DO NOTHING contract
+// at the service level: a double-click on the heart button must not
+// produce duplicates and must not error.
+func TestAdd_IsIdempotent(t *testing.T) {
+	srv, storage := newServiceFor(t)
+	ctx := context.Background()
+
+	if err := srv.Add(ctx, "alice@example.com", "var-1"); err != nil {
+		t.Fatalf("first Add: %v", err)
+	}
+	if err := srv.Add(ctx, "alice@example.com", "var-1"); err != nil {
+		t.Fatalf("second Add (idempotent): %v", err)
+	}
+
+	list, err := storage.ListByCustomer(ctx, "alice@example.com")
+	if err != nil {
+		t.Fatalf("ListByCustomer: %v", err)
+	}
+	if len(list) != 1 {
+		t.Fatalf("expected exactly one wishlist item; got %d", len(list))
+	}
+}
+
+// TestListByCustomer_NewestFirst pins the ordering contract — the account
+// page renders the list straight from the service so the storage adapter's
+// sort matters.
+func TestListByCustomer_NewestFirst(t *testing.T) {
+	storage := adapter.NewInMemory()
+	srv := app.NewService(storage)
+
+	ctx := context.Background()
+	srv = srv.WithClock(func() time.Time { return time.Date(2026, 5, 27, 12, 0, 0, 0, time.UTC) })
+	if err := srv.Add(ctx, "alice@example.com", "var-old"); err != nil {
+		t.Fatalf("Add old: %v", err)
+	}
+	srv = srv.WithClock(func() time.Time { return time.Date(2026, 5, 28, 12, 0, 0, 0, time.UTC) })
+	if err := srv.Add(ctx, "alice@example.com", "var-new"); err != nil {
+		t.Fatalf("Add new: %v", err)
+	}
+
+	list, err := srv.ListByCustomer(ctx, "alice@example.com")
+	if err != nil {
+		t.Fatalf("ListByCustomer: %v", err)
+	}
+	if len(list) != 2 {
+		t.Fatalf("expected 2 items; got %d", len(list))
+	}
+	if list[0].VariantID() != "var-new" || list[1].VariantID() != "var-old" {
+		t.Fatalf("expected newest first; got %s then %s", list[0].VariantID(), list[1].VariantID())
+	}
+}

--- a/backend/wishlist/bounded_context.go
+++ b/backend/wishlist/bounded_context.go
@@ -1,0 +1,26 @@
+// Package wishlist is the composition root for the wishlist bounded
+// context: it wires the postgres storage adapter into the application
+// Service. Compared to reviews this context has no cross-context port —
+// the wishlist owns its data wholly and depends only on
+// productcatalog_variant via the table's foreign key.
+package wishlist
+
+import (
+	"database/sql"
+
+	"github.com/bkielbasa/go-ecommerce/backend/internal/application"
+	"github.com/bkielbasa/go-ecommerce/backend/wishlist/adapter"
+	"github.com/bkielbasa/go-ecommerce/backend/wishlist/app"
+)
+
+// New wires the production adapter and returns both the
+// application.BoundedContext envelope and the concrete *app.Service so the
+// layout context can declare a narrow interface against its public methods
+// without leaking the storage type.
+func New(db *sql.DB) (application.BoundedContext, *app.Service) {
+	storage := adapter.NewPostgres(db)
+	srv := app.NewService(storage)
+	return &boundedContext{}, srv
+}
+
+type boundedContext struct{}

--- a/backend/wishlist/domain/item.go
+++ b/backend/wishlist/domain/item.go
@@ -1,0 +1,28 @@
+// Package domain holds the wishlist bounded-context value object: an Item
+// is a single (customer, variant) bookmark with the timestamp it was saved.
+// Wishlists are keyed by variant id rather than product id so that each
+// colour / size of a variant product is independently saveable.
+package domain
+
+import "time"
+
+// Item is the value object persisted in wishlist_item. A wishlist is just
+// the unordered set of these for a given customer; the application layer
+// presents them newest-first by addedAt.
+type Item struct {
+	customerID string
+	variantID  string
+	addedAt    time.Time
+}
+
+// Rebuild reconstructs an Item from a storage row. The wishlist domain has
+// no construction-time validation (the customer / variant ids are opaque to
+// it) so callers — including the application service — go through this
+// constructor too.
+func Rebuild(customerID, variantID string, addedAt time.Time) Item {
+	return Item{customerID: customerID, variantID: variantID, addedAt: addedAt}
+}
+
+func (i Item) CustomerID() string { return i.customerID }
+func (i Item) VariantID() string  { return i.variantID }
+func (i Item) AddedAt() time.Time { return i.addedAt }

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -32,6 +32,12 @@ services:
       # threshold in MINOR units (cents). Both default to zero (disabled).
       TAX_RATE_PERCENT: ${TAX_RATE_PERCENT:-0}
       FREE_SHIPPING_THRESHOLD: ${FREE_SHIPPING_THRESHOLD:-0}
+      # Display-only multi-currency. The picker in the header is shown only
+      # when SUPPORTED_CURRENCIES has more than one entry. FX_RATES are
+      # operator-configured (NOT a live feed).
+      DEFAULT_CURRENCY: ${DEFAULT_CURRENCY:-USD}
+      SUPPORTED_CURRENCIES: ${SUPPORTED_CURRENCIES:-USD}
+      FX_RATES: ${FX_RATES:-}
       # OpenTelemetry: ship traces / metrics / logs to the local collector.
       # Empty / unset values disable each exporter — observability.Init*
       # functions detect this and skip exporter setup so the app still

--- a/migrations/000024_reviews.down.sql
+++ b/migrations/000024_reviews.down.sql
@@ -1,0 +1,7 @@
+BEGIN;
+
+DROP INDEX IF EXISTS public.reviews_review_product_idx;
+DROP INDEX IF EXISTS public.reviews_review_one_per_customer_per_product;
+DROP TABLE IF EXISTS public.reviews_review;
+
+COMMIT;

--- a/migrations/000024_reviews.up.sql
+++ b/migrations/000024_reviews.up.sql
@@ -1,0 +1,27 @@
+BEGIN;
+
+-- reviews_review holds customer-submitted ratings and bodies for products.
+-- Only verified buyers can create rows (enforced in the application layer
+-- by joining checkout_order_item -> productcatalog_variant -> product_id).
+-- One review per (customer, product) is enforced by the partial unique
+-- index below, which ignores soft-deleted rows so a buyer whose review was
+-- removed by an admin can submit a fresh one.
+CREATE TABLE public.reviews_review (
+    id text PRIMARY KEY,
+    product_id text NOT NULL REFERENCES public.productcatalog_product(id) ON DELETE CASCADE,
+    customer_id text NOT NULL,
+    rating int NOT NULL CHECK (rating BETWEEN 1 AND 5),
+    body text NOT NULL,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    deleted_at timestamptz
+);
+
+CREATE UNIQUE INDEX reviews_review_one_per_customer_per_product
+    ON public.reviews_review(product_id, customer_id)
+    WHERE deleted_at IS NULL;
+
+CREATE INDEX reviews_review_product_idx
+    ON public.reviews_review(product_id, created_at DESC)
+    WHERE deleted_at IS NULL;
+
+COMMIT;

--- a/migrations/000025_wishlist.down.sql
+++ b/migrations/000025_wishlist.down.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+DROP INDEX IF EXISTS public.wishlist_item_customer_idx;
+DROP TABLE IF EXISTS public.wishlist_item;
+
+COMMIT;

--- a/migrations/000025_wishlist.up.sql
+++ b/migrations/000025_wishlist.up.sql
@@ -1,0 +1,19 @@
+BEGIN;
+
+-- wishlist_item holds the per-customer set of saved product variants. The
+-- key is (customer_id, variant_id) — a variant is the purchasable unit so
+-- different colours/sizes of the same product are independently saveable.
+-- The ON DELETE CASCADE on the variant FK keeps the table tidy: when an
+-- admin removes a variant from the catalogue, every wishlist entry that
+-- referenced it disappears with it.
+CREATE TABLE public.wishlist_item (
+    customer_id text NOT NULL,
+    variant_id text NOT NULL REFERENCES public.productcatalog_variant(id) ON DELETE CASCADE,
+    added_at timestamptz NOT NULL DEFAULT now(),
+    PRIMARY KEY (customer_id, variant_id)
+);
+
+CREATE INDEX wishlist_item_customer_idx
+    ON public.wishlist_item(customer_id, added_at DESC);
+
+COMMIT;

--- a/migrations/000026_promo_codes.down.sql
+++ b/migrations/000026_promo_codes.down.sql
@@ -1,0 +1,8 @@
+BEGIN;
+
+DROP INDEX IF EXISTS public.promo_redemption_customer_idx;
+DROP TABLE IF EXISTS public.promo_redemption;
+DROP TABLE IF EXISTS public.promo_code;
+DROP TYPE IF EXISTS promo_kind;
+
+COMMIT;

--- a/migrations/000026_promo_codes.up.sql
+++ b/migrations/000026_promo_codes.up.sql
@@ -1,0 +1,41 @@
+BEGIN;
+
+-- promo_code is the catalogue of discount codes admins can create. The PK is
+-- the code itself (text) — codes are surfaced to customers verbatim and there
+-- is no benefit to a synthetic id. value_minor carries the per-kind payload:
+-- for 'percent' it is 1..100 (whole-percent), for 'fixed' it is the discount
+-- amount in minor units (so e.g. 500 = $5.00), and for 'free_shipping' it is
+-- ignored. used_count is the running redemption tally; max_uses=0 means
+-- unlimited and per_customer_max=0 likewise.
+CREATE TYPE promo_kind AS ENUM ('percent', 'fixed', 'free_shipping');
+
+CREATE TABLE public.promo_code (
+    code text PRIMARY KEY,
+    kind promo_kind NOT NULL,
+    value_minor bigint NOT NULL DEFAULT 0,
+    currency text NOT NULL DEFAULT 'USD',
+    valid_from timestamptz,
+    valid_until timestamptz,
+    max_uses int NOT NULL DEFAULT 0,
+    per_customer_max int NOT NULL DEFAULT 1,
+    used_count int NOT NULL DEFAULT 0,
+    created_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- promo_redemption is the per-order ledger; the (code, order_id) PK gives us
+-- idempotency on retries (the same order can't be redeemed twice) and a fast
+-- lookup for per-customer limits via the (code, customer_id) index.
+CREATE TABLE public.promo_redemption (
+    code text NOT NULL REFERENCES public.promo_code(code) ON DELETE CASCADE,
+    order_id text NOT NULL,
+    customer_id text NOT NULL,
+    discount_amount_minor bigint NOT NULL,
+    currency text NOT NULL,
+    redeemed_at timestamptz NOT NULL DEFAULT now(),
+    PRIMARY KEY (code, order_id)
+);
+
+CREATE INDEX promo_redemption_customer_idx
+    ON public.promo_redemption(code, customer_id);
+
+COMMIT;

--- a/migrations/000027_checkout_order_discount.down.sql
+++ b/migrations/000027_checkout_order_discount.down.sql
@@ -1,0 +1,7 @@
+BEGIN;
+
+ALTER TABLE public.checkout_order
+    DROP COLUMN IF EXISTS discount_amount,
+    DROP COLUMN IF EXISTS discount_code;
+
+COMMIT;

--- a/migrations/000027_checkout_order_discount.up.sql
+++ b/migrations/000027_checkout_order_discount.up.sql
@@ -1,0 +1,11 @@
+BEGIN;
+
+-- Promo-code fields captured at place time. Both default to "no discount" so
+-- historical orders (placed before promo codes existed) remain
+-- arithmetic-identical and the projection's INSERT/UPSERT can keep treating
+-- "no promo" as omitting the columns.
+ALTER TABLE public.checkout_order
+    ADD COLUMN discount_code text NOT NULL DEFAULT '',
+    ADD COLUMN discount_amount bigint NOT NULL DEFAULT 0;
+
+COMMIT;


### PR DESCRIPTION
Four new store-side features.

- **Reviews & ratings** — verified-buyer-only product reviews (1-5 stars + body, one per customer per product). Product page shows aggregate + recent. Admin `/admin/reviews` soft-deletes. Migration 000024. New `HasPurchasedProduct` joins through `productcatalog_variant` to recover the catalog product id from order-line variant ids.
- **Wishlist** — per-customer, variant-keyed; HTMX toggle in the variant-box partial; `/account/wishlist` page. Migration 000025.
- **Promo codes** — percent / fixed / free-shipping codes with validity dates, max uses, per-customer cap. Atomic redemption (SELECT FOR UPDATE). `OrderPlaced` carries `DiscountCode` + `DiscountAmount` so history replays deterministically. Place() math: discount before tax. Admin CRUD at `/admin/promo-codes`. Anonymous customers can't use codes. Migrations 000026 + 000027.
- **Multi-currency (display-only)** — new `internal/fx` static rate table (operator-configured, NOT a live feed). Header picker; `POST /currency` persists in the session. `money` FuncMap helper converts stored USD minor units on render. Admin/emails stay in USD. Disclosure shown when picked currency != default.

## Test plan
- [x] build (incl. -tags integration) / vet / tests / lint green
- [x] docker: unverified-buyer review rejected; verified buyer succeeds; duplicate rejected; aggregate renders. wishlist HTMX toggle round-trip + account page. SAVE10 on \$145 wool throw → exact \$130.50 total + promo_redemption row + invalid-code rejected. EUR currency switch → \$9.00 paperclips render as €8.28 + "orders placed in USD" disclosure.