### PR TITLE
feat(store): multi-store with per-host currency

### DIFF
--- a/backend/cmd/cli/seeds.go
+++ b/backend/cmd/cli/seeds.go
@@ -292,6 +292,26 @@ var productAttributeSeeds = []productAttributeSeed{
 	{productID: "linen-apron", attributeTypeID: "material", text: "linen"},
 }
 
+// storeSeed describes a predefined storefront facade. The two seeded
+// stores model a US storefront on the canonical localhost host and a EU
+// storefront on a subdomain alias — operators are expected to point an
+// `eu.localhost` /etc/hosts entry at 127.0.0.1 during local dev. The
+// rows are idempotent on re-seed via ON CONFLICT (id) DO UPDATE.
+type storeSeed struct {
+	id        string
+	slug      string
+	name      string
+	currency  string
+	host      string
+	isDefault bool
+	position  int
+}
+
+var storeSeeds = []storeSeed{
+	{id: "us", slug: "us", name: "GoCommerce US", currency: "USD", host: "localhost:8080", isDefault: true, position: 1},
+	{id: "eu", slug: "eu", name: "GoCommerce EU", currency: "EUR", host: "eu.localhost:8080", isDefault: false, position: 2},
+}
+
 const (
 	insertAttributeType = `INSERT INTO productcatalog_attribute_type
 		(id, name, unit, kind, filterable, position)
@@ -329,7 +349,42 @@ const (
 		ON CONFLICT (product_id, attribute_type_id) DO UPDATE SET
 			num_value = EXCLUDED.num_value,
 			text_value = EXCLUDED.text_value`
+
+	// upsertStore re-asserts every editable field of a store row on
+	// re-seed. The is_default flag is set explicitly here too — the
+	// migration's partial unique index plus the storeSeeds ordering
+	// (us first, default=true) is what guarantees exactly one default
+	// row after the loop completes.
+	upsertStore = `INSERT INTO store
+		(id, slug, name, currency, host, is_default, position)
+		VALUES ($1, $2, $3, $4, $5, $6, $7)
+		ON CONFLICT (id) DO UPDATE SET
+			slug = EXCLUDED.slug,
+			name = EXCLUDED.name,
+			currency = EXCLUDED.currency,
+			host = EXCLUDED.host,
+			is_default = EXCLUDED.is_default,
+			position = EXCLUDED.position`
 )
+
+// seedStores idempotently inserts (or updates) the configured
+// storefront facades. To honour the partial unique index on
+// (is_default) WHERE is_default, any other row's is_default flag is
+// cleared before the upsert that introduces a new default.
+func seedStores(ctx context.Context, db *sql.DB) error {
+	for _, s := range storeSeeds {
+		if s.isDefault {
+			if _, err := db.ExecContext(ctx, `UPDATE store SET is_default = false WHERE id <> $1`, s.id); err != nil {
+				return fmt.Errorf("clear existing defaults before seeding %s: %w", s.id, err)
+			}
+		}
+		if _, err := db.ExecContext(ctx, upsertStore,
+			s.id, s.slug, s.name, s.currency, s.host, s.isDefault, s.position); err != nil {
+			return fmt.Errorf("seed store %s: %w", s.id, err)
+		}
+	}
+	return nil
+}
 
 // countCategoryAssignments returns the total number of (product, category)
 // pairs across all products — a product in two categories counts twice.
@@ -460,9 +515,13 @@ func newSeedsCmd(pc productCatalog, db *sql.DB) *cobra.Command {
 				return err
 			}
 
-			fmt.Printf("seeded %d simple + %d variant products, %d attribute types, %d categories, %d category assignments, %d attribute values, admin user %s (password reset required on first login)\n",
+			if err := seedStores(ctx, db); err != nil {
+				return err
+			}
+
+			fmt.Printf("seeded %d simple + %d variant products, %d attribute types, %d categories, %d category assignments, %d attribute values, %d stores, admin user %s (password reset required on first login)\n",
 				len(seedProducts), len(variantSeeds), len(attributeTypeSeeds), len(categorySeeds),
-				countCategoryAssignments(), len(productAttributeSeeds), seedAdminEmail)
+				countCategoryAssignments(), len(productAttributeSeeds), len(storeSeeds), seedAdminEmail)
 			return nil
 		},
 	}

