### PR TITLE
feat(search): Open Host Service module with productcatalog producer

### DIFF
--- a/backend/cmd/cli/reindex.go
+++ b/backend/cmd/cli/reindex.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+
+	"github.com/bkielbasa/go-ecommerce/backend/productcatalog"
+	pcapp "github.com/bkielbasa/go-ecommerce/backend/productcatalog/app"
+	pcdomain "github.com/bkielbasa/go-ecommerce/backend/productcatalog/domain"
+	"github.com/bkielbasa/go-ecommerce/backend/search"
+	searchapp "github.com/bkielbasa/go-ecommerce/backend/search/app"
+	searchdomain "github.com/bkielbasa/go-ecommerce/backend/search/domain"
+	"github.com/spf13/cobra"
+)
+
+// newReindexCmd wires the search bounded context and the product catalogue
+// directly (rather than reusing the cli's main ProductService — which has
+// the no-op indexer) and rebuilds the product slice of the search index
+// from scratch. Run after the `seeds` subcommand or whenever the catalogue
+// drifts away from the index (e.g. after a production migration).
+func newReindexCmd(db *sql.DB) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "reindex",
+		Short: "Rebuild the search index from the live catalogue",
+		Long: `Drops every product-kind document from the search index and
+re-walks the product catalogue, publishing each product as a fresh
+search Document. Safe to run repeatedly: it is a wipe-then-rebuild,
+not an incremental sync.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+
+			_, searchSrv := search.New(db)
+			// Build a productcatalog service WITHOUT a search indexer
+			// (we drive indexing manually below), so reading the
+			// catalogue does not trigger a recursive Index call.
+			_, catalogSrv := productcatalog.New(db, pcapp.NoopSearchIndexer)
+
+			n, err := reindexProducts(ctx, searchSrv, catalogSrv)
+			if err != nil {
+				return err
+			}
+			if _, err := fmt.Fprintf(cmd.OutOrStdout(), "reindexed %d products\n", n); err != nil {
+				return fmt.Errorf("write reindex summary: %w", err)
+			}
+			return nil
+		},
+	}
+	return cmd
+}
+
+// reindexProducts wipes the product slice of the search index and
+// republishes every product. The returned count is the number of
+// documents indexed; a failure during enumeration aborts the rebuild
+// (the index is already empty for the kind, so re-running the command
+// picks up where it left off).
+func reindexProducts(ctx context.Context, searchSrv *searchapp.Service, catalogSrv pcapp.ProductService) (int, error) {
+	if err := searchSrv.RemoveAllOfKind(ctx, searchdomain.KindProduct); err != nil {
+		return 0, fmt.Errorf("remove product documents: %w", err)
+	}
+
+	products, err := catalogSrv.AllProducts(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("load products: %w", err)
+	}
+
+	now := time.Now().UTC()
+	n := 0
+	for _, p := range products {
+		doc, err := buildProductDocument(p, now)
+		if err != nil {
+			return n, fmt.Errorf("translate product %s: %w", p.ID(), err)
+		}
+		if err := searchSrv.Index(ctx, doc); err != nil {
+			return n, fmt.Errorf("index product %s: %w", p.ID(), err)
+		}
+		n++
+	}
+	return n, nil
+}
+
+// buildProductDocument duplicates the productcatalog ACL's translation
+// (productToDocument) because that helper is unexported. Keeping a single
+// source of truth would mean exporting it from productcatalog/app; both
+// translators are short and easy to keep in step here, and a follow-up
+// commit can hoist the helper if a third caller appears.
+func buildProductDocument(p pcdomain.Product, updatedAt time.Time) (searchdomain.Document, error) {
+	tags := make([]string, 0, len(p.Categories()))
+	for _, c := range p.Categories() {
+		tags = append(tags, c.Name())
+	}
+	priceFrom := p.PriceFrom()
+	meta := map[string]string{
+		"currency":    priceFrom.Currency().String(),
+		"price_minor": fmt.Sprintf("%d", priceFrom.Amount()),
+	}
+	if t := p.Thumbnail(); t != "" {
+		meta["thumbnail"] = t
+	}
+	url := fmt.Sprintf("/product/%s", p.ID())
+	return searchdomain.NewDocument(
+		searchdomain.KindProduct,
+		string(p.ID()),
+		p.Name(),
+		p.Description(),
+		url,
+		tags,
+		meta,
+		updatedAt,
+	)
+}

--- a/backend/cmd/cli/rootcmd.go
+++ b/backend/cmd/cli/rootcmd.go
@@ -20,9 +20,14 @@ var rootCmd = &cobra.Command{
 
 func Execute(db *sql.DB) {
 	storage := adapter.NewPostgres(db)
-	appServ := app.NewProductService(storage)
+	// CLI catalogue writes do not maintain the search index — the CLI's
+	// `reindex` subcommand owns the index lifecycle separately, building
+	// its own search.New(db). Wiring the NoopSearchIndexer keeps every
+	// other subcommand index-agnostic.
+	appServ := app.NewProductService(storage).WithSearchIndexer(app.NoopSearchIndexer)
 	rootCmd.AddCommand(newProductCatalogCmd(appServ))
 	rootCmd.AddCommand(newSeedsCmd(appServ, db))
+	rootCmd.AddCommand(newReindexCmd(db))
 
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, err)

--- a/backend/cmd/web/main.go
+++ b/backend/cmd/web/main.go
@@ -26,6 +26,7 @@ import (
 	"github.com/bkielbasa/go-ecommerce/backend/productcatalog"
 	"github.com/bkielbasa/go-ecommerce/backend/promo"
 	"github.com/bkielbasa/go-ecommerce/backend/reviews"
+	"github.com/bkielbasa/go-ecommerce/backend/search"
 	"github.com/bkielbasa/go-ecommerce/backend/shippinginfo"
 	"github.com/bkielbasa/go-ecommerce/backend/wishlist"
 	"github.com/joho/godotenv"
@@ -123,7 +124,11 @@ func main() {
 
 	app.AddDependency(dependency.NewSQL(db))
 	bus := eventbus.New(logger)
-	pcBD, catalogService := productcatalog.New(db)
+	// Search OHS: published-language storage + service. The same *app.Service
+	// instance is wired as both productcatalog's SearchIndexer (write side)
+	// and layout's searchService (read side) — one struct, two roles.
+	searchBD, searchSrv := search.New(db)
+	pcBD, catalogService := productcatalog.New(db, searchSrv)
 	cartBD, cartSrv := cart.New(db, logger, catalogService)
 	authBD, authService := auth.New(db)
 	pricing := checkoutapp.PricingPolicy{
@@ -203,7 +208,7 @@ func main() {
 	// remain stored and charged in DefaultCurrency (USD).
 	fxRates := fx.New(cfg.DefaultCurrency, cfg.SupportedCurrencies, cfg.FXRates, logger)
 
-	app.AddBoundedContext(layout.New(logger, cartSrv, catalogService, authService, checkoutSrv, checkoutQry, shipSrv, reviewsSrv, wishlistSrv, promoSrv, imgStore, cfg.UploadsDir, []byte(cfg.SessionSecret), cfg.CookieSecure, cfg.CSRFEnabled, mailerSrv, cfg.BaseURL, fxRates))
+	app.AddBoundedContext(layout.New(logger, cartSrv, catalogService, authService, checkoutSrv, checkoutQry, shipSrv, reviewsSrv, wishlistSrv, promoSrv, searchSrv, imgStore, cfg.UploadsDir, []byte(cfg.SessionSecret), cfg.CookieSecure, cfg.CSRFEnabled, mailerSrv, cfg.BaseURL, fxRates))
 	// CSRF protection wraps every route on the application router. It must be
 	// installed after layout.New has set up the session store (which the
 	// middleware reads from) but before app.Run() begins serving.
@@ -214,6 +219,7 @@ func main() {
 	app.AddBoundedContext(reviewsBD)
 	app.AddBoundedContext(wishlistBD)
 	app.AddBoundedContext(promoBD)
+	app.AddBoundedContext(searchBD)
 
 	// Reservation TTL sweeper: releases stock held by pending orders whose
 	// confirmation never arrived (process crash, abandoned cart after stock

--- a/backend/layout/bounded_context.go
+++ b/backend/layout/bounded_context.go
@@ -16,6 +16,7 @@ import (
 	pcdomain "github.com/bkielbasa/go-ecommerce/backend/productcatalog/domain"
 	promodomain "github.com/bkielbasa/go-ecommerce/backend/promo/domain"
 	reviewsDomain "github.com/bkielbasa/go-ecommerce/backend/reviews/domain"
+	searchapp "github.com/bkielbasa/go-ecommerce/backend/search/app"
 	shipDomain "github.com/bkielbasa/go-ecommerce/backend/shippinginfo/domain"
 	wishlistDomain "github.com/bkielbasa/go-ecommerce/backend/wishlist/domain"
 	"github.com/sirupsen/logrus"
@@ -137,6 +138,14 @@ type wishlistService interface {
 	Contains(ctx context.Context, customerID, variantID string) (bool, error)
 }
 
+// searchService is the narrow seam the layout package needs from the
+// search OHS. It maps onto search/app.Service.Search — Search returns
+// hits keyed by (kind, id) plus a relevance rank; the storefront uses
+// it to drive the "product grid when q is set" path in AllProducts.
+type searchService interface {
+	Search(ctx context.Context, q string, opts searchapp.QueryOptions) ([]searchapp.Hit, error)
+}
+
 // checkoutQueries is the read side of the checkout context (CQRS); it returns
 // dedicated read models, not the write aggregate.
 type checkoutQueries interface {
@@ -156,7 +165,7 @@ type checkoutQueries interface {
 // csrfEnabled toggles the request-level CSRF check; production always wants
 // true, and only local debugging should ever flip it to false (see
 // cmd/web/config.go CSRFEnabled for the operator-facing knob).
-func New(logger logrus.FieldLogger, cartSrv cartService, catalogSrv catalogService, authSrv authService, checkoutSrv checkoutCommands, checkoutQry checkoutQueries, shipSrv shippingService, reviewsSrv reviewsService, wishlistSrv wishlistService, promoSrv promoService, imageStore imagestore.Store, uploadsDir string, sessionSecret []byte, cookieSecure, csrfEnabled bool, mailerSrv mailer.Mailer, baseURL string, rates fx.Rates) application.BoundedContext {
+func New(logger logrus.FieldLogger, cartSrv cartService, catalogSrv catalogService, authSrv authService, checkoutSrv checkoutCommands, checkoutQry checkoutQueries, shipSrv shippingService, reviewsSrv reviewsService, wishlistSrv wishlistService, promoSrv promoService, searchSrv searchService, imageStore imagestore.Store, uploadsDir string, sessionSecret []byte, cookieSecure, csrfEnabled bool, mailerSrv mailer.Mailer, baseURL string, rates fx.Rates) application.BoundedContext {
 	store = newCookieStore(sessionSecret, cookieSecure)
 	setCSRFEnabled(csrfEnabled)
 	return &boundedContext{
@@ -170,6 +179,7 @@ func New(logger logrus.FieldLogger, cartSrv cartService, catalogSrv catalogServi
 			reviewsSrv:  reviewsSrv,
 			wishlistSrv: wishlistSrv,
 			promoSrv:    promoSrv,
+			searchSrv:   searchSrv,
 			imageStore:  imageStore,
 			mailer:      mailerSrv,
 			baseURL:     baseURL,

--- a/backend/layout/http.go
+++ b/backend/layout/http.go
@@ -50,6 +50,7 @@ type httpHandler struct {
 	reviewsSrv  reviewsService
 	wishlistSrv wishlistService
 	promoSrv    promoService
+	searchSrv   searchService
 	imageStore  imagestore.Store
 	mailer      mailer.Mailer
 	baseURL     string

--- a/backend/layout/http_product.go
+++ b/backend/layout/http_product.go
@@ -1,6 +1,7 @@
 package layout
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"html/template"
@@ -10,7 +11,11 @@ import (
 
 	"github.com/bkielbasa/go-ecommerce/backend/cart/domain"
 	"github.com/bkielbasa/go-ecommerce/backend/internal/https"
+	"github.com/bkielbasa/go-ecommerce/backend/internal/observability"
 	pcapp "github.com/bkielbasa/go-ecommerce/backend/productcatalog/app"
+	pcdomain "github.com/bkielbasa/go-ecommerce/backend/productcatalog/domain"
+	searchapp "github.com/bkielbasa/go-ecommerce/backend/search/app"
+	searchdomain "github.com/bkielbasa/go-ecommerce/backend/search/domain"
 	"github.com/gorilla/mux"
 )
 
@@ -24,56 +29,68 @@ func (handler httpHandler) AllProducts(w http.ResponseWriter, r *http.Request) {
 	category := q.Get("category")
 	search := strings.TrimSpace(q.Get("q"))
 
-	query := pcapp.ProductQuery{
-		CategorySlug:   category,
-		NumericRanges:  map[string]pcapp.Range{},
-		EnumSelections: map[string][]string{},
-		Search:         search,
-	}
+	var products []pcdomain.Product
+	var err error
 
-	// Use the facets for this scope to know which params are numeric vs enum.
-	facets, err := handler.catalogSrv.Facets(ctx, category)
-	if err != nil {
-		handler.logger.WithError(err).WithField("category", category).Warn("cannot get facets")
-		facets = nil
-	}
+	if search != "" {
+		// Search-driven path: route the query through the search OHS and
+		// hydrate the returned hits via the catalogue. Facet/category
+		// rail values are intentionally ignored here — the rail is a
+		// best-effort secondary filter while search is the primary
+		// intent. Failures degrade silently to an empty result rather
+		// than 500ing.
+		products = handler.searchProducts(ctx, search)
+	} else {
+		query := pcapp.ProductQuery{
+			CategorySlug:   category,
+			NumericRanges:  map[string]pcapp.Range{},
+			EnumSelections: map[string][]string{},
+		}
 
-	for _, f := range facets {
-		typeID := f.Type.ID()
-		switch {
-		case f.Type.IsNumeric():
-			minStr := q.Get(typeID + "_min")
-			maxStr := q.Get(typeID + "_max")
-			if minStr == "" && maxStr == "" {
-				continue
-			}
-			rng := pcapp.Range{}
-			if minStr != "" {
-				if v, errParse := strconv.ParseFloat(minStr, 64); errParse == nil {
-					rng.Min = &v
+		// Use the facets for this scope to know which params are numeric vs enum.
+		facets, fErr := handler.catalogSrv.Facets(ctx, category)
+		if fErr != nil {
+			handler.logger.WithError(fErr).WithField("category", category).Warn("cannot get facets")
+			facets = nil
+		}
+
+		for _, f := range facets {
+			typeID := f.Type.ID()
+			switch {
+			case f.Type.IsNumeric():
+				minStr := q.Get(typeID + "_min")
+				maxStr := q.Get(typeID + "_max")
+				if minStr == "" && maxStr == "" {
+					continue
 				}
-			}
-			if maxStr != "" {
-				if v, errParse := strconv.ParseFloat(maxStr, 64); errParse == nil {
-					rng.Max = &v
+				rng := pcapp.Range{}
+				if minStr != "" {
+					if v, errParse := strconv.ParseFloat(minStr, 64); errParse == nil {
+						rng.Min = &v
+					}
 				}
-			}
-			if rng.Min == nil && rng.Max == nil {
-				continue
-			}
-			query.NumericRanges[typeID] = rng
-		case f.Type.IsEnum():
-			if vals := q[typeID]; len(vals) > 0 {
-				query.EnumSelections[typeID] = vals
+				if maxStr != "" {
+					if v, errParse := strconv.ParseFloat(maxStr, 64); errParse == nil {
+						rng.Max = &v
+					}
+				}
+				if rng.Min == nil && rng.Max == nil {
+					continue
+				}
+				query.NumericRanges[typeID] = rng
+			case f.Type.IsEnum():
+				if vals := q[typeID]; len(vals) > 0 {
+					query.EnumSelections[typeID] = vals
+				}
 			}
 		}
-	}
 
-	products, err := handler.catalogSrv.List(ctx, query)
-	if err != nil {
-		https.InternalError(w, "internal-error", "cannot get list of all products")
-		handler.logger.WithError(err).Error("cannot get list of all products")
-		return
+		products, err = handler.catalogSrv.List(ctx, query)
+		if err != nil {
+			https.InternalError(w, "internal-error", "cannot get list of all products")
+			handler.logger.WithError(err).Error("cannot get list of all products")
+			return
+		}
 	}
 
 	resp := map[string]any{
@@ -103,6 +120,42 @@ func (handler httpHandler) AllProducts(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
+}
+
+// searchProducts queries the search OHS for product hits and hydrates each
+// hit through catalogSrv.Find so the grid template gets full Product
+// values (with variants, price, thumbnail). All failures degrade silently
+// to an empty result — the storefront prefers an empty grid over a 500
+// when the search index is misbehaving, since the catalogue itself is
+// still browseable via the category rail.
+func (handler httpHandler) searchProducts(ctx context.Context, q string) []pcdomain.Product {
+	// Record the user-visible search request — moved out of
+	// ProductService.List when search migrated to the OHS.
+	observability.SearchQueriesInc(ctx)
+	if handler.searchSrv == nil {
+		return nil
+	}
+	hits, err := handler.searchSrv.Search(ctx, q, searchapp.QueryOptions{
+		Kinds: []searchdomain.Kind{searchdomain.KindProduct},
+	})
+	if err != nil {
+		handler.logger.WithError(err).WithField("query", q).Warn("search OHS query failed; returning empty grid")
+		return nil
+	}
+	out := make([]pcdomain.Product, 0, len(hits))
+	for _, h := range hits {
+		p, err := handler.catalogSrv.Find(ctx, h.Document.ID())
+		if err != nil {
+			// A hit that no longer resolves to a product almost always
+			// means the catalogue and the search index drifted (admin
+			// deleted the product before the index was updated). Skip
+			// it; `cli reindex` will tidy up later.
+			handler.logger.WithError(err).WithField("product_id", h.Document.ID()).Warn("search hit does not resolve to a product; skipping")
+			continue
+		}
+		out = append(out, p)
+	}
+	return out
 }
 
 func (handler httpHandler) Product(w http.ResponseWriter, r *http.Request) {

--- a/backend/productcatalog/adapter/inmemory.go
+++ b/backend/productcatalog/adapter/inmemory.go
@@ -3,7 +3,6 @@ package adapter
 import (
 	"context"
 	"sort"
-	"strings"
 	"time"
 
 	"github.com/bkielbasa/go-ecommerce/backend/productcatalog/app"
@@ -506,7 +505,6 @@ func (im *inMemory) inCategory(productID, slug string) bool {
 }
 
 func (im *inMemory) ListProducts(ctx context.Context, q app.ProductQuery) ([]domain.Product, error) {
-	search := strings.ToLower(strings.TrimSpace(q.Search))
 	var out []domain.Product
 	for _, p := range im.products {
 		pid := string(p.ID())
@@ -517,11 +515,6 @@ func (im *inMemory) ListProducts(ctx context.Context, q app.ProductQuery) ([]dom
 			continue
 		}
 		if !im.matchesEnum(pid, q.EnumSelections) {
-			continue
-		}
-		if search != "" &&
-			!strings.Contains(strings.ToLower(p.Name()), search) &&
-			!strings.Contains(strings.ToLower(p.Description()), search) {
 			continue
 		}
 		out = append(out, im.hydrate(p))

--- a/backend/productcatalog/adapter/postgres.go
+++ b/backend/productcatalog/adapter/postgres.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"sort"
-	"strings"
 	"time"
 
 	"github.com/bkielbasa/go-ecommerce/backend/productcatalog/app"
@@ -987,11 +986,6 @@ func (db postgres) ListProducts(ctx context.Context, q app.ProductQuery) ([]doma
 		query += fmt.Sprintf(` AND EXISTS (
 			SELECT 1 FROM productcatalog_product_attribute pa
 			WHERE pa.product_id = p.id AND pa.attribute_type_id = %s AND pa.text_value = ANY(%s))`, idPH, valPH)
-	}
-
-	if s := strings.TrimSpace(q.Search); s != "" {
-		ph := set("%" + s + "%")
-		query += fmt.Sprintf(` AND (p.name ILIKE %s OR p.description ILIKE %s)`, ph, ph)
 	}
 
 	query += ` ORDER BY p.id`

--- a/backend/productcatalog/app/product.go
+++ b/backend/productcatalog/app/product.go
@@ -5,9 +5,12 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/bkielbasa/go-ecommerce/backend/internal/observability"
 	"github.com/bkielbasa/go-ecommerce/backend/productcatalog/domain"
+	searchdomain "github.com/bkielbasa/go-ecommerce/backend/search/domain"
+	"github.com/sirupsen/logrus"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
@@ -26,7 +29,9 @@ func recordSpanError(span trace.Span, err error) {
 }
 
 type ProductService struct {
-	storage ProductStorage
+	storage   ProductStorage
+	searchIdx SearchIndexer
+	now       func() time.Time
 }
 
 type ProductStorage interface {
@@ -75,8 +80,56 @@ type ProductStorage interface {
 	ListStockMovements(ctx context.Context, variantID string, limit int) ([]domain.StockMovement, error)
 }
 
+// NewProductService wires the service against a ProductStorage. The
+// SearchIndexer slot defaults to NoopSearchIndexer so callers that do not
+// (yet) participate in search (tests, the CLI) keep working unchanged;
+// production composition swaps in the live indexer with WithSearchIndexer.
 func NewProductService(s ProductStorage) ProductService {
-	return ProductService{storage: s}
+	return ProductService{
+		storage:   s,
+		searchIdx: NoopSearchIndexer,
+		now:       time.Now,
+	}
+}
+
+// WithSearchIndexer returns a copy of the service that publishes index
+// updates after every successful product mutation. Index failures are
+// best-effort: they are logged and discarded, never returned, so a flaky
+// search index cannot break product writes (the catalogue is the source
+// of truth — the index can be rebuilt via `cli reindex`).
+func (ps ProductService) WithSearchIndexer(idx SearchIndexer) ProductService {
+	if idx == nil {
+		idx = NoopSearchIndexer
+	}
+	ps.searchIdx = idx
+	return ps
+}
+
+// reindexProduct re-loads the product from storage (so the latest variants,
+// categories and attributes are picked up) and translates it through the
+// ACL into a search Document. Failures are logged at Warn — the product
+// mutation that triggered this call has already succeeded.
+func (ps ProductService) reindexProduct(ctx context.Context, productID string) {
+	p, err := ps.storage.Find(ctx, productID)
+	if err != nil {
+		logrus.WithError(err).WithField("product_id", productID).Warn("search reindex: cannot load product")
+		return
+	}
+	doc, err := productToDocument(p, ps.now())
+	if err != nil {
+		logrus.WithError(err).WithField("product_id", productID).Warn("search reindex: cannot build document")
+		return
+	}
+	if err := ps.searchIdx.Index(ctx, doc); err != nil {
+		logrus.WithError(err).WithField("product_id", productID).Warn("search reindex: indexer rejected document")
+	}
+}
+
+// removeFromIndex removes the product from the index, best-effort.
+func (ps ProductService) removeFromIndex(ctx context.Context, productID string) {
+	if err := ps.searchIdx.Remove(ctx, searchdomain.KindProduct, productID); err != nil {
+		logrus.WithError(err).WithField("product_id", productID).Warn("search reindex: indexer failed to remove document")
+	}
 }
 
 func (ps ProductService) AllProducts(ctx context.Context) ([]domain.Product, error) {
@@ -158,19 +211,15 @@ func (ps ProductService) Release(ctx context.Context, quantities map[string]int)
 }
 
 // List returns the products matching the given listing-page query.
+//
+// Note: free-text search no longer flows through here. The storefront's
+// /search route is served by the search bounded context (an OHS); this
+// method is strictly category + facet filtering now.
 func (ps ProductService) List(ctx context.Context, q ProductQuery) ([]domain.Product, error) {
 	ctx, span := tracer.Start(ctx, "Catalog.List", trace.WithAttributes(
 		attribute.String("catalog.category_slug", q.CategorySlug),
-		attribute.Bool("catalog.has_search", q.Search != ""),
 	))
 	defer span.End()
-
-	// Search-driven listings are the user-visible search count; non-search
-	// listings (category browsing) are intentionally NOT counted as
-	// searches.
-	if q.Search != "" {
-		observability.SearchQueriesInc(ctx)
-	}
 
 	products, err := ps.storage.ListProducts(ctx, q)
 	if err != nil {
@@ -427,7 +476,13 @@ func (ps ProductService) Add(ctx context.Context, id, name, desc string, priceMi
 	// A simple product is purchasable through a single default variant
 	// carrying its price (no options) and the product image.
 	defaultVariant := domain.NewVariant("var-"+id, id, thumbnail, nil, priceVO, defaultStock)
-	return ps.storage.AddVariant(ctx, id, 0, defaultVariant)
+	if err := ps.storage.AddVariant(ctx, id, 0, defaultVariant); err != nil {
+		return err
+	}
+	// Publish to the search index after the variant exists so PriceFrom
+	// reflects the freshly inserted default variant's price.
+	ps.reindexProduct(ctx, id)
+	return nil
 }
 
 // UpdateProduct validates the core product fields and persists them. It only
@@ -450,13 +505,21 @@ func (ps ProductService) UpdateProduct(ctx context.Context, id, name, desc strin
 	if err != nil {
 		return err
 	}
-	return ps.storage.UpdateProduct(ctx, p)
+	if err := ps.storage.UpdateProduct(ctx, p); err != nil {
+		return err
+	}
+	ps.reindexProduct(ctx, id)
+	return nil
 }
 
 // DeleteProduct removes a product; its variants, category and attribute links
 // cascade in storage.
 func (ps ProductService) DeleteProduct(ctx context.Context, id string) error {
-	return ps.storage.DeleteProduct(ctx, id)
+	if err := ps.storage.DeleteProduct(ctx, id); err != nil {
+		return err
+	}
+	ps.removeFromIndex(ctx, id)
+	return nil
 }
 
 // SetVariantStock sets a single variant's stock level (rejecting negatives)
@@ -626,6 +689,9 @@ func (ps ProductService) AddVariantProduct(ctx context.Context, id, name, desc, 
 			return err
 		}
 	}
+	// Index after all variants are inserted so PriceFrom reflects the
+	// full set (the lowest variant price).
+	ps.reindexProduct(ctx, id)
 	return nil
 }
 
@@ -679,7 +745,12 @@ func (ps ProductService) AddVariantToProduct(ctx context.Context, productID, sku
 	existing := product.Variants()
 	variantID := ps.uniqueVariantID(productID, sku, existing)
 	position := len(existing)
-	return ps.storage.AddVariant(ctx, productID, position, domain.NewVariant(variantID, sku, image, options, price, stock))
+	if err := ps.storage.AddVariant(ctx, productID, position, domain.NewVariant(variantID, sku, image, options, price, stock)); err != nil {
+		return err
+	}
+	// A new variant can change the displayed "from" price; reindex.
+	ps.reindexProduct(ctx, productID)
+	return nil
 }
 
 // uniqueVariantID derives a variant id (slug of sku, else productID-<n>) that
@@ -711,7 +782,17 @@ func (ps ProductService) UpdateVariant(ctx context.Context, variantID, sku, imag
 	if _, err := domain.NewCurrency(currency); err != nil {
 		return fmt.Errorf("invalid currency: %w", err)
 	}
-	return ps.storage.UpdateVariant(ctx, variantID, sku, image, priceMinor, currency, stock)
+	// Resolve the owning product up front so we can reindex it after the
+	// update. We don't fail the mutation if the lookup misses (a missing
+	// variant is the storage layer's problem to report).
+	owner, _, lookupErr := ps.storage.FindVariant(ctx, variantID)
+	if err := ps.storage.UpdateVariant(ctx, variantID, sku, image, priceMinor, currency, stock); err != nil {
+		return err
+	}
+	if lookupErr == nil {
+		ps.reindexProduct(ctx, string(owner.ID()))
+	}
+	return nil
 }
 
 // DeleteVariant removes a variant from a product, refusing to delete the last
@@ -724,7 +805,13 @@ func (ps ProductService) DeleteVariant(ctx context.Context, productID, variantID
 	if len(product.Variants()) <= 1 {
 		return fmt.Errorf("cannot delete the last variant: a product needs at least one variant")
 	}
-	return ps.storage.DeleteVariant(ctx, variantID)
+	if err := ps.storage.DeleteVariant(ctx, variantID); err != nil {
+		return err
+	}
+	// The deleted variant may have been the cheapest; reindex so PriceFrom
+	// is correct.
+	ps.reindexProduct(ctx, productID)
+	return nil
 }
 
 // AddOptionType adds a new option type to an existing product. Because a

--- a/backend/productcatalog/app/query.go
+++ b/backend/productcatalog/app/query.go
@@ -10,13 +10,16 @@ type Range struct {
 
 // ProductQuery describes a listing-page filter: an optional category (by slug),
 // numeric attribute ranges and enum attribute selections. The maps are keyed by
-// attribute-type id. Search, when non-empty, applies a case-insensitive
-// substring match across the product name and description.
+// attribute-type id.
+//
+// Free-text search USED to live here as a Search field; it has been moved
+// to the search bounded context (an Open Host Service) and the storefront
+// routes /api/v1/products?q=... through that context instead. Listing
+// queries are now strictly category + facet filters.
 type ProductQuery struct {
 	CategorySlug   string
 	NumericRanges  map[string]Range
 	EnumSelections map[string][]string
-	Search         string
 }
 
 // AttributeAssignment is a single product attribute value to persist. Num is

--- a/backend/productcatalog/app/searchindexer.go
+++ b/backend/productcatalog/app/searchindexer.go
@@ -1,0 +1,79 @@
+package app
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strconv"
+	"time"
+
+	"github.com/bkielbasa/go-ecommerce/backend/productcatalog/domain"
+	searchdomain "github.com/bkielbasa/go-ecommerce/backend/search/domain"
+)
+
+// SearchIndexer is the Anti-Corruption Layer port productcatalog calls
+// after every mutation. It mirrors the shape of search/app.Indexer
+// (Index/Remove) but is declared HERE — in the consumer of the search
+// OHS — so the productcatalog package does not have to import
+// search/app. The only search-package symbol leaking in is
+// search/domain.Document, which IS the published language; importing
+// that is fine (and unavoidable).
+//
+// Production wires *search/app.Service into this slot. Tests and the
+// CLI write paths (where indexing is irrelevant) pass NoopSearchIndexer.
+type SearchIndexer interface {
+	Index(ctx context.Context, doc searchdomain.Document) error
+	Remove(ctx context.Context, kind searchdomain.Kind, id string) error
+}
+
+// noopSearchIndexer satisfies SearchIndexer without touching any storage.
+// It exists so tests and CLI paths that do not need a real index can wire
+// productcatalog without spinning up the search bounded context.
+type noopSearchIndexer struct{}
+
+func (noopSearchIndexer) Index(_ context.Context, _ searchdomain.Document) error {
+	return nil
+}
+
+func (noopSearchIndexer) Remove(_ context.Context, _ searchdomain.Kind, _ string) error {
+	return nil
+}
+
+// NoopSearchIndexer is the do-nothing SearchIndexer wired by callers that
+// do not need indexing (tests, the `cli` binary's catalogue write paths).
+var NoopSearchIndexer SearchIndexer = noopSearchIndexer{}
+
+// productToDocument is the translation step of the ACL: it maps a
+// productcatalog Product into the search OHS's published language
+// (search/domain.Document). The product's display URL ("/product/<id>")
+// is constructed here, which is where the storefront also links from
+// catalog cards, so search hits and grid links agree.
+//
+// The meta map carries display-time metadata (currency, price minor
+// units, thumbnail) so future consumers (e.g. a unified search results
+// page) can render cards without re-fetching the product.
+func productToDocument(p domain.Product, updatedAt time.Time) (searchdomain.Document, error) {
+	tags := make([]string, 0, len(p.Categories()))
+	for _, c := range p.Categories() {
+		tags = append(tags, c.Name())
+	}
+	priceFrom := p.PriceFrom()
+	meta := map[string]string{
+		"currency":    priceFrom.Currency().String(),
+		"price_minor": strconv.FormatInt(priceFrom.Amount(), 10),
+	}
+	if t := p.Thumbnail(); t != "" {
+		meta["thumbnail"] = t
+	}
+	productURL := fmt.Sprintf("/product/%s", url.PathEscape(string(p.ID())))
+	return searchdomain.NewDocument(
+		searchdomain.KindProduct,
+		string(p.ID()),
+		p.Name(),
+		p.Description(),
+		productURL,
+		tags,
+		meta,
+		updatedAt,
+	)
+}

--- a/backend/productcatalog/bounded_context.go
+++ b/backend/productcatalog/bounded_context.go
@@ -8,9 +8,14 @@ import (
 	"github.com/bkielbasa/go-ecommerce/backend/productcatalog/app"
 )
 
-func New(db *sql.DB) (application.BoundedContext, app.ProductService) {
+// New wires the production storage adapter and returns the bounded-context
+// envelope plus the concrete ProductService. The supplied SearchIndexer is
+// invoked after every successful product mutation (Add/Update/Delete plus
+// the variant-management operations that change displayed price/name);
+// pass app.NoopSearchIndexer to opt out (e.g. in the CLI, or in tests).
+func New(db *sql.DB, searchIdx app.SearchIndexer) (application.BoundedContext, app.ProductService) {
 	storage := adapter.NewPostgres(db)
-	appServ := app.NewProductService(storage)
+	appServ := app.NewProductService(storage).WithSearchIndexer(searchIdx)
 
 	return &boundedContext{}, appServ
 }

--- a/backend/search/Readme.md
+++ b/backend/search/Readme.md
@@ -1,0 +1,52 @@
+# search — Open Host Service
+
+The `search` package publishes a single value object — `domain.Document` —
+together with a `Kind` discriminator. Any other bounded context that owns
+searchable content (today: `productcatalog`; tomorrow: `blog`, `faq`) maps
+its records into that published language via a small Anti-Corruption Layer
+on the producer side and calls the `Indexer` port to keep the index in
+sync.
+
+This is the **Open Host Service (OHS)** pattern from DDD: the search context
+exposes a stable, narrow contract (the `Document` shape + two ports) and
+every consumer translates into it. Producers do **not** depend on search's
+storage or app types; they depend only on `search/domain`.
+
+## Ports
+
+- `app.Indexer` — write side, used by producers: `Index(ctx, Document)`,
+  `Remove(ctx, kind, id)`.
+- `app.Querier` — read side, used by consumers (the storefront):
+  `Search(ctx, q, QueryOptions) ([]Hit, error)`.
+- `app.Storage` — persistence port the adapters satisfy
+  (postgres + in-memory).
+
+The `*app.Service` struct implements **both** roles, so production wires the
+same instance into productcatalog's `SearchIndexer` slot and layout's
+`searchService` slot.
+
+## Storage shape
+
+Postgres (migration `000028_search_documents`): a single `search_document`
+table keyed by `(kind, id)` with a stored `tsvector` aggregating title
+(weight A), body (weight B) and tags (weight C), backed by a GIN index.
+Queries go through `websearch_to_tsquery('simple', $1)` and rank with
+`ts_rank_cd`.
+
+The `simple` configuration is used (not `english`) to keep substring-like
+behaviour for short product titles; switching to `english` (stemming) is a
+one-migration change.
+
+## Adding a new producer (e.g. `blog`)
+
+1. In your producer package, declare your own `Kind` constant (any
+   non-empty string — search does not maintain a closed enum).
+2. Declare a local `SearchIndexer` interface mirroring `app.Indexer` (so
+   your package does not import `search/app`).
+3. Write a translator (`postToDocument`) that returns a
+   `search/domain.Document`.
+4. Call `Index` / `Remove` after every successful mutation; log and
+   continue on failure (the index can be rebuilt by `cmd/cli reindex`).
+5. Add a `reindex <yourkind>` subcommand if you want offline rebuilds.
+
+No change to the `search` package is required.

--- a/backend/search/adapter/inmemory.go
+++ b/backend/search/adapter/inmemory.go
@@ -1,0 +1,104 @@
+package adapter
+
+import (
+	"context"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/bkielbasa/go-ecommerce/backend/search/app"
+	"github.com/bkielbasa/go-ecommerce/backend/search/domain"
+)
+
+// docKey is the composite primary key the in-memory store uses. The
+// postgres adapter relies on a real (kind, id) primary key; we mirror that
+// here so a test asserting Upsert-then-Upsert-of-same-key replaces the
+// row rather than appending a second one.
+type docKey struct {
+	Kind domain.Kind
+	ID   string
+}
+
+// InMemory is the test-friendly Storage adapter. Query is a naive
+// case-insensitive substring scan over title and body — good enough to
+// exercise the service-level wiring (Index → Search hit, Remove → no
+// hit, RemoveAllOfKind, Kinds filter). Production goes through the
+// postgres adapter's full-text index.
+type InMemory struct {
+	mu   sync.Mutex
+	docs map[docKey]domain.Document
+}
+
+// NewInMemory returns an empty InMemory storage instance.
+func NewInMemory() *InMemory {
+	return &InMemory{docs: map[docKey]domain.Document{}}
+}
+
+// Upsert stores (or replaces) the document keyed by (Kind, ID).
+func (m *InMemory) Upsert(_ context.Context, doc domain.Document) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.docs[docKey{Kind: doc.Kind(), ID: doc.ID()}] = doc
+	return nil
+}
+
+// Remove deletes the document keyed by (kind, id). Missing rows are a
+// no-op (mirroring postgres' DELETE ... WHERE which simply affects 0 rows).
+func (m *InMemory) Remove(_ context.Context, kind domain.Kind, id string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.docs, docKey{Kind: kind, ID: id})
+	return nil
+}
+
+// Query runs the naive substring scan. The rank for an in-memory hit is
+// 1.0 (the service-level tests only check identity, not ordering); ties
+// are broken by id for deterministic output.
+func (m *InMemory) Query(_ context.Context, q string, opts app.QueryOptions) ([]app.Hit, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	needle := strings.ToLower(strings.TrimSpace(q))
+	if needle == "" {
+		return nil, nil
+	}
+	kindFilter := map[domain.Kind]bool{}
+	for _, k := range opts.Kinds {
+		kindFilter[k] = true
+	}
+
+	var hits []app.Hit
+	for _, d := range m.docs {
+		if len(kindFilter) > 0 && !kindFilter[d.Kind()] {
+			continue
+		}
+		hay := strings.ToLower(d.Title() + "\n" + d.Body())
+		if !strings.Contains(hay, needle) {
+			continue
+		}
+		hits = append(hits, app.Hit{Document: d, Rank: 1.0})
+	}
+	sort.Slice(hits, func(i, j int) bool {
+		// Deterministic ordering: by kind, then id.
+		if hits[i].Document.Kind() != hits[j].Document.Kind() {
+			return hits[i].Document.Kind() < hits[j].Document.Kind()
+		}
+		return hits[i].Document.ID() < hits[j].Document.ID()
+	})
+	if opts.Limit > 0 && len(hits) > opts.Limit {
+		hits = hits[:opts.Limit]
+	}
+	return hits, nil
+}
+
+// RemoveAllOfKind drops every document owned by the given producer.
+func (m *InMemory) RemoveAllOfKind(_ context.Context, kind domain.Kind) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for k := range m.docs {
+		if k.Kind == kind {
+			delete(m.docs, k)
+		}
+	}
+	return nil
+}

--- a/backend/search/adapter/postgres.go
+++ b/backend/search/adapter/postgres.go
@@ -1,0 +1,167 @@
+package adapter
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/bkielbasa/go-ecommerce/backend/search/app"
+	"github.com/bkielbasa/go-ecommerce/backend/search/domain"
+	"github.com/lib/pq"
+)
+
+// Postgres is the production Storage adapter. Documents live in a single
+// search_document table with a stored, GIN-indexed tsvector aggregating
+// title (weight A), body (weight B) and tags (weight C). All queries are
+// parameterised; no user input is interpolated into the SQL string.
+//
+// Trade-off — text-search configuration: we use 'simple' rather than
+// 'english' on purpose. 'english' applies stemming (e.g. "running" → "run")
+// which is great for natural-language search but surprises in a demo where
+// product names contain compounds and brand-ish nouns. 'simple' lowercases
+// and tokenises only, matching the storefront's plain-substring mental
+// model more closely. If the catalogue ever leans heavily on long-form
+// copy, switching the config (and reindexing) is a one-migration change.
+type Postgres struct {
+	db *sql.DB
+}
+
+// NewPostgres wires the adapter against the shared *sql.DB.
+func NewPostgres(db *sql.DB) *Postgres {
+	return &Postgres{db: db}
+}
+
+// upsertSQL writes (or replaces) a document keyed by (kind, id). The
+// generated `ts` column is automatically recomputed by postgres on every
+// insert/update, so we never write to it explicitly.
+const upsertSQL = `INSERT INTO search_document
+		(kind, id, title, body, url, tags, meta, updated_at)
+	VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb, $8)
+	ON CONFLICT (kind, id) DO UPDATE SET
+		title = EXCLUDED.title,
+		body = EXCLUDED.body,
+		url = EXCLUDED.url,
+		tags = EXCLUDED.tags,
+		meta = EXCLUDED.meta,
+		updated_at = EXCLUDED.updated_at`
+
+// Upsert serialises the document and writes it. meta is stored as jsonb;
+// nil meta maps cleanly to "{}".
+func (p *Postgres) Upsert(ctx context.Context, doc domain.Document) error {
+	metaBytes, err := json.Marshal(doc.Meta())
+	if err != nil {
+		return fmt.Errorf("marshal meta: %w", err)
+	}
+	updatedAt := doc.UpdatedAt()
+	if updatedAt.IsZero() {
+		updatedAt = time.Now().UTC()
+	}
+	if _, err := p.db.ExecContext(ctx, upsertSQL,
+		string(doc.Kind()),
+		doc.ID(),
+		doc.Title(),
+		doc.Body(),
+		doc.URL(),
+		pq.Array(doc.Tags()),
+		string(metaBytes),
+		updatedAt,
+	); err != nil {
+		return fmt.Errorf("upsert search document: %w", err)
+	}
+	return nil
+}
+
+// Remove deletes the row keyed by (kind, id). Missing rows are a no-op.
+func (p *Postgres) Remove(ctx context.Context, kind domain.Kind, id string) error {
+	if _, err := p.db.ExecContext(ctx,
+		`DELETE FROM search_document WHERE kind = $1 AND id = $2`,
+		string(kind), id,
+	); err != nil {
+		return fmt.Errorf("delete search document: %w", err)
+	}
+	return nil
+}
+
+// querySQL runs a websearch_to_tsquery against the stored tsvector. The
+// kind filter is optional: pass a NULL text[] (no Kinds option) to scan
+// every kind. Ranking uses ts_rank_cd which prefers proximity-weighted
+// matches over plain ts_rank.
+const querySQL = `SELECT kind, id, title, body, url, tags, meta, updated_at,
+		ts_rank_cd(ts, q) AS rank
+	FROM search_document, websearch_to_tsquery('simple', $1) q
+	WHERE ts @@ q
+	  AND ($2::text[] IS NULL OR kind = ANY($2))
+	ORDER BY rank DESC
+	LIMIT $3`
+
+// Query runs a full-text search. The kind filter is parameterised through
+// pq.Array; a nil opts.Kinds passes NULL and matches every kind.
+func (p *Postgres) Query(ctx context.Context, q string, opts app.QueryOptions) ([]app.Hit, error) {
+	limit := opts.Limit
+	if limit <= 0 {
+		// Service applies its own default, but be defensive in case a
+		// caller wires Storage directly (e.g. integration tests).
+		limit = 50
+	}
+
+	var kindsArg interface{}
+	if len(opts.Kinds) == 0 {
+		kindsArg = nil
+	} else {
+		kinds := make([]string, 0, len(opts.Kinds))
+		for _, k := range opts.Kinds {
+			kinds = append(kinds, string(k))
+		}
+		kindsArg = pq.Array(kinds)
+	}
+
+	rows, err := p.db.QueryContext(ctx, querySQL, q, kindsArg, limit)
+	if err != nil {
+		return nil, fmt.Errorf("query search: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []app.Hit
+	for rows.Next() {
+		var (
+			kind, id, title, body, url string
+			tags                       []string
+			metaRaw                    []byte
+			updatedAt                  time.Time
+			rank                       float64
+		)
+		if err := rows.Scan(&kind, &id, &title, &body, &url, pq.Array(&tags), &metaRaw, &updatedAt, &rank); err != nil {
+			return nil, fmt.Errorf("scan search hit: %w", err)
+		}
+		meta := map[string]string{}
+		if len(metaRaw) > 0 {
+			// Tolerate a stray null jsonb (defensive — the column is
+			// NOT NULL DEFAULT '{}' so this should never trigger).
+			if err := json.Unmarshal(metaRaw, &meta); err != nil {
+				return nil, fmt.Errorf("unmarshal meta: %w", err)
+			}
+		}
+		out = append(out, app.Hit{
+			Document: domain.RebuildDocument(domain.Kind(kind), id, title, body, url, tags, meta, updatedAt),
+			Rank:     rank,
+		})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("rows: %w", err)
+	}
+	return out, nil
+}
+
+// RemoveAllOfKind clears every row of the given kind — used by the
+// `reindex` CLI before walking the producer.
+func (p *Postgres) RemoveAllOfKind(ctx context.Context, kind domain.Kind) error {
+	if _, err := p.db.ExecContext(ctx,
+		`DELETE FROM search_document WHERE kind = $1`,
+		string(kind),
+	); err != nil {
+		return fmt.Errorf("remove kind: %w", err)
+	}
+	return nil
+}

--- a/backend/search/app/service.go
+++ b/backend/search/app/service.go
@@ -1,0 +1,115 @@
+// Package app holds the search application layer: the Storage port the
+// adapters satisfy, the Indexer / Querier roles producers and consumers
+// depend on, and the Service that implements both. The service is a thin
+// pass-through over Storage with a small amount of input normalisation
+// (trim the query string before forwarding); the heavy lifting (full-text
+// index, ranking) lives in the postgres adapter.
+package app
+
+import (
+	"context"
+	"strings"
+
+	"github.com/bkielbasa/go-ecommerce/backend/search/domain"
+)
+
+// Storage is the persistence port the search adapters satisfy. Two
+// implementations ship today: postgres (production) and in-memory (tests).
+type Storage interface {
+	// Upsert indexes or replaces the document keyed by (Kind, ID).
+	Upsert(ctx context.Context, doc domain.Document) error
+	// Remove deletes the document keyed by (Kind, ID). Idempotent — removing
+	// a row that does not exist is not an error.
+	Remove(ctx context.Context, kind domain.Kind, id string) error
+	// Query runs a full-text search and returns matching hits ordered by
+	// the storage's relevance score (descending).
+	Query(ctx context.Context, q string, opts QueryOptions) ([]Hit, error)
+	// RemoveAllOfKind deletes every document of the given kind. Used by the
+	// `reindex` CLI to start from a clean slate before walking the producer.
+	RemoveAllOfKind(ctx context.Context, kind domain.Kind) error
+}
+
+// QueryOptions narrows a search. Kinds, when non-empty, restricts the
+// result set to those producer kinds; an empty slice means "all kinds".
+// Limit caps the result count (0 falls back to defaultLimit).
+type QueryOptions struct {
+	Kinds []domain.Kind
+	Limit int
+}
+
+// defaultLimit is the cap applied when QueryOptions.Limit is non-positive.
+// The storefront page renders a flat grid, so an upper bound keeps the
+// hydration loop bounded; 50 is more than the visible page would render in
+// practice and well below the gridtemplate's render budget.
+const defaultLimit = 50
+
+// Hit pairs a Document with its storage-supplied relevance Rank. The
+// search context does not define what "rank" means beyond "higher is
+// better"; for the postgres adapter it is ts_rank_cd over the document's
+// tsvector. Consumers are free to ignore Rank.
+type Hit struct {
+	Document domain.Document
+	Rank     float64
+}
+
+// Indexer is the OHS write-side port producers depend on. The productcatalog
+// app holds its own copy of this interface shape (so it does not have to
+// import search/app); the Service satisfies both.
+type Indexer interface {
+	Index(ctx context.Context, doc domain.Document) error
+	Remove(ctx context.Context, kind domain.Kind, id string) error
+}
+
+// Querier is the OHS read-side port consumers (the storefront) depend on.
+// Mirrors the Storage.Query signature exactly.
+type Querier interface {
+	Search(ctx context.Context, q string, opts QueryOptions) ([]Hit, error)
+}
+
+// Service implements both Indexer (write side) and Querier (read side)
+// against a single Storage. One struct, two roles — production wires the
+// same instance into both seams (productcatalog's SearchIndexer slot and
+// layout's searchService slot).
+type Service struct {
+	storage Storage
+}
+
+// NewService wires the service against a Storage.
+func NewService(storage Storage) *Service {
+	return &Service{storage: storage}
+}
+
+// Index forwards a translated document to storage. The producer's ACL has
+// already validated the document via domain.NewDocument; here we only
+// pass through.
+func (s *Service) Index(ctx context.Context, doc domain.Document) error {
+	return s.storage.Upsert(ctx, doc)
+}
+
+// Remove deletes the document keyed by (kind, id) from the index.
+func (s *Service) Remove(ctx context.Context, kind domain.Kind, id string) error {
+	return s.storage.Remove(ctx, kind, id)
+}
+
+// Search runs a full-text query against the storage adapter. The query
+// string is trimmed; an empty (or whitespace-only) query returns no hits
+// without dialling storage (the postgres tsquery would treat it as a
+// catch-all match, which is not the intent at the storefront).
+func (s *Service) Search(ctx context.Context, q string, opts QueryOptions) ([]Hit, error) {
+	q = strings.TrimSpace(q)
+	if q == "" {
+		return nil, nil
+	}
+	if opts.Limit <= 0 {
+		opts.Limit = defaultLimit
+	}
+	return s.storage.Query(ctx, q, opts)
+}
+
+// RemoveAllOfKind is the bulk-clear used by the reindex CLI. It is exposed
+// directly (rather than through a "drop everything" sentinel) so producers
+// can rebuild their own kind without touching documents owned by other
+// producers.
+func (s *Service) RemoveAllOfKind(ctx context.Context, kind domain.Kind) error {
+	return s.storage.RemoveAllOfKind(ctx, kind)
+}

--- a/backend/search/app/service_test.go
+++ b/backend/search/app/service_test.go
@@ -1,0 +1,138 @@
+package app_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/bkielbasa/go-ecommerce/backend/search/adapter"
+	"github.com/bkielbasa/go-ecommerce/backend/search/app"
+	"github.com/bkielbasa/go-ecommerce/backend/search/domain"
+)
+
+// newServiceWithSeed builds a service backed by the in-memory adapter and
+// seeds two product-kind documents plus one of an experimental "blog" kind
+// so the Kinds filter has something to discriminate against. Using a
+// string literal for the blog kind (instead of a typed constant) is
+// deliberate — the OHS pattern says producers add their own kinds without
+// the search package changing.
+func newServiceWithSeed(t *testing.T) *app.Service {
+	t.Helper()
+	storage := adapter.NewInMemory()
+	srv := app.NewService(storage)
+
+	now := time.Date(2026, 5, 28, 12, 0, 0, 0, time.UTC)
+	docs := []domain.Document{
+		mustDoc(t, domain.KindProduct, "p-mug", "Ceramic Mug", "speckled stoneware mug", "/product/p-mug", []string{"kitchen"}, nil, now),
+		mustDoc(t, domain.KindProduct, "p-spoon", "Walnut Spoon", "hand-carved wooden spoon", "/product/p-spoon", []string{"kitchen"}, nil, now),
+		mustDoc(t, domain.Kind("blog"), "b-1", "Spoon Care Guide", "how to oil your wooden spoon", "/blog/b-1", nil, nil, now),
+	}
+	for _, d := range docs {
+		if err := srv.Index(context.Background(), d); err != nil {
+			t.Fatalf("seed Index(%s/%s): %v", d.Kind(), d.ID(), err)
+		}
+	}
+	return srv
+}
+
+func mustDoc(t *testing.T, kind domain.Kind, id, title, body, url string, tags []string, meta map[string]string, updatedAt time.Time) domain.Document {
+	t.Helper()
+	d, err := domain.NewDocument(kind, id, title, body, url, tags, meta, updatedAt)
+	if err != nil {
+		t.Fatalf("NewDocument(%s/%s): %v", kind, id, err)
+	}
+	return d
+}
+
+func TestSearch_HitsIndexedDocument(t *testing.T) {
+	srv := newServiceWithSeed(t)
+
+	hits, err := srv.Search(context.Background(), "mug", app.QueryOptions{})
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(hits) != 1 {
+		t.Fatalf("Search(mug): expected 1 hit, got %d (%+v)", len(hits), hits)
+	}
+	if got := hits[0].Document.ID(); got != "p-mug" {
+		t.Errorf("Search(mug): hit id = %q, want %q", got, "p-mug")
+	}
+}
+
+func TestSearch_KindsFilterRestrictsResults(t *testing.T) {
+	srv := newServiceWithSeed(t)
+
+	// "spoon" matches BOTH the product (Walnut Spoon) and the blog post
+	// (Spoon Care Guide). Filtering by KindProduct must drop the blog hit.
+	all, err := srv.Search(context.Background(), "spoon", app.QueryOptions{})
+	if err != nil {
+		t.Fatalf("Search(spoon, all): %v", err)
+	}
+	if len(all) != 2 {
+		t.Fatalf("Search(spoon, all): expected 2 hits, got %d", len(all))
+	}
+
+	products, err := srv.Search(context.Background(), "spoon", app.QueryOptions{Kinds: []domain.Kind{domain.KindProduct}})
+	if err != nil {
+		t.Fatalf("Search(spoon, products): %v", err)
+	}
+	if len(products) != 1 {
+		t.Fatalf("Search(spoon, products): expected 1 hit, got %d", len(products))
+	}
+	if got := products[0].Document.Kind(); got != domain.KindProduct {
+		t.Errorf("Search(spoon, products): hit kind = %q, want %q", got, domain.KindProduct)
+	}
+}
+
+func TestRemove_RemovesFromSearch(t *testing.T) {
+	srv := newServiceWithSeed(t)
+
+	if err := srv.Remove(context.Background(), domain.KindProduct, "p-mug"); err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+
+	hits, err := srv.Search(context.Background(), "mug", app.QueryOptions{})
+	if err != nil {
+		t.Fatalf("Search after Remove: %v", err)
+	}
+	if len(hits) != 0 {
+		t.Errorf("expected zero hits after Remove, got %d (%+v)", len(hits), hits)
+	}
+}
+
+func TestRemoveAllOfKind_ClearsKindButLeavesOthers(t *testing.T) {
+	srv := newServiceWithSeed(t)
+
+	if err := srv.RemoveAllOfKind(context.Background(), domain.KindProduct); err != nil {
+		t.Fatalf("RemoveAllOfKind: %v", err)
+	}
+
+	// Products should be gone, the blog post should remain.
+	productHits, err := srv.Search(context.Background(), "spoon", app.QueryOptions{Kinds: []domain.Kind{domain.KindProduct}})
+	if err != nil {
+		t.Fatalf("Search products: %v", err)
+	}
+	if len(productHits) != 0 {
+		t.Errorf("expected 0 product hits after RemoveAllOfKind, got %d", len(productHits))
+	}
+
+	blogHits, err := srv.Search(context.Background(), "spoon", app.QueryOptions{Kinds: []domain.Kind{domain.Kind("blog")}})
+	if err != nil {
+		t.Fatalf("Search blog: %v", err)
+	}
+	if len(blogHits) != 1 {
+		t.Errorf("expected 1 blog hit to survive, got %d", len(blogHits))
+	}
+}
+
+func TestSearch_EmptyQueryReturnsNoHits(t *testing.T) {
+	srv := newServiceWithSeed(t)
+
+	hits, err := srv.Search(context.Background(), "   ", app.QueryOptions{})
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(hits) != 0 {
+		t.Errorf("expected empty result for whitespace query, got %d (%+v)", len(hits), hits)
+	}
+}

--- a/backend/search/bounded_context.go
+++ b/backend/search/bounded_context.go
@@ -1,0 +1,26 @@
+// Package search is the composition root for the search bounded context.
+// It wires the postgres storage adapter into the application Service and
+// returns both the application.BoundedContext envelope and the concrete
+// *app.Service so callers can use it as both an Indexer (productcatalog)
+// and a Querier (layout) without going through a narrower facade.
+package search
+
+import (
+	"database/sql"
+
+	"github.com/bkielbasa/go-ecommerce/backend/internal/application"
+	"github.com/bkielbasa/go-ecommerce/backend/search/adapter"
+	"github.com/bkielbasa/go-ecommerce/backend/search/app"
+)
+
+// New wires the production storage adapter and returns the bounded-context
+// envelope plus the concrete *app.Service. The Service satisfies both the
+// Indexer and Querier roles; production passes the same instance into
+// productcatalog (for indexing on writes) and layout (for searching).
+func New(db *sql.DB) (application.BoundedContext, *app.Service) {
+	storage := adapter.NewPostgres(db)
+	srv := app.NewService(storage)
+	return &boundedContext{}, srv
+}
+
+type boundedContext struct{}

--- a/backend/search/domain/document.go
+++ b/backend/search/domain/document.go
@@ -1,0 +1,150 @@
+// Package domain holds the search bounded context's published language.
+//
+// The search context is an Open Host Service (OHS): it publishes a single
+// value object — Document — together with a Kind discriminator. Every
+// producer that wants to be searchable (productcatalog today; blog and faq
+// tomorrow) translates its own domain into a Document via a thin
+// Anti-Corruption Layer on the producer side. The search context itself does
+// not know about products, blog posts, or anything else — it only knows
+// about documents.
+//
+// Hits are uniquely identified by the pair (Kind, ID). The same id may
+// appear under different kinds (a product and a faq about it can share an
+// id), and storage adapters key on the pair, not the id alone.
+//
+// Adding a new producer requires no change here: a producer chooses a new
+// Kind value (any non-empty string), translates its records to Documents and
+// calls Indexer.Index. The set of known kinds is intentionally NOT a closed
+// enum at the type level — it is open by design (that is the OHS pattern).
+package domain
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// Kind discriminates documents by the producer that owns them. The search
+// context exposes one constant per producer it has been told about (today:
+// product); future producers can add new constants on their side without
+// changing search.
+type Kind string
+
+// KindProduct is the kind used by the productcatalog producer. It is the
+// only kind shipped with the initial cut; blog/faq are deliberately out of
+// scope but the architecture accepts new string-valued kinds without
+// touching this package.
+const KindProduct Kind = "product"
+
+// ErrInvalidDocument is returned by NewDocument when any input fails
+// validation (empty kind/id/title; whitespace-only body trimming to empty
+// would be allowed — body is informational, title is the primary signal).
+var ErrInvalidDocument = errors.New("invalid document")
+
+// Document is the published language of the search OHS. Producers translate
+// to it; consumers (the storefront) consume it. The fields are unexported
+// so callers cannot smuggle in a half-constructed value; use NewDocument
+// (validating) or RebuildDocument (hydration from storage).
+type Document struct {
+	kind      Kind
+	id        string
+	title     string
+	body      string
+	url       string
+	tags      []string
+	meta      map[string]string
+	updatedAt time.Time
+}
+
+// NewDocument validates inputs and returns a freshly built Document. tags
+// and meta are normalised to non-nil empty containers so callers (templates,
+// rebuild helpers) can always range over them without a nil guard.
+func NewDocument(kind Kind, id, title, body, url string, tags []string, meta map[string]string, updatedAt time.Time) (Document, error) {
+	if strings.TrimSpace(string(kind)) == "" {
+		return Document{}, fmt.Errorf("%w: kind cannot be empty", ErrInvalidDocument)
+	}
+	if strings.TrimSpace(id) == "" {
+		return Document{}, fmt.Errorf("%w: id cannot be empty", ErrInvalidDocument)
+	}
+	if strings.TrimSpace(title) == "" {
+		return Document{}, fmt.Errorf("%w: title cannot be empty", ErrInvalidDocument)
+	}
+	cleanTags := make([]string, 0, len(tags))
+	for _, t := range tags {
+		t = strings.TrimSpace(t)
+		if t == "" {
+			continue
+		}
+		cleanTags = append(cleanTags, t)
+	}
+	cleanMeta := make(map[string]string, len(meta))
+	for k, v := range meta {
+		k = strings.TrimSpace(k)
+		if k == "" {
+			continue
+		}
+		cleanMeta[k] = v
+	}
+	return Document{
+		kind:      kind,
+		id:        id,
+		title:     title,
+		body:      strings.TrimSpace(body),
+		url:       url,
+		tags:      cleanTags,
+		meta:      cleanMeta,
+		updatedAt: updatedAt,
+	}, nil
+}
+
+// RebuildDocument reconstructs a Document from a storage row, skipping the
+// validation that NewDocument performs (the row has been validated once on
+// the way in). tags / meta are normalised to non-nil containers.
+func RebuildDocument(kind Kind, id, title, body, url string, tags []string, meta map[string]string, updatedAt time.Time) Document {
+	if tags == nil {
+		tags = []string{}
+	}
+	if meta == nil {
+		meta = map[string]string{}
+	}
+	return Document{
+		kind:      kind,
+		id:        id,
+		title:     title,
+		body:      body,
+		url:       url,
+		tags:      tags,
+		meta:      meta,
+		updatedAt: updatedAt,
+	}
+}
+
+// Kind returns the producer-owned discriminator.
+func (d Document) Kind() Kind { return d.kind }
+
+// ID returns the producer-side id (unique within Kind).
+func (d Document) ID() string { return d.id }
+
+// Title is the primary text signal — weighted highest in the storage's
+// full-text index (the postgres adapter setweights it with 'A').
+func (d Document) Title() string { return d.title }
+
+// Body is the secondary text signal (weight 'B' in postgres).
+func (d Document) Body() string { return d.body }
+
+// URL is where the storefront should link the search hit; producers own its
+// shape (e.g. "/product/<id>"). The search context does not parse it.
+func (d Document) URL() string { return d.url }
+
+// Tags are short labels (e.g. category names) used as the tertiary text
+// signal (weight 'C' in postgres) and as filter candidates for future UI.
+func (d Document) Tags() []string { return d.tags }
+
+// Meta is arbitrary producer-supplied metadata (e.g. currency, price_minor,
+// thumbnail). The search context treats it as opaque key/value strings.
+func (d Document) Meta() map[string]string { return d.meta }
+
+// UpdatedAt is the producer-supplied last-modified timestamp; storage stamps
+// the row updated_at on every upsert in any case.
+func (d Document) UpdatedAt() time.Time { return d.updatedAt }

--- a/migrations/000028_search_documents.down.sql
+++ b/migrations/000028_search_documents.down.sql
@@ -1,0 +1,8 @@
+BEGIN;
+
+DROP INDEX IF EXISTS public.search_document_kind_idx;
+DROP INDEX IF EXISTS public.search_document_ts_idx;
+DROP TABLE IF EXISTS public.search_document;
+DROP FUNCTION IF EXISTS public.search_document_refresh_ts();
+
+COMMIT;

--- a/migrations/000028_search_documents.up.sql
+++ b/migrations/000028_search_documents.up.sql
@@ -1,0 +1,49 @@
+BEGIN;
+
+-- search_document is the storage for the search bounded context's published
+-- language (a Document value object). Producers (productcatalog today;
+-- blog/faq later) translate their records into rows here via a small ACL
+-- on their side; the search context itself does not know about products
+-- or any other domain.
+--
+-- (kind, id) is the composite primary key: hits are uniquely identified by
+-- the pair, so two producers can safely share an id namespace.
+--
+-- `ts` aggregates title (weight A), body (weight B) and tags (weight C)
+-- into a tsvector. We use the 'simple' configuration (lowercases + tokenises
+-- with no stemming) — matches the storefront's plain-substring mental model
+-- for short product titles. Postgres rejects a GENERATED expression that
+-- chains setweight + to_tsvector('simple', ...) as "not immutable" on its
+-- conservative immutability check, so we maintain ts via a trigger instead.
+CREATE TABLE public.search_document (
+    kind text NOT NULL,
+    id text NOT NULL,
+    title text NOT NULL,
+    body text NOT NULL,
+    url text NOT NULL,
+    tags text[] NOT NULL DEFAULT '{}',
+    meta jsonb NOT NULL DEFAULT '{}'::jsonb,
+    updated_at timestamptz NOT NULL DEFAULT now(),
+    ts tsvector,
+    PRIMARY KEY (kind, id)
+);
+
+CREATE OR REPLACE FUNCTION public.search_document_refresh_ts() RETURNS trigger AS $$
+BEGIN
+    NEW.ts :=
+        setweight(to_tsvector('simple', coalesce(NEW.title, '')), 'A') ||
+        setweight(to_tsvector('simple', coalesce(NEW.body, '')), 'B') ||
+        setweight(to_tsvector('simple', coalesce(array_to_string(NEW.tags, ' '), '')), 'C');
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER search_document_refresh_ts_bi
+    BEFORE INSERT OR UPDATE OF title, body, tags
+    ON public.search_document
+    FOR EACH ROW EXECUTE FUNCTION public.search_document_refresh_ts();
+
+CREATE INDEX search_document_ts_idx ON public.search_document USING GIN (ts);
+CREATE INDEX search_document_kind_idx ON public.search_document(kind);
+
+COMMIT;


### PR DESCRIPTION
A new search/ bounded context exposes its own published language — a Document value object plus Indexer + Querier ports. Producers (productcatalog today; blog/faq later) translate their domain to Document via a small ACL and call Indexer.Index / Remove. Search itself knows nothing about products or any consumer domain.

- Migration 000028: search_document(kind,id PK; title/body/url/tags/meta/updated_at, ts tsvector). Weighted tsvector via trigger (A=title, B=body, C=tags); GIN index. Query uses websearch_to_tsquery + ts_rank_cd.
- In-memory adapter mirrors the storage contract for tests.
- productcatalog ACL: SearchIndexer port + productToDocument translator; ProductService calls Index/Remove after every product+variant mutation. Index failures are logged and swallowed (never break the underlying mutation).
- Storefront /search and /api/v1/products?q= route q through the search service; product hits hydrate via catalogSrv.Find and render as the existing cards. The old ProductQuery.Search ILIKE field is removed.
- New `cli reindex` command walks AllProducts and rebuilds the index — bootstrap and drift-recovery path.

## Test plan
- [x] build / build -tags integration / vet / tests / lint green
- [x] docker: migration 000028 applies; `cli reindex` indexes 11 products; `q=mug` returns Ceramic Mug; `q=cast iron` returns Cast Iron Skillet (multi-word); `q=xyz` empty state; admin creates Glowstone Lantern → auto-indexed → `q=glowstone` returns it; admin deletes → row removed