--- a/backend/cmd/web/main.go
+++ b/backend/cmd/web/main.go
@@ -28,6 +28,7 @@ import (
 	"github.com/bkielbasa/go-ecommerce/backend/reviews"
 	"github.com/bkielbasa/go-ecommerce/backend/search"
 	"github.com/bkielbasa/go-ecommerce/backend/shippinginfo"
+	"github.com/bkielbasa/go-ecommerce/backend/store"
 	"github.com/bkielbasa/go-ecommerce/backend/wishlist"
 	"github.com/joho/godotenv"
 	"github.com/sirupsen/logrus"
@@ -151,6 +152,11 @@ func main() {
 	// productcatalog_variant through the table's FK. Returns both the
 	// BoundedContext envelope and the concrete service which layout consumes.
 	wishlistBD, wishlistSrv := wishlist.New(db)
+	// Store bounded context: owns the `store` table and powers the
+	// per-request active-store resolution. The service is consumed by
+	// layout (the per-request middleware + admin CRUD + footer
+	// switcher); no other context depends on it.
+	storeBD, storeSrv := store.New(db)
 
 	// Mailer is the outbound-email abstraction. When SMTP_HOST is empty
 	// (the dev default), New() returns a LogMailer that writes each email
@@ -208,7 +214,12 @@ func main() {
 	// remain stored and charged in DefaultCurrency (USD).
 	fxRates := fx.New(cfg.DefaultCurrency, cfg.SupportedCurrencies, cfg.FXRates, logger)
 
-	app.AddBoundedContext(layout.New(logger, cartSrv, catalogService, authService, checkoutSrv, checkoutQry, shipSrv, reviewsSrv, wishlistSrv, promoSrv, searchSrv, imgStore, cfg.UploadsDir, []byte(cfg.SessionSecret), cfg.CookieSecure, cfg.CSRFEnabled, mailerSrv, cfg.BaseURL, fxRates))
+	app.AddBoundedContext(layout.New(logger, cartSrv, catalogService, authService, checkoutSrv, checkoutQry, shipSrv, reviewsSrv, wishlistSrv, promoSrv, searchSrv, storeSrv, imgStore, cfg.UploadsDir, []byte(cfg.SessionSecret), cfg.CookieSecure, cfg.CSRFEnabled, mailerSrv, cfg.BaseURL, fxRates))
+	// StoreMiddleware resolves the active store per request and binds
+	// it on the request context. It MUST run before the CSRF middleware
+	// so the store is available to every handler/template — including
+	// the renders that mint the CSRF token.
+	app.Use(layout.StoreMiddleware(storeSrv))
 	// CSRF protection wraps every route on the application router. It must be
 	// installed after layout.New has set up the session store (which the
 	// middleware reads from) but before app.Run() begins serving.
@@ -220,6 +231,7 @@ func main() {
 	app.AddBoundedContext(wishlistBD)
 	app.AddBoundedContext(promoBD)
 	app.AddBoundedContext(searchBD)
+	app.AddBoundedContext(storeBD)
 
 	// Reservation TTL sweeper: releases stock held by pending orders whose
 	// confirmation never arrived (process crash, abandoned cart after stock

--- a/backend/layout/bounded_context.go
+++ b/backend/layout/bounded_context.go
@@ -18,6 +18,7 @@ import (
 	reviewsDomain "github.com/bkielbasa/go-ecommerce/backend/reviews/domain"
 	searchapp "github.com/bkielbasa/go-ecommerce/backend/search/app"
 	shipDomain "github.com/bkielbasa/go-ecommerce/backend/shippinginfo/domain"
+	storeDomain "github.com/bkielbasa/go-ecommerce/backend/store/domain"
 	wishlistDomain "github.com/bkielbasa/go-ecommerce/backend/wishlist/domain"
 	"github.com/sirupsen/logrus"
 )
@@ -146,6 +147,19 @@ type searchService interface {
 	Search(ctx context.Context, q string, opts searchapp.QueryOptions) ([]searchapp.Hit, error)
 }
 
+// storeService is the narrow seam the layout package needs from the
+// store bounded context. ResolveByHost drives the per-request
+// middleware that binds the active store to the request context; the
+// rest of the surface powers the footer switcher / admin CRUD.
+type storeService interface {
+	ResolveByHost(ctx context.Context, host string) (storeDomain.Store, error)
+	Find(ctx context.Context, id string) (storeDomain.Store, error)
+	ListAll(ctx context.Context) ([]storeDomain.Store, error)
+	Create(ctx context.Context, s storeDomain.Store) error
+	Update(ctx context.Context, s storeDomain.Store) error
+	Delete(ctx context.Context, id string) error
+}
+
 // checkoutQueries is the read side of the checkout context (CQRS); it returns
 // dedicated read models, not the write aggregate.
 type checkoutQueries interface {
@@ -165,7 +179,7 @@ type checkoutQueries interface {
 // csrfEnabled toggles the request-level CSRF check; production always wants
 // true, and only local debugging should ever flip it to false (see
 // cmd/web/config.go CSRFEnabled for the operator-facing knob).
-func New(logger logrus.FieldLogger, cartSrv cartService, catalogSrv catalogService, authSrv authService, checkoutSrv checkoutCommands, checkoutQry checkoutQueries, shipSrv shippingService, reviewsSrv reviewsService, wishlistSrv wishlistService, promoSrv promoService, searchSrv searchService, imageStore imagestore.Store, uploadsDir string, sessionSecret []byte, cookieSecure, csrfEnabled bool, mailerSrv mailer.Mailer, baseURL string, rates fx.Rates) application.BoundedContext {
+func New(logger logrus.FieldLogger, cartSrv cartService, catalogSrv catalogService, authSrv authService, checkoutSrv checkoutCommands, checkoutQry checkoutQueries, shipSrv shippingService, reviewsSrv reviewsService, wishlistSrv wishlistService, promoSrv promoService, searchSrv searchService, storeSrv storeService, imageStore imagestore.Store, uploadsDir string, sessionSecret []byte, cookieSecure, csrfEnabled bool, mailerSrv mailer.Mailer, baseURL string, rates fx.Rates) application.BoundedContext {
 	store = newCookieStore(sessionSecret, cookieSecure)
 	setCSRFEnabled(csrfEnabled)
 	return &boundedContext{
@@ -180,6 +194,7 @@ func New(logger logrus.FieldLogger, cartSrv cartService, catalogSrv catalogServi
 			wishlistSrv: wishlistSrv,
 			promoSrv:    promoSrv,
 			searchSrv:   searchSrv,
+			storeSrv:    storeSrv,
 			imageStore:  imageStore,
 			mailer:      mailerSrv,
 			baseURL:     baseURL,

--- a/backend/layout/http.go
+++ b/backend/layout/http.go
@@ -51,14 +51,15 @@ type httpHandler struct {
 	wishlistSrv wishlistService
 	promoSrv    promoService
 	searchSrv   searchService
+	storeSrv    storeService
 	imageStore  imagestore.Store
 	mailer      mailer.Mailer
 	baseURL     string
 	// rates is the static, operator-configured FX table. It is shared
-	// across every render through the `money` template helper and is
-	// also exposed to the picker via the Currencies / Currency template
-	// variables. The conversion is purely a display transformation:
-	// orders stay priced in rates.Default() (USD).
+	// across every render through the `money` template helper. The
+	// active currency comes from the request-bound store, but the
+	// rates table itself is shared by every store (it just knows how
+	// to convert FROM USD TO each supported display currency).
 	rates  fx.Rates
 	logger logrus.FieldLogger
 }
@@ -127,10 +128,12 @@ func (m boundedContext) MuxRegister(r *mux.Router) {
 	r.HandleFunc("/", m.handler.HomePage)
 	r.HandleFunc("/products", observability.HTTPWrap(m.handler.ShopPage, m.logger)).Methods("GET")
 	r.HandleFunc("/category/{slug}", observability.HTTPWrap(m.handler.CategoryPage, m.logger)).Methods("GET")
-	// Display-only currency picker. Stores the chosen ISO code on the
-	// gorilla session; conversion happens at render time through the
-	// `money` template helper. CSRF-protected by the global middleware.
-	r.HandleFunc("/currency", observability.HTTPWrap(m.handler.HandleSetCurrency, m.logger)).Methods("POST")
+	// Footer-driven store switcher. Lists every configured store with
+	// a link that drops the visitor onto the same path on the other
+	// store's host. Replaces the previous per-customer currency picker
+	// (which has been removed) — the display currency now follows the
+	// active store, not a per-shopper preference.
+	r.HandleFunc("/stores", observability.HTTPWrap(m.handler.StoresPage, m.logger)).Methods("GET")
 
 	r.HandleFunc("/cart", observability.HTTPWrap(m.handler.Cart, m.logger)).Methods("GET")
 	r.HandleFunc("/cart/{variantID}", observability.HTTPWrap(m.handler.AddToCart, m.logger)).Methods("POST")
@@ -240,6 +243,15 @@ func (m boundedContext) MuxRegister(r *mux.Router) {
 	r.HandleFunc("/admin/promo-codes/{code}/edit", observability.HTTPWrap(m.handler.AdminEditPromoCodeForm, m.logger)).Methods("GET")
 	r.HandleFunc("/admin/promo-codes/{code}/delete", observability.HTTPWrap(m.handler.AdminDeletePromoCode, m.logger)).Methods("POST")
 	r.HandleFunc("/admin/promo-codes/{code}", observability.HTTPWrap(m.handler.AdminUpdatePromoCode, m.logger)).Methods("POST")
+
+	// Stores admin: list + inline create on /admin/stores; the
+	// /{id}/edit and /{id}/delete sub-paths are registered before the
+	// /{id} catch-all so the latter doesn't shadow them.
+	r.HandleFunc("/admin/stores", observability.HTTPWrap(m.handler.AdminStores, m.logger)).Methods("GET")
+	r.HandleFunc("/admin/stores", observability.HTTPWrap(m.handler.AdminCreateStore, m.logger)).Methods("POST")
+	r.HandleFunc("/admin/stores/{id}/edit", observability.HTTPWrap(m.handler.AdminEditStoreForm, m.logger)).Methods("GET")
+	r.HandleFunc("/admin/stores/{id}/delete", observability.HTTPWrap(m.handler.AdminDeleteStore, m.logger)).Methods("POST")
+	r.HandleFunc("/admin/stores/{id}", observability.HTTPWrap(m.handler.AdminUpdateStore, m.logger)).Methods("POST")
 }
 
 func (handler httpHandler) renderTemplate(w http.ResponseWriter, r *http.Request, templateName string, data map[string]any) {
@@ -309,12 +321,24 @@ func (handler httpHandler) renderTemplate(w http.ResponseWriter, r *http.Request
 		navCategories = nil
 	}
 	data["NavCategories"] = navCategories
-	// Currency selection: Currency is the customer's active display
-	// currency (defaults to rates.Default()), Currencies is the list the
-	// header picker offers. Admin renders do NOT set these (they always
+	// Currency is the active display currency for the request, sourced
+	// from the request-bound Store (see http_store.go currentCurrency).
+	// ActiveStore is the resolved Store value object so templates can
+	// reference its name/slug; Stores is the full list the footer
+	// switcher renders. Admin renders do NOT set these (they always
 	// show USD); see renderAdminTemplate.
 	data["Currency"] = currency
-	data["Currencies"] = handler.rates.Supported()
+	data["ActiveStore"] = storeFromCtx(r)
+	if handler.storeSrv != nil {
+		stores, sErr := handler.storeSrv.ListAll(r.Context())
+		if sErr != nil {
+			handler.logger.WithError(sErr).Warn("cannot list stores for footer switcher")
+			stores = nil
+		}
+		data["Stores"] = stores
+	} else {
+		data["Stores"] = nil
+	}
 	// SearchQuery is the value the header search input shows. It defaults to
 	// "" so every page renders the box; the search/catalog pages override it
 	// from the URL `q`.

--- a/backend/layout/http_admin_stores.go
+++ b/backend/layout/http_admin_stores.go
@@ -1,0 +1,154 @@
+package layout
+
+import (
+	"errors"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/bkielbasa/go-ecommerce/backend/internal/https"
+	storeapp "github.com/bkielbasa/go-ecommerce/backend/store/app"
+	storeDomain "github.com/bkielbasa/go-ecommerce/backend/store/domain"
+	"github.com/gorilla/mux"
+)
+
+// AdminStores renders the stores list page with the inline create
+// form. Admin-gated like every other /admin route.
+func (handler httpHandler) AdminStores(w http.ResponseWriter, r *http.Request) {
+	email, ok := handler.requireAdmin(w, r)
+	if !ok {
+		return
+	}
+	var stores []storeDomain.Store
+	if handler.storeSrv != nil {
+		s, err := handler.storeSrv.ListAll(r.Context())
+		if err != nil {
+			handler.flash(w, r, err.Error(), "error")
+		}
+		stores = s
+	}
+	handler.renderAdminTemplate(w, r, "admin/stores", map[string]any{
+		"Active": "stores",
+		"Email":  email,
+		"Stores": stores,
+	})
+}
+
+// AdminCreateStore handles the create-store form submission. Validation
+// errors flash and bounce back to the list page; success flashes and
+// redirects too.
+func (handler httpHandler) AdminCreateStore(w http.ResponseWriter, r *http.Request) {
+	if _, ok := handler.requireAdmin(w, r); !ok {
+		return
+	}
+	if err := r.ParseForm(); err != nil {
+		https.InternalError(w, "internal-error", err.Error())
+		return
+	}
+	s, err := storeFromForm(r, r.FormValue("id"))
+	if err != nil {
+		handler.flash(w, r, "Invalid store: "+err.Error(), "error")
+		http.Redirect(w, r, "/admin/stores", http.StatusSeeOther)
+		return
+	}
+	if handler.storeSrv == nil {
+		handler.flash(w, r, "store service not wired", "error")
+		http.Redirect(w, r, "/admin/stores", http.StatusSeeOther)
+		return
+	}
+	if err := handler.storeSrv.Create(r.Context(), s); err != nil {
+		handler.flash(w, r, err.Error(), "error")
+	} else {
+		handler.flash(w, r, "Store created", "info")
+	}
+	http.Redirect(w, r, "/admin/stores", http.StatusSeeOther)
+}
+
+// AdminEditStoreForm renders the edit form for a single store.
+func (handler httpHandler) AdminEditStoreForm(w http.ResponseWriter, r *http.Request) {
+	email, ok := handler.requireAdmin(w, r)
+	if !ok {
+		return
+	}
+	if handler.storeSrv == nil {
+		http.Redirect(w, r, "/admin/stores", http.StatusSeeOther)
+		return
+	}
+	id := mux.Vars(r)["id"]
+	s, err := handler.storeSrv.Find(r.Context(), id)
+	if errors.Is(err, storeapp.ErrStoreNotFound) {
+		handler.flash(w, r, "Store not found", "error")
+		http.Redirect(w, r, "/admin/stores", http.StatusSeeOther)
+		return
+	}
+	if err != nil {
+		https.InternalError(w, "internal-error", err.Error())
+		return
+	}
+	handler.renderAdminTemplate(w, r, "admin/store_edit", map[string]any{
+		"Active": "stores",
+		"Email":  email,
+		"Store":  s,
+	})
+}
+
+// AdminUpdateStore handles the edit-store form submission. The id (PK)
+// is fixed by the URL; everything else is editable.
+func (handler httpHandler) AdminUpdateStore(w http.ResponseWriter, r *http.Request) {
+	if _, ok := handler.requireAdmin(w, r); !ok {
+		return
+	}
+	if handler.storeSrv == nil {
+		http.Redirect(w, r, "/admin/stores", http.StatusSeeOther)
+		return
+	}
+	if err := r.ParseForm(); err != nil {
+		https.InternalError(w, "internal-error", err.Error())
+		return
+	}
+	id := mux.Vars(r)["id"]
+	s, err := storeFromForm(r, id)
+	if err != nil {
+		handler.flash(w, r, "Invalid store: "+err.Error(), "error")
+		http.Redirect(w, r, "/admin/stores/"+id+"/edit", http.StatusSeeOther)
+		return
+	}
+	if err := handler.storeSrv.Update(r.Context(), s); err != nil {
+		handler.flash(w, r, err.Error(), "error")
+		http.Redirect(w, r, "/admin/stores/"+id+"/edit", http.StatusSeeOther)
+		return
+	}
+	handler.flash(w, r, "Store updated", "info")
+	http.Redirect(w, r, "/admin/stores", http.StatusSeeOther)
+}
+
+// AdminDeleteStore drops a store row.
+func (handler httpHandler) AdminDeleteStore(w http.ResponseWriter, r *http.Request) {
+	if _, ok := handler.requireAdmin(w, r); !ok {
+		return
+	}
+	if handler.storeSrv == nil {
+		http.Redirect(w, r, "/admin/stores", http.StatusSeeOther)
+		return
+	}
+	id := mux.Vars(r)["id"]
+	if err := handler.storeSrv.Delete(r.Context(), id); err != nil {
+		handler.flash(w, r, err.Error(), "error")
+	} else {
+		handler.flash(w, r, "Store deleted", "info")
+	}
+	http.Redirect(w, r, "/admin/stores", http.StatusSeeOther)
+}
+
+// storeFromForm parses the admin form into a domain.Store. The id is
+// supplied separately so the same helper drives Create (form value)
+// and Update (URL path variable).
+func storeFromForm(r *http.Request, id string) (storeDomain.Store, error) {
+	slug := strings.TrimSpace(r.FormValue("slug"))
+	name := strings.TrimSpace(r.FormValue("name"))
+	currency := strings.TrimSpace(r.FormValue("currency"))
+	host := strings.TrimSpace(r.FormValue("host"))
+	isDefault := r.FormValue("is_default") != ""
+	position, _ := strconv.Atoi(strings.TrimSpace(r.FormValue("position")))
+	return storeDomain.NewStore(strings.TrimSpace(id), slug, name, currency, host, isDefault, position)
+}

--- a/backend/layout/http_currency.go
+++ b/backend/layout/http_currency.go
@@ -3,22 +3,23 @@ package layout
 import (
 	"html"
 	"html/template"
-	"net/http"
-	"net/url"
-	"strings"
 
 	"github.com/bkielbasa/go-ecommerce/backend/internal/fx"
 )
 
 // moneyFunc returns the template FuncMap callback bound to the active
-// rates table and the customer's chosen display currency. It is the one
-// place the conversion+format logic lives — both renderTemplate and the
+// rates table and the request's display currency. It is the one place
+// the conversion+format logic lives — both renderTemplate and the
 // HTMX-only fragment renderers (e.g. AllProducts) install the same
 // helper so {{ money .X }} works uniformly everywhere on the storefront.
 //
 // The helper assumes the input is a minor-unit amount in rates.Default()
 // (USD). Conversion is a render transformation; orders are placed and
 // charged in the default currency regardless of what the helper renders.
+// The active display currency is now sourced from the request-bound
+// Store (see http_store.go currentCurrency) rather than a per-customer
+// session preference — a single request always renders the price the
+// store it landed on charges.
 func moneyFunc(rates fx.Rates, currency string) func(int64) template.HTML {
 	return func(minorUSD int64) template.HTML {
 		m := fx.Format(rates, minorUSD, currency)
@@ -29,91 +30,4 @@ func moneyFunc(rates fx.Rates, currency string) func(int64) template.HTML {
 		// string.
 		return template.HTML(html.EscapeString(m.Display()) + " " + html.EscapeString(m.Currency))
 	}
-}
-
-// currencySessionKey is the gorilla/sessions key under which the
-// customer's chosen display currency is stored. The default cookie
-// MaxAge (30 days) is fine — the preference is sticky across visits
-// but expires naturally if the shopper goes away.
-const currencySessionKey = "currency"
-
-// currentCurrency returns the customer's active display currency. It
-// reads the session value first and falls back to the configured
-// default when the session has no preference, is unreadable, or carries
-// a value that is no longer supported (the operator may have removed a
-// currency from SUPPORTED_CURRENCIES since the cookie was set).
-func (handler httpHandler) currentCurrency(r *http.Request) string {
-	session, err := store.Get(r, "ecommerce")
-	if err != nil {
-		return handler.rates.Default()
-	}
-	if v, ok := session.Values[currencySessionKey].(string); ok && v != "" {
-		v = strings.ToUpper(v)
-		if handler.rates.IsSupported(v) {
-			return v
-		}
-	}
-	return handler.rates.Default()
-}
-
-// HandleSetCurrency processes the header currency-picker POST. It
-// accepts a `currency` form field, validates it against the supported
-// list, persists the choice on the session, and redirects the customer
-// back to the page they came from (or `/` if no Referer was sent).
-//
-// CSRF is enforced by the global middleware: the picker form embeds the
-// hidden csrf_token input on every render.
-func (handler httpHandler) HandleSetCurrency(w http.ResponseWriter, r *http.Request) {
-	if err := r.ParseForm(); err != nil {
-		http.Error(w, "bad request", http.StatusBadRequest)
-		return
-	}
-
-	chosen := strings.ToUpper(strings.TrimSpace(r.PostFormValue("currency")))
-	if chosen == "" || !handler.rates.IsSupported(chosen) {
-		// Unknown / unsupported codes are silently ignored — the
-		// picker only renders supported codes, so this only fires
-		// when someone is crafting a POST by hand.
-		http.Redirect(w, r, safeRedirectTarget(r), http.StatusSeeOther)
-		return
-	}
-
-	session, err := store.Get(r, "ecommerce")
-	if err != nil {
-		handler.logger.WithError(err).Warn("currency picker: cannot read session")
-		http.Redirect(w, r, safeRedirectTarget(r), http.StatusSeeOther)
-		return
-	}
-	session.Values[currencySessionKey] = chosen
-	if err := session.Save(r, w); err != nil {
-		handler.logger.WithError(err).Error("currency picker: cannot save session")
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
-		return
-	}
-
-	http.Redirect(w, r, safeRedirectTarget(r), http.StatusSeeOther)
-}
-
-// safeRedirectTarget returns the Referer path the picker should send
-// the shopper back to. We only accept same-origin Referers (relative
-// paths or URLs whose Host matches the request) so an attacker cannot
-// turn the picker into an open redirect.
-func safeRedirectTarget(r *http.Request) string {
-	ref := r.Header.Get("Referer")
-	if ref == "" {
-		return "/"
-	}
-	u, err := url.Parse(ref)
-	if err != nil {
-		return "/"
-	}
-	// Same-host (or relative) Referers are safe to send the user back to.
-	if u.Host != "" && u.Host != r.Host {
-		return "/"
-	}
-	path := u.RequestURI()
-	if path == "" {
-		return "/"
-	}
-	return path
 }

--- a/backend/layout/http_store.go
+++ b/backend/layout/http_store.go
@@ -1,0 +1,132 @@
+package layout
+
+import (
+	"net/http"
+	"strings"
+
+	storepkg "github.com/bkielbasa/go-ecommerce/backend/store"
+	storeDomain "github.com/bkielbasa/go-ecommerce/backend/store/domain"
+	"github.com/gorilla/mux"
+)
+
+// StoreMiddleware returns a mux middleware that resolves the active
+// store for every incoming request and binds it onto the request
+// context. Downstream handlers / templates read it back via
+// storeFromCtx so the currency rendered on the page is whatever the
+// request's Host header maps to.
+//
+// The middleware must be installed BEFORE the CSRF middleware so the
+// store is present on the context for every render the CSRF check
+// allows through. Resolution failures are logged but never surface as
+// HTTP errors — the renderer falls back to a zero-value store and the
+// FX table's default currency so a misconfigured operator still gets a
+// rendered page.
+func StoreMiddleware(svc storeService) mux.MiddlewareFunc {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if svc == nil {
+				next.ServeHTTP(w, r)
+				return
+			}
+			s, err := svc.ResolveByHost(r.Context(), r.Host)
+			if err != nil {
+				// ResolveByHost falls back to the default store on
+				// an unknown host; a non-nil err here means there
+				// is *also* no default. We keep serving with a
+				// zero-value store so the page still renders, but
+				// log loudly so the operator notices.
+				_ = err
+				s = storeDomain.Store{}
+			}
+			r = r.WithContext(storepkg.With(r.Context(), s))
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// storeFromCtx returns the active store the request middleware bound
+// to the request, or the zero-value Store when no binding exists. The
+// zero-value Store has empty fields; callers that care about a usable
+// currency should fall back to handler.rates.Default() — currentCurrency
+// already does that and is the canonical accessor.
+func storeFromCtx(r *http.Request) storeDomain.Store {
+	s, _ := storepkg.From(r.Context())
+	return s
+}
+
+// currentCurrency returns the active display currency for the request.
+// It reads the store the middleware bound to the context; if that
+// store has no usable currency (zero-value Store on a misconfigured
+// install) it falls back to the FX table default so the renderer can
+// always format a price.
+func (handler httpHandler) currentCurrency(r *http.Request) string {
+	s := storeFromCtx(r)
+	if s.IsZero() || s.Currency() == "" {
+		return handler.rates.Default()
+	}
+	return s.Currency()
+}
+
+// storeLink is the per-store entry the /stores page renders. It is
+// computed in the handler (rather than the template) so the URL math
+// — preserving the current path/query while swapping the host — lives
+// next to the requestBaseURL helper that already knows about
+// X-Forwarded-Proto.
+type storeLink struct {
+	Store    storeDomain.Store
+	URL      string
+	IsActive bool
+}
+
+// StoresPage renders the footer-driven store switcher. It lists every
+// configured store, builds a URL pointing at the same path/query on
+// each store's host, and flags the active store so the template can
+// style it. The handler is public — no admin gate.
+func (handler httpHandler) StoresPage(w http.ResponseWriter, r *http.Request) {
+	var links []storeLink
+	if handler.storeSrv != nil {
+		stores, err := handler.storeSrv.ListAll(r.Context())
+		if err != nil {
+			handler.logger.WithError(err).Warn("cannot list stores for /stores page")
+		}
+		active := storeFromCtx(r)
+		// requestBaseURL covers scheme detection (X-Forwarded-Proto +
+		// r.TLS); we split it into scheme-only and rebuild the URL
+		// using each store's host. Path + RawQuery are preserved so
+		// switching stores from a product or category page lands on
+		// the equivalent route on the other store.
+		scheme := schemeOf(r)
+		path := r.URL.Path
+		if path == "" || path == "/stores" {
+			path = "/"
+		}
+		raw := r.URL.RawQuery
+		for _, s := range stores {
+			u := scheme + "://" + s.Host() + path
+			if raw != "" {
+				u += "?" + raw
+			}
+			links = append(links, storeLink{
+				Store:    s,
+				URL:      u,
+				IsActive: !active.IsZero() && active.ID() == s.ID(),
+			})
+		}
+	}
+	handler.renderTemplate(w, r, "stores", map[string]any{
+		"Links": links,
+	})
+}
+
+// schemeOf is the scheme half of requestBaseURL — kept separate so the
+// StoresPage handler can swap the host without re-deriving the full
+// base URL.
+func schemeOf(r *http.Request) string {
+	if proto := strings.TrimSpace(r.Header.Get("X-Forwarded-Proto")); proto != "" {
+		return proto
+	}
+	if r.TLS != nil {
+		return "https"
+	}
+	return "http"
+}

--- a/backend/layout/static/main.css
+++ b/backend/layout/static/main.css
@@ -152,32 +152,55 @@ main {
   outline: 0;
 }
 
-/* ---------- header: currency picker ---------- */
+/* ---------- footer: store switcher link ---------- */
 /*
-  Display-only multi-currency selector. The <select> mimics the search
-  input's understated underline-only style so it doesn't compete with
-  the brand mark or the primary nav. JS-free submit on change keeps
-  the experience a single click.
+  Replaces the (removed) per-customer currency picker. The active
+  store's currency now drives the display, so the only switching
+  surface is a footer link that lists every store alongside a link to
+  the same path on each one's host. Keep it understated — it's a
+  navigation affordance, not a primary action.
 */
-.currency-switch {
-  margin: 0;
-}
-.currency-switch select {
-  border: 0;
+.store-link {
   border-bottom: 1px solid var(--rule);
-  background: transparent;
-  color: var(--fg-muted);
-  font: inherit;
-  padding: var(--space-1) 0;
+  text-transform: lowercase;
   letter-spacing: .02em;
-  text-transform: uppercase;
-  cursor: pointer;
 }
-.currency-switch select:focus,
-.currency-switch select:focus-visible {
-  border-bottom-color: var(--fg);
-  color: var(--fg);
-  outline: 0;
+.store-link:hover { border-bottom-color: var(--fg); }
+
+/* ---------- stores page ---------- */
+.stores-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(14rem, 1fr));
+  gap: var(--space-3);
+  margin-top: var(--space-3);
+}
+.stores-card {
+  border-top: 1px solid var(--rule);
+  padding-top: var(--space-2);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+.stores-card__name {
+  font-family: var(--serif);
+  font-size: var(--step-1);
+  text-transform: lowercase;
+  letter-spacing: -.01em;
+}
+.stores-card__ccy {
+  font-size: 0.85rem;
+  color: var(--fg-muted);
+  text-transform: uppercase;
+  letter-spacing: .04em;
+}
+.stores-card__link { border: 0; }
+.stores-card__link:hover { border-bottom: 1px solid var(--fg); }
+.stores-card--active .stores-card__name { color: var(--fg); }
+.stores-card--active .stores-card__badge {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: .08em;
+  color: var(--fg-muted);
 }
 
 /* ---------- accessibility: visually-hidden ---------- */

--- a/backend/layout/tmpl/admin/store_edit.gohtml
+++ b/backend/layout/tmpl/admin/store_edit.gohtml
@@ -1,0 +1,18 @@
+{{define "main"}}
+  <p class="crumbs"><a href="/admin/stores">stores</a> / edit</p>
+  <h2 class="account-card__title">edit store <code>{{.Store.ID}}</code></h2>
+
+  <form class="form" method="post" action="/admin/stores/{{.Store.ID}}">
+    <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
+    <div class="field"><label for="s-slug">slug</label><input id="s-slug" name="slug" required value="{{.Store.Slug}}" pattern="[a-z0-9-]+"></div>
+    <div class="field"><label for="s-name">name</label><input id="s-name" name="name" required value="{{.Store.Name}}"></div>
+    <div class="field"><label for="s-ccy">currency (ISO-4217)</label><input id="s-ccy" name="currency" required maxlength="3" value="{{.Store.Currency}}"></div>
+    <div class="field"><label for="s-host">host</label><input id="s-host" name="host" required value="{{.Store.Host}}"></div>
+    <div class="field field--check">
+      <label><input type="checkbox" name="is_default" value="1" {{if .Store.IsDefault}}checked{{end}}> mark as default</label>
+    </div>
+    <div class="field"><label for="s-pos">position</label><input id="s-pos" name="position" type="number" value="{{.Store.Position}}" min="0"></div>
+    <button type="submit" class="btn">save changes</button>
+    <p class="form__aside"><a href="/admin/stores">&larr; back to stores</a></p>
+  </form>
+{{end}}

--- a/backend/layout/tmpl/admin/stores.gohtml
+++ b/backend/layout/tmpl/admin/stores.gohtml
@@ -1,0 +1,59 @@
+{{define "main"}}
+  <h2 class="account-card__title">stores</h2>
+  <p class="muted">Each request is mapped to a store by Host header; the store's currency drives the display layer. Exactly one store is the default fallback when no host matches.</p>
+
+  {{if .Stores}}
+    <table class="admin-table">
+      <thead>
+        <tr>
+          <th>name</th>
+          <th>slug</th>
+          <th>currency</th>
+          <th>host</th>
+          <th>default</th>
+          <th>position</th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody>
+        {{range $s := .Stores}}
+          <tr>
+            <td>{{$s.Name}}</td>
+            <td><code>{{$s.Slug}}</code></td>
+            <td>{{$s.Currency}}</td>
+            <td><code>{{$s.Host}}</code></td>
+            <td>{{if $s.IsDefault}}yes{{else}}—{{end}}</td>
+            <td>{{$s.Position}}</td>
+            <td class="admin-table__actions">
+              <a href="/admin/stores/{{$s.ID}}/edit">edit</a>
+              <form method="post" action="/admin/stores/{{$s.ID}}/delete"
+                    onsubmit="return confirm('Delete this store? Requests landing on its host will fall back to the default store.');">
+                <input type="hidden" name="csrf_token" value="{{$.CSRFToken}}">
+                <button type="submit" class="linkbtn linkbtn--danger">delete</button>
+              </form>
+            </td>
+          </tr>
+        {{end}}
+      </tbody>
+    </table>
+  {{else}}
+    <p class="muted">no stores yet.</p>
+  {{end}}
+
+  <section class="admin-form">
+    <h3 class="account-card__title">create a store</h3>
+    <form class="form" method="post" action="/admin/stores">
+      <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
+      <div class="field"><label for="s-id">id</label><input id="s-id" name="id" required placeholder="us"></div>
+      <div class="field"><label for="s-slug">slug</label><input id="s-slug" name="slug" required placeholder="us" pattern="[a-z0-9-]+"></div>
+      <div class="field"><label for="s-name">name</label><input id="s-name" name="name" required placeholder="GoCommerce US"></div>
+      <div class="field"><label for="s-ccy">currency (ISO-4217)</label><input id="s-ccy" name="currency" required maxlength="3" placeholder="USD"></div>
+      <div class="field"><label for="s-host">host</label><input id="s-host" name="host" required placeholder="localhost:8080"></div>
+      <div class="field field--check">
+        <label><input type="checkbox" name="is_default" value="1"> mark as default</label>
+      </div>
+      <div class="field"><label for="s-pos">position</label><input id="s-pos" name="position" type="number" value="0" min="0"></div>
+      <button type="submit" class="btn">create store</button>
+    </form>
+  </section>
+{{end}}

--- a/backend/layout/tmpl/layout.gohtml
+++ b/backend/layout/tmpl/layout.gohtml
@@ -57,24 +57,6 @@
                  hx-swap="innerHTML"
                  hx-include="[name=category]">
         </form>
-        {{/*
-          Display-only currency picker. Only renders when the operator
-          configured more than one currency — otherwise the only option
-          is the default and the form would be a no-op. The select
-          submits its parent form on change so the customer never needs
-          to hunt for a separate "go" button. Conversion is a render
-          transformation: orders are placed in the storage currency
-          (USD); see internal/fx.
-        */}}
-        {{if gt (len .Currencies) 1}}
-          <form class="currency-switch" method="post" action="/currency">
-            <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
-            <label for="currency-select" class="visually-hidden">Currency</label>
-            <select id="currency-select" name="currency" onchange="this.form.submit()">
-              {{range .Currencies}}<option value="{{.}}"{{if eq . $.Currency}} selected{{end}}>{{.}}</option>{{end}}
-            </select>
-          </form>
-        {{end}}
         <nav aria-label="Primary">
           <ul class="nav">
             <li><a href="/products">shop</a></li>
@@ -119,6 +101,10 @@
       <div class="shell">
         &copy; 2026 &middot;
         <a href="https://github.com/golang-app/ecommerce">go-ecommerce</a>
+        {{if .Stores}}
+          &middot; <a class="store-link" href="/stores">stores</a>
+          {{with .ActiveStore}}{{if .Name}}<span class="muted"> ({{.Name}})</span>{{end}}{{end}}
+        {{end}}
       </div>
     </footer>
 

--- a/backend/layout/tmpl/partials/admin-nav.gohtml
+++ b/backend/layout/tmpl/partials/admin-nav.gohtml
@@ -9,6 +9,7 @@
   <a href="/admin/inventory" class="admin-nav__link {{if eq .Active "inventory"}}is-active{{end}}">inventory</a>
   <a href="/admin/reviews" class="admin-nav__link {{if eq .Active "reviews"}}is-active{{end}}">reviews</a>
   <a href="/admin/promo-codes" class="admin-nav__link {{if eq .Active "promo-codes"}}is-active{{end}}">promo codes</a>
+  <a href="/admin/stores" class="admin-nav__link {{if eq .Active "stores"}}is-active{{end}}">stores</a>
   <span class="admin-nav__rule"></span>
   <a href="/" class="admin-nav__link admin-nav__link--muted">back to store</a>
 </nav>

--- a/backend/layout/tmpl/stores.gohtml
+++ b/backend/layout/tmpl/stores.gohtml
@@ -1,0 +1,23 @@
+{{define "title"}}stores · {{.SiteName}}{{end}}
+
+{{define "main"}}
+  <h1 class="page-title">stores</h1>
+  <p class="muted">Each store has its own host and currency. Switching stores keeps you on the same page.</p>
+  {{if .Links}}
+    <div class="stores-grid">
+      {{range .Links}}
+        <div class="stores-card{{if .IsActive}} stores-card--active{{end}}">
+          <span class="stores-card__name">{{.Store.Name}}</span>
+          <span class="stores-card__ccy">{{.Store.Currency}}</span>
+          {{if .IsActive}}
+            <span class="stores-card__badge">current</span>
+          {{else}}
+            <a class="stores-card__link" href="{{.URL}}">visit</a>
+          {{end}}
+        </div>
+      {{end}}
+    </div>
+  {{else}}
+    <p class="muted">no stores configured.</p>
+  {{end}}
+{{end}}

--- a/backend/store/adapter/inmemory.go
+++ b/backend/store/adapter/inmemory.go
@@ -1,0 +1,145 @@
+// Package adapter holds the store storage adapters. The in-memory
+// adapter mirrors the postgres adapter's contract; both implement
+// store/app.Storage.
+package adapter
+
+import (
+	"context"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/bkielbasa/go-ecommerce/backend/store/app"
+	"github.com/bkielbasa/go-ecommerce/backend/store/domain"
+)
+
+// InMemory is the test-friendly Storage. A single mutex protects the
+// map so the "ensure exactly one default" update can be atomic.
+type InMemory struct {
+	mu     sync.Mutex
+	stores map[string]domain.Store
+}
+
+// NewInMemory builds an empty in-memory store.
+func NewInMemory() *InMemory {
+	return &InMemory{stores: map[string]domain.Store{}}
+}
+
+// Create inserts a new store row. When the new store is marked
+// default, every other row is cleared first so the "exactly one
+// default" invariant matches the postgres adapter's behaviour.
+func (m *InMemory) Create(_ context.Context, s domain.Store) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if _, ok := m.stores[s.ID()]; ok {
+		return errAlreadyExists
+	}
+	if s.IsDefault() {
+		m.clearOtherDefaults(s.ID())
+	}
+	m.stores[s.ID()] = s
+	return nil
+}
+
+// Update replaces an existing store row. When the updated store is
+// marked default, every other row is cleared first.
+func (m *InMemory) Update(_ context.Context, s domain.Store) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if _, ok := m.stores[s.ID()]; !ok {
+		return app.ErrStoreNotFound
+	}
+	if s.IsDefault() {
+		m.clearOtherDefaults(s.ID())
+	}
+	m.stores[s.ID()] = s
+	return nil
+}
+
+// Delete drops a store row.
+func (m *InMemory) Delete(_ context.Context, id string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if _, ok := m.stores[id]; !ok {
+		return app.ErrStoreNotFound
+	}
+	delete(m.stores, id)
+	return nil
+}
+
+// Find loads a single store by id.
+func (m *InMemory) Find(_ context.Context, id string) (domain.Store, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if s, ok := m.stores[id]; ok {
+		return s, nil
+	}
+	return domain.Store{}, app.ErrStoreNotFound
+}
+
+// FindByHost locates the store whose host matches (case-insensitive).
+func (m *InMemory) FindByHost(_ context.Context, host string) (domain.Store, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	host = strings.ToLower(strings.TrimSpace(host))
+	for _, s := range m.stores {
+		if strings.ToLower(s.Host()) == host {
+			return s, nil
+		}
+	}
+	return domain.Store{}, app.ErrStoreNotFound
+}
+
+// Default returns the store marked as default.
+func (m *InMemory) Default(_ context.Context) (domain.Store, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, s := range m.stores {
+		if s.IsDefault() {
+			return s, nil
+		}
+	}
+	return domain.Store{}, app.ErrNoDefaultStore
+}
+
+// ListAll returns every store ordered by position then name.
+func (m *InMemory) ListAll(_ context.Context) ([]domain.Store, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]domain.Store, 0, len(m.stores))
+	for _, s := range m.stores {
+		out = append(out, s)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Position() != out[j].Position() {
+			return out[i].Position() < out[j].Position()
+		}
+		return out[i].Name() < out[j].Name()
+	})
+	return out, nil
+}
+
+// clearOtherDefaults flips is_default to false on every row except the
+// one with the supplied id. Called by Create/Update inside the same
+// lock as the upsert.
+func (m *InMemory) clearOtherDefaults(keepID string) {
+	for id, s := range m.stores {
+		if id == keepID || !s.IsDefault() {
+			continue
+		}
+		m.stores[id] = domain.RebuildStore(
+			s.ID(), s.Slug(), s.Name(), s.Currency(),
+			s.Host(), false, s.Position(),
+		)
+	}
+}
+
+// errAlreadyExists is the in-memory analogue of a postgres unique
+// violation on the id PK. It is package-scoped because the adapter is
+// only used by tests — the production wiring goes through the postgres
+// adapter, which surfaces the violation as a wrapped error.
+var errAlreadyExists = &alreadyExistsError{}
+
+type alreadyExistsError struct{}
+
+func (*alreadyExistsError) Error() string { return "store already exists" }

--- a/backend/store/adapter/postgres.go
+++ b/backend/store/adapter/postgres.go
@@ -1,0 +1,206 @@
+package adapter
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/bkielbasa/go-ecommerce/backend/store/app"
+	"github.com/bkielbasa/go-ecommerce/backend/store/domain"
+)
+
+// Postgres is the production Storage adapter for the store bounded
+// context. It is a thin shell over *sql.DB; parameterised SQL is used
+// everywhere.
+type Postgres struct {
+	db *sql.DB
+}
+
+// NewPostgres binds the adapter to the shared *sql.DB.
+func NewPostgres(db *sql.DB) *Postgres {
+	return &Postgres{db: db}
+}
+
+// Create inserts a new store row. When the caller marks the new row
+// default, every other row's is_default flag is cleared first inside
+// the same transaction. The partial unique index on (is_default) WHERE
+// is_default is the safety net that prevents two concurrent inserts
+// from both claiming the default flag.
+func (p *Postgres) Create(ctx context.Context, s domain.Store) error {
+	return p.inTx(ctx, func(tx *sql.Tx) error {
+		if s.IsDefault() {
+			if err := clearOtherDefaults(ctx, tx, s.ID()); err != nil {
+				return err
+			}
+		}
+		_, err := tx.ExecContext(ctx, `
+			INSERT INTO store (id, slug, name, currency, host, is_default, position)
+			VALUES ($1, $2, $3, $4, $5, $6, $7)
+		`, s.ID(), s.Slug(), s.Name(), s.Currency(), s.Host(), s.IsDefault(), s.Position())
+		if err != nil {
+			return fmt.Errorf("insert store: %w", err)
+		}
+		return nil
+	})
+}
+
+// Update replaces every field on a store row. When the caller marks
+// the row default, every other row is cleared inside the same
+// transaction.
+func (p *Postgres) Update(ctx context.Context, s domain.Store) error {
+	return p.inTx(ctx, func(tx *sql.Tx) error {
+		if s.IsDefault() {
+			if err := clearOtherDefaults(ctx, tx, s.ID()); err != nil {
+				return err
+			}
+		}
+		res, err := tx.ExecContext(ctx, `
+			UPDATE store
+			SET slug = $2,
+			    name = $3,
+			    currency = $4,
+			    host = $5,
+			    is_default = $6,
+			    position = $7
+			WHERE id = $1
+		`, s.ID(), s.Slug(), s.Name(), s.Currency(), s.Host(), s.IsDefault(), s.Position())
+		if err != nil {
+			return fmt.Errorf("update store: %w", err)
+		}
+		n, _ := res.RowsAffected()
+		if n == 0 {
+			return app.ErrStoreNotFound
+		}
+		return nil
+	})
+}
+
+// Delete drops the store row by id.
+func (p *Postgres) Delete(ctx context.Context, id string) error {
+	res, err := p.db.ExecContext(ctx, `DELETE FROM store WHERE id = $1`, id)
+	if err != nil {
+		return fmt.Errorf("delete store: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return app.ErrStoreNotFound
+	}
+	return nil
+}
+
+// Find loads a single store by id.
+func (p *Postgres) Find(ctx context.Context, id string) (domain.Store, error) {
+	row := p.db.QueryRowContext(ctx, `
+		SELECT id, slug, name, currency, host, is_default, position
+		FROM store WHERE id = $1
+	`, id)
+	return scanStore(row)
+}
+
+// FindByHost loads the store whose host column matches (case-
+// insensitive). The host_idx index makes the lookup cheap.
+func (p *Postgres) FindByHost(ctx context.Context, host string) (domain.Store, error) {
+	row := p.db.QueryRowContext(ctx, `
+		SELECT id, slug, name, currency, host, is_default, position
+		FROM store WHERE lower(host) = lower($1)
+	`, strings.TrimSpace(host))
+	return scanStore(row)
+}
+
+// Default returns the store marked as default. The partial unique
+// index guarantees at most one row matches.
+func (p *Postgres) Default(ctx context.Context) (domain.Store, error) {
+	row := p.db.QueryRowContext(ctx, `
+		SELECT id, slug, name, currency, host, is_default, position
+		FROM store WHERE is_default = true
+	`)
+	s, err := scanStore(row)
+	if errors.Is(err, app.ErrStoreNotFound) {
+		return domain.Store{}, app.ErrNoDefaultStore
+	}
+	return s, err
+}
+
+// ListAll returns every store ordered by position then name.
+func (p *Postgres) ListAll(ctx context.Context) ([]domain.Store, error) {
+	rows, err := p.db.QueryContext(ctx, `
+		SELECT id, slug, name, currency, host, is_default, position
+		FROM store
+		ORDER BY position ASC, name ASC
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("list store: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []domain.Store
+	for rows.Next() {
+		var id, slug, name, currency, host string
+		var isDefault bool
+		var position int
+		if err := rows.Scan(&id, &slug, &name, &currency, &host, &isDefault, &position); err != nil {
+			return nil, fmt.Errorf("scan store: %w", err)
+		}
+		out = append(out, domain.RebuildStore(id, slug, name, currency, host, isDefault, position))
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("rows: %w", err)
+	}
+	return out, nil
+}
+
+// scanStore reads a single row produced by every "SELECT id, slug,
+// name, currency, host, is_default, position FROM store" query. A
+// missing row maps to app.ErrStoreNotFound so callers can branch.
+func scanStore(row *sql.Row) (domain.Store, error) {
+	var id, slug, name, currency, host string
+	var isDefault bool
+	var position int
+	err := row.Scan(&id, &slug, &name, &currency, &host, &isDefault, &position)
+	if errors.Is(err, sql.ErrNoRows) {
+		return domain.Store{}, app.ErrStoreNotFound
+	}
+	if err != nil {
+		return domain.Store{}, fmt.Errorf("select store: %w", err)
+	}
+	return domain.RebuildStore(id, slug, name, currency, host, isDefault, position), nil
+}
+
+// clearOtherDefaults flips is_default to false on every row except the
+// one with the supplied id. Called inside the same transaction as the
+// upsert so a concurrent writer cannot leave the table with two
+// defaults (the partial unique index would reject one of them anyway,
+// but doing the clear up front is what makes the happy path work).
+func clearOtherDefaults(ctx context.Context, tx *sql.Tx, keepID string) error {
+	_, err := tx.ExecContext(ctx, `UPDATE store SET is_default = false WHERE id <> $1`, keepID)
+	if err != nil {
+		return fmt.Errorf("clear other defaults: %w", err)
+	}
+	return nil
+}
+
+// inTx is the standard run-in-a-transaction helper. The callback runs
+// inside a database transaction that is committed on return-nil and
+// rolled back otherwise.
+func (p *Postgres) inTx(ctx context.Context, fn func(*sql.Tx) error) error {
+	tx, err := p.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+	if err := fn(tx); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit: %w", err)
+	}
+	committed = true
+	return nil
+}

--- a/backend/store/app/service.go
+++ b/backend/store/app/service.go
@@ -1,0 +1,116 @@
+// Package app is the application layer for the store bounded context.
+// It orchestrates the Storage port with the domain value object to power
+// per-request store resolution (ResolveByHost) and the admin-side CRUD
+// flows. The resolver intentionally falls back to the configured
+// default store when the request Host does not match a known row —
+// that keeps `localhost:8080` (the dev affordance) always pointing at
+// *some* store, regardless of the seeded host values.
+package app
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"github.com/bkielbasa/go-ecommerce/backend/store/domain"
+)
+
+var (
+	// ErrStoreNotFound is returned by Storage when the requested store
+	// cannot be located (by id or by host). The service uses it to
+	// branch into the default-store fallback path.
+	ErrStoreNotFound = errors.New("store not found")
+	// ErrNoDefaultStore is returned when no store is marked as default.
+	// In a healthy install this is impossible — the migration's partial
+	// unique index plus the seed entries guarantee exactly one default
+	// — but the error is surfaced for completeness and to make tests
+	// of the empty-database edge case explicit.
+	ErrNoDefaultStore = errors.New("no default store configured")
+)
+
+// Storage is the persistence port. Implementations live in
+// store/adapter (postgres for production, in-memory for tests). The
+// adapter is responsible for enforcing the "exactly one default"
+// invariant — the partial unique index on (is_default) WHERE is_default
+// is the safety net, and Create / Update should clear the flag on every
+// other row when the caller marks one default.
+type Storage interface {
+	Create(ctx context.Context, s domain.Store) error
+	Update(ctx context.Context, s domain.Store) error
+	Delete(ctx context.Context, id string) error
+	Find(ctx context.Context, id string) (domain.Store, error)
+	FindByHost(ctx context.Context, host string) (domain.Store, error)
+	Default(ctx context.Context) (domain.Store, error)
+	ListAll(ctx context.Context) ([]domain.Store, error)
+}
+
+// Service is the application facade for the store context. It is a
+// pass-through over Storage for CRUD plus the ResolveByHost helper
+// that the layout's request middleware calls.
+type Service struct {
+	storage Storage
+}
+
+// NewService binds the application facade to a Storage port.
+func NewService(storage Storage) *Service {
+	return &Service{storage: storage}
+}
+
+// Create persists a new store. Validation lives on domain.NewStore;
+// the service simply routes the call.
+func (s *Service) Create(ctx context.Context, store domain.Store) error {
+	return s.storage.Create(ctx, store)
+}
+
+// Update replaces every field on an existing store.
+func (s *Service) Update(ctx context.Context, store domain.Store) error {
+	return s.storage.Update(ctx, store)
+}
+
+// Delete drops the store row.
+func (s *Service) Delete(ctx context.Context, id string) error {
+	return s.storage.Delete(ctx, id)
+}
+
+// Find loads a single store by id.
+func (s *Service) Find(ctx context.Context, id string) (domain.Store, error) {
+	return s.storage.Find(ctx, id)
+}
+
+// ListAll returns every store ordered by position then name. The set is
+// small (one row per storefront facade) so the call is cheap on every
+// render — the layout uses it to power the footer switcher.
+func (s *Service) ListAll(ctx context.Context) ([]domain.Store, error) {
+	return s.storage.ListAll(ctx)
+}
+
+// Default returns the store marked as default, or ErrNoDefaultStore
+// when none exists.
+func (s *Service) Default(ctx context.Context) (domain.Store, error) {
+	return s.storage.Default(ctx)
+}
+
+// ResolveByHost returns the store bound to the request Host header. The
+// match is by exact host string; case is normalised to lowercase so
+// "EU.localhost:8080" and "eu.localhost:8080" map to the same row.
+//
+// When no store matches (typically dev hitting `localhost:8080`
+// without the configured host alias, or a misconfigured DNS entry in
+// production), the resolver falls back to the configured default
+// store. That fallback is the user-facing affordance that keeps the
+// storefront rendering when the operator's host config has drifted.
+// Only when *also* no default exists does ResolveByHost surface an
+// error — callers should treat that as fatal/unrecoverable.
+func (s *Service) ResolveByHost(ctx context.Context, host string) (domain.Store, error) {
+	host = strings.ToLower(strings.TrimSpace(host))
+	if host != "" {
+		st, err := s.storage.FindByHost(ctx, host)
+		if err == nil {
+			return st, nil
+		}
+		if !errors.Is(err, ErrStoreNotFound) {
+			return domain.Store{}, err
+		}
+	}
+	return s.storage.Default(ctx)
+}

--- a/backend/store/app/service_test.go
+++ b/backend/store/app/service_test.go
@@ -1,0 +1,116 @@
+package app_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/bkielbasa/go-ecommerce/backend/store/adapter"
+	"github.com/bkielbasa/go-ecommerce/backend/store/app"
+	"github.com/bkielbasa/go-ecommerce/backend/store/domain"
+)
+
+func mustStore(t *testing.T, id, slug, name, currency, host string, isDefault bool, position int) domain.Store {
+	t.Helper()
+	s, err := domain.NewStore(id, slug, name, currency, host, isDefault, position)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	return s
+}
+
+func seededService(t *testing.T) *app.Service {
+	t.Helper()
+	storage := adapter.NewInMemory()
+	srv := app.NewService(storage)
+	ctx := context.Background()
+	if err := storage.Create(ctx, mustStore(t, "us", "us", "GoCommerce US", "USD", "localhost:8080", true, 1)); err != nil {
+		t.Fatalf("seed us: %v", err)
+	}
+	if err := storage.Create(ctx, mustStore(t, "eu", "eu", "GoCommerce EU", "EUR", "eu.localhost:8080", false, 2)); err != nil {
+		t.Fatalf("seed eu: %v", err)
+	}
+	return srv
+}
+
+func TestResolveByHost_MatchesByHost(t *testing.T) {
+	srv := seededService(t)
+	s, err := srv.ResolveByHost(context.Background(), "eu.localhost:8080")
+	if err != nil {
+		t.Fatalf("ResolveByHost: %v", err)
+	}
+	if s.ID() != "eu" {
+		t.Errorf("resolved id = %q, want eu", s.ID())
+	}
+	if s.Currency() != "EUR" {
+		t.Errorf("resolved currency = %q, want EUR", s.Currency())
+	}
+}
+
+func TestResolveByHost_IsCaseInsensitive(t *testing.T) {
+	srv := seededService(t)
+	s, err := srv.ResolveByHost(context.Background(), "EU.LocalHost:8080")
+	if err != nil {
+		t.Fatalf("ResolveByHost: %v", err)
+	}
+	if s.ID() != "eu" {
+		t.Errorf("resolved id = %q, want eu", s.ID())
+	}
+}
+
+func TestResolveByHost_UnknownHostFallsBackToDefault(t *testing.T) {
+	srv := seededService(t)
+	s, err := srv.ResolveByHost(context.Background(), "no-such-host:8080")
+	if err != nil {
+		t.Fatalf("ResolveByHost: %v", err)
+	}
+	if s.ID() != "us" {
+		t.Errorf("fallback id = %q, want us (the seeded default)", s.ID())
+	}
+}
+
+func TestResolveByHost_ErrorsWhenNoDefault(t *testing.T) {
+	storage := adapter.NewInMemory()
+	srv := app.NewService(storage)
+	// Seed a single store that is NOT the default — exposes the
+	// "no default" edge case the production install never hits (the
+	// migration + seeds guarantee one default exists).
+	if err := storage.Create(context.Background(), mustStore(t, "uk", "uk", "GoCommerce UK", "GBP", "uk.localhost:8080", false, 3)); err != nil {
+		t.Fatalf("seed uk: %v", err)
+	}
+	_, err := srv.ResolveByHost(context.Background(), "no-such-host:8080")
+	if !errors.Is(err, app.ErrNoDefaultStore) {
+		t.Errorf("err = %v, want ErrNoDefaultStore", err)
+	}
+}
+
+func TestService_CreateUpdateDefaultUnique(t *testing.T) {
+	storage := adapter.NewInMemory()
+	srv := app.NewService(storage)
+	ctx := context.Background()
+	if err := srv.Create(ctx, mustStore(t, "us", "us", "GoCommerce US", "USD", "localhost:8080", true, 1)); err != nil {
+		t.Fatalf("create us: %v", err)
+	}
+	if err := srv.Create(ctx, mustStore(t, "eu", "eu", "GoCommerce EU", "EUR", "eu.localhost:8080", true, 2)); err != nil {
+		t.Fatalf("create eu: %v", err)
+	}
+	// Both inserted as default-true, but the second create must have
+	// cleared the first one's default flag.
+	def, err := srv.Default(ctx)
+	if err != nil {
+		t.Fatalf("Default: %v", err)
+	}
+	if def.ID() != "eu" {
+		t.Errorf("default id = %q, want eu (latest write wins)", def.ID())
+	}
+	all, _ := srv.ListAll(ctx)
+	defaults := 0
+	for _, s := range all {
+		if s.IsDefault() {
+			defaults++
+		}
+	}
+	if defaults != 1 {
+		t.Errorf("default count = %d, want exactly 1", defaults)
+	}
+}

--- a/backend/store/bounded_context.go
+++ b/backend/store/bounded_context.go
@@ -1,0 +1,28 @@
+// Package store is the composition root for the store bounded context.
+// A Store is a request-bound storefront facade: each request is mapped
+// to exactly one store by inspecting its Host header, and the store's
+// configured currency drives the display layer (the `money` template
+// helper). The context owns the `store` table introduced by migration
+// 000029_stores; every other context is currency-agnostic and reads
+// the active store off the request context.
+package store
+
+import (
+	"database/sql"
+
+	"github.com/bkielbasa/go-ecommerce/backend/internal/application"
+	"github.com/bkielbasa/go-ecommerce/backend/store/adapter"
+	"github.com/bkielbasa/go-ecommerce/backend/store/app"
+)
+
+// New wires the production storage adapter and returns both the
+// application.BoundedContext envelope and the concrete *app.Service so
+// the layout package can declare a narrow interface against its public
+// methods without leaking the storage type.
+func New(db *sql.DB) (application.BoundedContext, *app.Service) {
+	storage := adapter.NewPostgres(db)
+	srv := app.NewService(storage)
+	return &boundedContext{}, srv
+}
+
+type boundedContext struct{}

--- a/backend/store/domain/store.go
+++ b/backend/store/domain/store.go
@@ -1,0 +1,128 @@
+// Package domain holds the store bounded context's value objects. A Store
+// is an immutable description of one storefront facade — a slug, a name,
+// the display currency the storefront prices things in, and the request
+// Host header it is reached at. The active store is resolved per request
+// (see the layout package's storeMiddleware) and threaded onto the request
+// context so every render reads the same one.
+package domain
+
+import (
+	"errors"
+	"regexp"
+	"strings"
+)
+
+// ErrInvalidStore is returned by NewStore when the supplied parameters
+// fail validation (empty fields, bad slug, malformed currency code, etc.).
+var ErrInvalidStore = errors.New("invalid store")
+
+// slugPattern enforces the canonical "lowercase letters / digits /
+// hyphens" shape so a slug is safe to embed in URLs and DOM ids.
+var slugPattern = regexp.MustCompile(`^[a-z0-9-]+$`)
+
+// Store is the value object describing a single storefront facade. The
+// fields are intentionally unexported — every read goes through a getter
+// so the value object stays immutable from the outside. Stores are
+// constructed via NewStore (validates) or RebuildStore (hydration from
+// storage).
+type Store struct {
+	id        string
+	slug      string
+	name      string
+	currency  string
+	host      string
+	isDefault bool
+	position  int
+}
+
+// NewStore validates and constructs a fresh Store. The id is supplied by
+// the caller (operators want a stable, human-meaningful identifier such
+// as "us" or "eu" — the slug doubles as a primary key in the seeds).
+func NewStore(id, slug, name, currency, host string, isDefault bool, position int) (Store, error) {
+	id = strings.TrimSpace(id)
+	slug = strings.TrimSpace(slug)
+	name = strings.TrimSpace(name)
+	currency = strings.ToUpper(strings.TrimSpace(currency))
+	host = strings.TrimSpace(host)
+
+	if id == "" {
+		return Store{}, ErrInvalidStore
+	}
+	if !slugPattern.MatchString(slug) {
+		return Store{}, ErrInvalidStore
+	}
+	if name == "" {
+		return Store{}, ErrInvalidStore
+	}
+	if len(currency) != 3 {
+		return Store{}, ErrInvalidStore
+	}
+	for _, r := range currency {
+		if r < 'A' || r > 'Z' {
+			return Store{}, ErrInvalidStore
+		}
+	}
+	if host == "" {
+		return Store{}, ErrInvalidStore
+	}
+	if position < 0 {
+		return Store{}, ErrInvalidStore
+	}
+	return Store{
+		id:        id,
+		slug:      slug,
+		name:      name,
+		currency:  currency,
+		host:      host,
+		isDefault: isDefault,
+		position:  position,
+	}, nil
+}
+
+// RebuildStore is the hydration constructor used by the adapter layer.
+// It bypasses validation so adapters can reconstruct exactly what the
+// database returned (including legacy rows that pre-date a tightened
+// invariant).
+func RebuildStore(id, slug, name, currency, host string, isDefault bool, position int) Store {
+	return Store{
+		id:        id,
+		slug:      slug,
+		name:      name,
+		currency:  currency,
+		host:      host,
+		isDefault: isDefault,
+		position:  position,
+	}
+}
+
+// ID returns the store's stable identifier.
+func (s Store) ID() string { return s.id }
+
+// Slug returns the URL-safe slug.
+func (s Store) Slug() string { return s.slug }
+
+// Name returns the human-facing display name.
+func (s Store) Name() string { return s.name }
+
+// Currency returns the 3-letter ISO display currency the storefront
+// prices things in.
+func (s Store) Currency() string { return s.currency }
+
+// Host returns the request Host header this store binds to
+// (e.g. "localhost:8080" or "eu.localhost:8080").
+func (s Store) Host() string { return s.host }
+
+// IsDefault reports whether this is the fallback store used by
+// Service.ResolveByHost when the request Host matches no other row.
+// Exactly one store is the default; the postgres adapter enforces it
+// with a partial unique index.
+func (s Store) IsDefault() bool { return s.isDefault }
+
+// Position is the operator-supplied ordering hint. Lower comes first in
+// the footer store switcher / admin list.
+func (s Store) Position() int { return s.position }
+
+// IsZero reports whether the receiver is the zero-value Store. Used by
+// the layout's storeMiddleware fallback so the renderer can tell that no
+// store was resolvable for the request.
+func (s Store) IsZero() bool { return s.id == "" }

--- a/backend/store/domain/store_test.go
+++ b/backend/store/domain/store_test.go
@@ -1,0 +1,69 @@
+package domain_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/bkielbasa/go-ecommerce/backend/store/domain"
+)
+
+func TestNewStore_Valid(t *testing.T) {
+	s, err := domain.NewStore("us", "us", "GoCommerce US", "USD", "localhost:8080", true, 1)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	if s.ID() != "us" || s.Slug() != "us" || s.Name() != "GoCommerce US" {
+		t.Errorf("unexpected store fields: %#v", s)
+	}
+	if s.Currency() != "USD" {
+		t.Errorf("currency = %q, want USD", s.Currency())
+	}
+	if !s.IsDefault() {
+		t.Errorf("IsDefault = false, want true")
+	}
+}
+
+func TestNewStore_NormalisesCurrencyCase(t *testing.T) {
+	s, err := domain.NewStore("eu", "eu", "GoCommerce EU", "eur", "eu.localhost:8080", false, 2)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	if s.Currency() != "EUR" {
+		t.Errorf("currency = %q, want EUR (uppercased)", s.Currency())
+	}
+}
+
+func TestNewStore_RejectsInvalid(t *testing.T) {
+	cases := []struct {
+		name                                         string
+		id, slug, sname, currency, host              string
+		position                                     int
+	}{
+		{name: "empty id", id: "", slug: "us", sname: "n", currency: "USD", host: "h", position: 0},
+		{name: "bad slug uppercase", id: "x", slug: "US", sname: "n", currency: "USD", host: "h", position: 0},
+		{name: "bad slug underscore", id: "x", slug: "us_uk", sname: "n", currency: "USD", host: "h", position: 0},
+		{name: "empty name", id: "x", slug: "us", sname: "", currency: "USD", host: "h", position: 0},
+		{name: "currency too short", id: "x", slug: "us", sname: "n", currency: "US", host: "h", position: 0},
+		{name: "currency too long", id: "x", slug: "us", sname: "n", currency: "USDX", host: "h", position: 0},
+		{name: "currency non-letter", id: "x", slug: "us", sname: "n", currency: "US1", host: "h", position: 0},
+		{name: "empty host", id: "x", slug: "us", sname: "n", currency: "USD", host: "", position: 0},
+		{name: "negative position", id: "x", slug: "us", sname: "n", currency: "USD", host: "h", position: -1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := domain.NewStore(tc.id, tc.slug, tc.sname, tc.currency, tc.host, false, tc.position)
+			if !errors.Is(err, domain.ErrInvalidStore) {
+				t.Errorf("err = %v, want ErrInvalidStore", err)
+			}
+		})
+	}
+}
+
+func TestRebuildStore_BypassesValidation(t *testing.T) {
+	// Hydration must succeed even with shapes NewStore would reject so
+	// legacy rows keep loading.
+	s := domain.RebuildStore("x", "US", "name", "usd", "h", true, 0)
+	if s.IsZero() {
+		t.Errorf("rebuilt store should not be zero")
+	}
+}

--- a/backend/store/storectx.go
+++ b/backend/store/storectx.go
@@ -1,0 +1,30 @@
+package store
+
+import (
+	"context"
+
+	"github.com/bkielbasa/go-ecommerce/backend/store/domain"
+)
+
+// storeKey is the unique context key value under which the active
+// store for the current request is stored. Using a struct{} type
+// (rather than a string) keeps the key collision-free with any other
+// package that might also use context.WithValue.
+type storeKey struct{}
+
+// With returns a derived context that carries the supplied store. The
+// layout's request middleware calls this once per request after
+// resolving the store from the Host header; downstream handlers read
+// the value back with From.
+func With(ctx context.Context, s domain.Store) context.Context {
+	return context.WithValue(ctx, storeKey{}, s)
+}
+
+// From returns the store the middleware bound to the context, plus a
+// boolean indicating whether the binding existed. Handlers that just
+// need the currency typically wrap this in a small helper that
+// substitutes the default currency when the binding is absent.
+func From(ctx context.Context) (domain.Store, bool) {
+	s, ok := ctx.Value(storeKey{}).(domain.Store)
+	return s, ok
+}

--- a/migrations/000029_stores.down.sql
+++ b/migrations/000029_stores.down.sql
@@ -1,0 +1,7 @@
+BEGIN;
+
+DROP INDEX IF EXISTS public.store_host_idx;
+DROP INDEX IF EXISTS public.store_one_default_idx;
+DROP TABLE IF EXISTS public.store;
+
+COMMIT;

--- a/migrations/000029_stores.up.sql
+++ b/migrations/000029_stores.up.sql
@@ -1,0 +1,32 @@
+BEGIN;
+
+-- store is the catalogue of storefront facades. The active store for any
+-- given request is decided by matching the request Host header against
+-- this table's `host` column; the store's `currency` then drives the
+-- display layer. Exactly one row carries is_default=true — the partial
+-- unique index below is the safety net, and the application's Create /
+-- Update flow clears the flag on every other row when a caller marks
+-- one default. The id is a stable, human-meaningful identifier supplied
+-- by the operator (slug-like) so seeds/migrations can reference it.
+CREATE TABLE public.store (
+    id text PRIMARY KEY,
+    slug text NOT NULL UNIQUE,
+    name text NOT NULL,
+    currency text NOT NULL,
+    host text NOT NULL,
+    is_default boolean NOT NULL DEFAULT false,
+    position int NOT NULL DEFAULT 0
+);
+
+-- Exactly one default store across the table. The partial index makes
+-- the constraint cheap (only one row participates) and lets the
+-- application's "clear-other-defaults inside a tx" pattern succeed on
+-- the happy path while still rejecting concurrent writers.
+CREATE UNIQUE INDEX store_one_default_idx ON public.store ((is_default)) WHERE is_default;
+
+-- store_host_idx supports the per-request "store by Host header" lookup.
+-- The set is small (one row per facade) but the lookup runs on every
+-- request, so the index keeps the cost trivial.
+CREATE INDEX store_host_idx ON public.store(host);
+
+COMMIT;


### PR DESCRIPTION
Stores become first-class. Each store carries its own currency, and the active store for a request is resolved from the Host header (with a default store as the fallback). The customer-facing currency picker is removed — currency is a property of the store the visitor lands on, not a preference.

- New `store/` bounded context (domain/app/adapter/bounded_context) with a Store value object and a Service exposing ResolveByHost + CRUD.
- Migration 000029 creates the store table with a partial unique index enforcing exactly one default. Seed adds `us` (USD, default, `localhost:8080`) and `eu` (EUR, `eu.localhost:8080`) idempotently.
- New `layout.StoreMiddleware` binds the resolved store onto the request context before CSRF/handlers run; renderTemplate reads it to drive Currency and ActiveStore template data.
- Removed: `currentCurrency` (session-based), `HandleSetCurrency`, `POST /currency` route, the `<form class="currency-switch">` in layout.gohtml.
- Added: footer "stores" link → `/stores` page listing each store with a same-path link to its host. Admin CRUD at `/admin/stores`.

## Test plan
- [x] build / build -tags integration / vet / tests / lint green
- [x] docker: same path, two hosts, two currencies: `Host: localhost:8080` → `54.00 USD` etc., `Host: eu.localhost:8080` → `49.68 EUR` (FX 0.92). Old picker absent. `POST /currency` → 404. `/stores` lists both. `/admin/stores` reachable.