### PR TITLE
feat(reviews): moderation flow (pending/approved/rejected)

### DIFF
--- a/backend/layout/bounded_context.go
+++ b/backend/layout/bounded_context.go
@@ -118,14 +118,19 @@ type promoService interface {
 
 // reviewsService is the narrow seam the layout package needs from the
 // reviews bounded context: list / aggregate for the product page, submit /
-// has-reviewed for the customer-facing review form, and delete for the
-// admin moderation page. Mirrors *reviews/app.Service.
+// has-reviewed for the customer-facing review form, and the moderation
+// surface (approve / reject / delete / list pending / list all) for the
+// admin reviews page. Mirrors *reviews/app.Service.
 type reviewsService interface {
 	ListForProduct(ctx context.Context, productID string, limit int) ([]reviewsDomain.Review, error)
 	AggregateForProducts(ctx context.Context, productIDs []string) (map[string]reviewsDomain.Aggregate, error)
 	HasReviewed(ctx context.Context, productID, customerID string) (bool, error)
 	Submit(ctx context.Context, productID, customerID, body string, rating int) error
 	Delete(ctx context.Context, id string) error
+	Approve(ctx context.Context, id string) error
+	Reject(ctx context.Context, id string) error
+	ListPending(ctx context.Context, limit int) ([]reviewsDomain.Review, error)
+	ListAll(ctx context.Context, limit int) ([]reviewsDomain.Review, error)
 }
 
 // wishlistService is the narrow seam the layout package needs from the

--- a/backend/layout/http.go
+++ b/backend/layout/http.go
@@ -232,7 +232,14 @@ func (m boundedContext) MuxRegister(r *mux.Router) {
 
 	r.HandleFunc("/admin/inventory", observability.HTTPWrap(m.handler.AdminInventory, m.logger)).Methods("GET")
 
+	// Reviews admin: list + moderation actions. The approve/reject paths
+	// follow the same /{id}/<verb> shape as delete so the existing
+	// "register specific sub-paths before any catch-all" convention is
+	// preserved (none of these conflict — they're sibling verbs — but
+	// keeping them together makes the moderation surface easy to grep).
 	r.HandleFunc("/admin/reviews", observability.HTTPWrap(m.handler.AdminReviews, m.logger)).Methods("GET")
+	r.HandleFunc("/admin/reviews/{id}/approve", observability.HTTPWrap(m.handler.AdminApproveReview, m.logger)).Methods("POST")
+	r.HandleFunc("/admin/reviews/{id}/reject", observability.HTTPWrap(m.handler.AdminRejectReview, m.logger)).Methods("POST")
 	r.HandleFunc("/admin/reviews/{id}/delete", observability.HTTPWrap(m.handler.AdminDeleteReview, m.logger)).Methods("POST")
 
 	// Promo codes admin: list + inline create on /admin/promo-codes; the

--- a/backend/layout/http_reviews.go
+++ b/backend/layout/http_reviews.go
@@ -1,6 +1,7 @@
 package layout
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"strconv"
@@ -46,7 +47,12 @@ func (handler httpHandler) SubmitReview(w http.ResponseWriter, r *http.Request) 
 		// 5" etc.).
 		handler.flash(w, r, err.Error(), "error")
 	default:
-		handler.flash(w, r, "Thanks for your review!", "info")
+		// Reviews now go through a moderation queue; the storefront list
+		// is filtered to approved-only, so a successful Submit is invisible
+		// to the customer until an admin approves it. The flash explains
+		// the new flow so the silent product-page redirect doesn't feel
+		// broken.
+		handler.flash(w, r, "Thanks — your review is pending moderation and will appear once approved.", "info")
 	}
 	http.Redirect(w, r, "/product/"+productID+"#reviews", http.StatusSeeOther)
 }
@@ -60,41 +66,127 @@ type adminReviewRow struct {
 	ProductName string
 }
 
-// AdminReviews renders the moderation table. Newest first across all
-// products; each row gets a small POST form that soft-deletes the review.
+// AdminReviews renders the moderation table. The default tab is "pending"
+// (the queue of submissions awaiting an admin decision); the "all" tab
+// shows every non-deleted review regardless of status. Each row gets per-
+// status action buttons (approve / reject / delete) so an admin can make
+// the next decision without leaving the page.
 func (handler httpHandler) AdminReviews(w http.ResponseWriter, r *http.Request) {
 	email, ok := handler.requireAdmin(w, r)
 	if !ok {
 		return
 	}
-	// We do not have a global ListAll on the reviews service — that's an
-	// admin-only need and the rest of the app only reads per-product. To
-	// keep the service surface small we list per-product across the
-	// catalogue. For small/medium stores this is fine; if it became hot
-	// we'd add a dedicated query.
-	products, err := handler.catalogSrv.AllProducts(r.Context())
+
+	// Default tab is "pending" — the moderation queue. "all" shows every
+	// review (any status) so an admin can also reverse an earlier decision.
+	statusParam := strings.TrimSpace(r.URL.Query().Get("status"))
+	if statusParam != "all" {
+		statusParam = "pending"
+	}
+
+	var (
+		reviews []reviewsDomain.Review
+		err     error
+	)
+	if statusParam == "all" {
+		reviews, err = handler.reviewsSrv.ListAll(r.Context(), 200)
+	} else {
+		reviews, err = handler.reviewsSrv.ListPending(r.Context(), 200)
+	}
 	if err != nil {
 		https.InternalError(w, "internal-error", err.Error())
 		return
 	}
-	var rows []adminReviewRow
-	for _, p := range products {
-		list, err := handler.reviewsSrv.ListForProduct(r.Context(), string(p.ID()), 100)
-		if err != nil {
-			handler.logger.WithError(err).Warn("cannot list reviews for product")
-			continue
-		}
-		for _, rv := range list {
-			rows = append(rows, adminReviewRow{Review: rv, ProductID: string(p.ID()), ProductName: p.Name()})
-		}
+
+	// The pending count drives the tab label even on the "all" tab so the
+	// admin sees the queue size at a glance.
+	pendingCount, err := handler.pendingReviewCount(r.Context())
+	if err != nil {
+		handler.logger.WithError(err).Warn("cannot count pending reviews")
 	}
-	// Newest first across products.
-	sortReviewRowsNewestFirst(rows)
+
+	// Build the row decoration (product id + name) by resolving each
+	// review's product. We cache lookups so a product with many reviews
+	// only hits the catalogue once.
+	rows := handler.decorateReviewRows(r, reviews)
+
 	handler.renderAdminTemplate(w, r, "admin/reviews", map[string]any{
-		"Active": "reviews",
-		"Email":  email,
-		"Rows":   rows,
+		"Active":       "reviews",
+		"Email":        email,
+		"Rows":         rows,
+		"ActiveTab":    statusParam,
+		"PendingCount": pendingCount,
 	})
+}
+
+// pendingReviewCount returns the total pending-review backlog so the tab
+// label can show "Pending (N)". A non-blocking helper — callers log and
+// continue when this fails.
+func (handler httpHandler) pendingReviewCount(ctx context.Context) (int, error) {
+	pending, err := handler.reviewsSrv.ListPending(ctx, 1000)
+	if err != nil {
+		return 0, err
+	}
+	return len(pending), nil
+}
+
+// decorateReviewRows attaches the product id + display name to each review.
+// We resolve each unique product once (the catalogue lookup is cheap but
+// repeating it per review row would be wasteful when a product accumulates
+// many reviews).
+func (handler httpHandler) decorateReviewRows(r *http.Request, reviews []reviewsDomain.Review) []adminReviewRow {
+	type productInfo struct {
+		name string
+		ok   bool
+	}
+	cache := map[string]productInfo{}
+	rows := make([]adminReviewRow, 0, len(reviews))
+	for _, rv := range reviews {
+		pid := rv.ProductID()
+		info, seen := cache[pid]
+		if !seen {
+			p, err := handler.catalogSrv.Find(r.Context(), pid)
+			if err != nil {
+				handler.logger.WithError(err).Warn("cannot find product for review")
+				info = productInfo{name: pid, ok: false}
+			} else {
+				info = productInfo{name: p.Name(), ok: true}
+			}
+			cache[pid] = info
+		}
+		rows = append(rows, adminReviewRow{Review: rv, ProductID: pid, ProductName: info.name})
+	}
+	return rows
+}
+
+// AdminApproveReview flips a review to approved status and bounces back to
+// the moderation page (preserving the active tab via ?status=).
+func (handler httpHandler) AdminApproveReview(w http.ResponseWriter, r *http.Request) {
+	if _, ok := handler.requireAdmin(w, r); !ok {
+		return
+	}
+	id := mux.Vars(r)["id"]
+	if err := handler.reviewsSrv.Approve(r.Context(), id); err != nil {
+		https.InternalError(w, "internal-error", err.Error())
+		return
+	}
+	handler.flash(w, r, "Review approved.", "info")
+	http.Redirect(w, r, adminReviewsRedirect(r), http.StatusSeeOther)
+}
+
+// AdminRejectReview flips a review to rejected status and bounces back to
+// the moderation page (preserving the active tab via ?status=).
+func (handler httpHandler) AdminRejectReview(w http.ResponseWriter, r *http.Request) {
+	if _, ok := handler.requireAdmin(w, r); !ok {
+		return
+	}
+	id := mux.Vars(r)["id"]
+	if err := handler.reviewsSrv.Reject(r.Context(), id); err != nil {
+		https.InternalError(w, "internal-error", err.Error())
+		return
+	}
+	handler.flash(w, r, "Review rejected.", "info")
+	http.Redirect(w, r, adminReviewsRedirect(r), http.StatusSeeOther)
 }
 
 // AdminDeleteReview soft-deletes a review by id and bounces back to the
@@ -109,21 +201,17 @@ func (handler httpHandler) AdminDeleteReview(w http.ResponseWriter, r *http.Requ
 		return
 	}
 	handler.flash(w, r, "Review removed.", "info")
-	http.Redirect(w, r, "/admin/reviews", http.StatusSeeOther)
+	http.Redirect(w, r, adminReviewsRedirect(r), http.StatusSeeOther)
 }
 
-// sortReviewRowsNewestFirst sorts an admin review table in-place by
-// CreatedAt descending. Pulled out of AdminReviews so the handler reads
-// linearly.
-func sortReviewRowsNewestFirst(rows []adminReviewRow) {
-	// Simple insertion sort over a typically-small list keeps us off
-	// sort.Slice (which would require a captured closure inside the
-	// handler) and stays easy to read.
-	for i := 1; i < len(rows); i++ {
-		j := i
-		for j > 0 && rows[j-1].Review.CreatedAt().Before(rows[j].Review.CreatedAt()) {
-			rows[j-1], rows[j] = rows[j], rows[j-1]
-			j--
-		}
+// adminReviewsRedirect builds the redirect target after a moderation
+// action so the admin stays on the same tab. The status query param is
+// passed in via the form (hidden input) so we honour it even though POST
+// requests don't carry the prior page's query string.
+func adminReviewsRedirect(r *http.Request) string {
+	status := strings.TrimSpace(r.FormValue("status"))
+	if status == "all" {
+		return "/admin/reviews?status=all"
 	}
+	return "/admin/reviews"
 }

--- a/backend/layout/tmpl/admin/reviews.gohtml
+++ b/backend/layout/tmpl/admin/reviews.gohtml
@@ -1,6 +1,17 @@
 {{define "main"}}
   <h2 class="account-card__title">reviews</h2>
 
+  <nav class="tabs" aria-label="review status">
+    <a href="/admin/reviews"
+       class="tabs__link {{if eq .ActiveTab "pending"}}is-active{{end}}">
+      Pending ({{.PendingCount}})
+    </a>
+    <a href="/admin/reviews?status=all"
+       class="tabs__link {{if eq .ActiveTab "all"}}is-active{{end}}">
+      All
+    </a>
+  </nav>
+
   {{if .Rows}}
     <table class="admin-table">
       <thead>
@@ -8,6 +19,7 @@
           <th>product</th>
           <th>customer</th>
           <th>rating</th>
+          <th>status</th>
           <th>created</th>
           <th>body</th>
           <th></th>
@@ -19,11 +31,27 @@
             <td><a href="/product/{{$row.ProductID}}">{{$row.ProductName}}</a></td>
             <td>{{$row.Review.CustomerID}}</td>
             <td>{{$row.Review.Rating}} / 5</td>
+            <td>{{$row.Review.Status}}</td>
             <td>{{$row.Review.CreatedAt.Format "Jan 2, 2006 15:04"}}</td>
             <td>{{$row.Review.Body}}</td>
-            <td>
+            <td class="admin-table__actions">
+              {{if ne (printf "%s" $row.Review.Status) "approved"}}
+                <form method="post" action="/admin/reviews/{{$row.Review.ID}}/approve">
+                  <input type="hidden" name="csrf_token" value="{{$.CSRFToken}}">
+                  <input type="hidden" name="status" value="{{$.ActiveTab}}">
+                  <button type="submit" class="btn btn--primary">approve</button>
+                </form>
+              {{end}}
+              {{if ne (printf "%s" $row.Review.Status) "rejected"}}
+                <form method="post" action="/admin/reviews/{{$row.Review.ID}}/reject">
+                  <input type="hidden" name="csrf_token" value="{{$.CSRFToken}}">
+                  <input type="hidden" name="status" value="{{$.ActiveTab}}">
+                  <button type="submit" class="btn">reject</button>
+                </form>
+              {{end}}
               <form method="post" action="/admin/reviews/{{$row.Review.ID}}/delete">
                 <input type="hidden" name="csrf_token" value="{{$.CSRFToken}}">
+                <input type="hidden" name="status" value="{{$.ActiveTab}}">
                 <button type="submit" class="btn btn--danger">delete</button>
               </form>
             </td>
@@ -32,6 +60,10 @@
       </tbody>
     </table>
   {{else}}
-    <p class="muted">no reviews yet.</p>
+    {{if eq .ActiveTab "pending"}}
+      <p class="muted">no reviews waiting for moderation.</p>
+    {{else}}
+      <p class="muted">no reviews yet.</p>
+    {{end}}
   {{end}}
 {{end}}

--- a/backend/reviews/adapter/inmemory.go
+++ b/backend/reviews/adapter/inmemory.go
@@ -53,20 +53,39 @@ func (m *InMemory) SoftDelete(ctx context.Context, id string) error {
 		if r.ID() != id || r.IsDeleted() {
 			continue
 		}
-		m.reviews[i] = domain.RebuildReview(r.ID(), r.ProductID(), r.CustomerID(), r.Body(), r.Rating(), r.CreatedAt(), &now)
+		m.reviews[i] = domain.RebuildReview(r.ID(), r.ProductID(), r.CustomerID(), r.Body(), r.Rating(), r.CreatedAt(), &now, r.Status())
 		return nil
 	}
 	return nil
 }
 
-// ByProduct returns the active reviews for a product, newest-first, capped
-// at limit.
+// SetStatus flips the moderation state on a non-deleted review. Mirrors
+// the postgres adapter's UPDATE that filters out soft-deleted rows.
+func (m *InMemory) SetStatus(ctx context.Context, id string, status domain.Status) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for i, r := range m.reviews {
+		if r.ID() != id || r.IsDeleted() {
+			continue
+		}
+		m.reviews[i] = domain.RebuildReview(r.ID(), r.ProductID(), r.CustomerID(), r.Body(), r.Rating(), r.CreatedAt(), r.DeletedAt(), status)
+		return nil
+	}
+	return nil
+}
+
+// ByProduct returns the approved reviews for a product, newest-first, capped
+// at limit. Pending/rejected reviews are deliberately excluded — this is
+// the storefront-facing query.
 func (m *InMemory) ByProduct(ctx context.Context, productID string, limit int) ([]domain.Review, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	var out []domain.Review
 	for _, r := range m.reviews {
 		if r.IsDeleted() || r.ProductID() != productID {
+			continue
+		}
+		if !r.IsApproved() {
 			continue
 		}
 		out = append(out, r)
@@ -79,7 +98,8 @@ func (m *InMemory) ByProduct(ctx context.Context, productID string, limit int) (
 }
 
 // AggregateForProducts returns one Aggregate per product id that has at
-// least one active review.
+// least one approved review. Pending/rejected reviews do not contribute
+// to the storefront-visible badge.
 func (m *InMemory) AggregateForProducts(ctx context.Context, productIDs []string) (map[string]domain.Aggregate, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -96,6 +116,9 @@ func (m *InMemory) AggregateForProducts(ctx context.Context, productIDs []string
 	totals := map[string]*acc{}
 	for _, r := range m.reviews {
 		if r.IsDeleted() {
+			continue
+		}
+		if !r.IsApproved() {
 			continue
 		}
 		if !wanted[r.ProductID()] {
@@ -116,8 +139,10 @@ func (m *InMemory) AggregateForProducts(ctx context.Context, productIDs []string
 	return out, nil
 }
 
-// HasReviewed reports whether an active review by this customer exists for
-// the product.
+// HasReviewed reports whether any active (non-deleted) review by this
+// customer exists for the product. Status-agnostic on purpose — mirrors
+// the partial unique index in postgres so the storefront hides the submit
+// form whenever there is any row that would block resubmission.
 func (m *InMemory) HasReviewed(ctx context.Context, productID, customerID string) (bool, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -130,4 +155,45 @@ func (m *InMemory) HasReviewed(ctx context.Context, productID, customerID string
 		}
 	}
 	return false, nil
+}
+
+// ListByStatus returns every non-deleted review at the given status, newest
+// first, capped at limit.
+func (m *InMemory) ListByStatus(ctx context.Context, status domain.Status, limit int) ([]domain.Review, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	var out []domain.Review
+	for _, r := range m.reviews {
+		if r.IsDeleted() {
+			continue
+		}
+		if r.Status() != status {
+			continue
+		}
+		out = append(out, r)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].CreatedAt().After(out[j].CreatedAt()) })
+	if limit > 0 && len(out) > limit {
+		out = out[:limit]
+	}
+	return out, nil
+}
+
+// ListAll returns every non-deleted review (any status), newest first,
+// capped at limit.
+func (m *InMemory) ListAll(ctx context.Context, limit int) ([]domain.Review, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	var out []domain.Review
+	for _, r := range m.reviews {
+		if r.IsDeleted() {
+			continue
+		}
+		out = append(out, r)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].CreatedAt().After(out[j].CreatedAt()) })
+	if limit > 0 && len(out) > limit {
+		out = out[:limit]
+	}
+	return out, nil
 }

--- a/backend/reviews/adapter/postgres.go
+++ b/backend/reviews/adapter/postgres.go
@@ -35,11 +35,21 @@ func NewPostgres(db *sql.DB) *Postgres {
 // Insert writes a fresh review. A unique-index conflict (the partial unique
 // index that ignores soft-deleted rows) is surfaced as ErrDuplicateReview so
 // callers can render a friendly message.
+//
+// Trade-off note on the unique index: the partial unique constraint
+// `(product_id, customer_id) WHERE deleted_at IS NULL` is intentionally
+// status-agnostic. That means once a customer's review is rejected they
+// cannot resubmit a fresh (pending) review for the same product —
+// resubmission is gated on the admin first soft-deleting the rejected row,
+// which clears the partial-unique key. The alternative (relaxing the index
+// to additionally exclude rejected rows) was rejected on purpose because
+// it would let a customer flood the queue with new submissions every time
+// one was rejected. Admins can soft-delete to reset.
 func (p *Postgres) Insert(ctx context.Context, r domain.Review) error {
 	_, err := p.db.ExecContext(ctx, `
-		INSERT INTO reviews_review (id, product_id, customer_id, rating, body, created_at)
-		VALUES ($1, $2, $3, $4, $5, $6)
-	`, r.ID(), r.ProductID(), r.CustomerID(), r.Rating(), r.Body(), r.CreatedAt())
+		INSERT INTO reviews_review (id, product_id, customer_id, rating, body, created_at, status)
+		VALUES ($1, $2, $3, $4, $5, $6, $7)
+	`, r.ID(), r.ProductID(), r.CustomerID(), r.Rating(), r.Body(), r.CreatedAt(), string(r.Status()))
 	if err != nil {
 		var pqErr *pq.Error
 		if errors.As(err, &pqErr) && string(pqErr.Code) == pgUniqueViolation {
@@ -63,14 +73,29 @@ func (p *Postgres) SoftDelete(ctx context.Context, id string) error {
 	return nil
 }
 
-// ByProduct returns the active reviews for a product, newest-first, capped
-// at limit. The DB query relies on the (product_id, created_at DESC) partial
-// index for ordering.
+// SetStatus flips a review's moderation state. The CHECK constraint on the
+// column protects against unknown values even if a caller bypassed the
+// domain layer's validation.
+func (p *Postgres) SetStatus(ctx context.Context, id string, status domain.Status) error {
+	_, err := p.db.ExecContext(ctx, `
+		UPDATE reviews_review SET status = $2
+		WHERE id = $1 AND deleted_at IS NULL
+	`, id, string(status))
+	if err != nil {
+		return fmt.Errorf("set review status: %w", err)
+	}
+	return nil
+}
+
+// ByProduct returns the approved reviews for a product, newest-first, capped
+// at limit. Pending and rejected reviews are deliberately excluded — this is
+// the storefront-facing query. The DB query relies on the
+// (product_id, created_at DESC) partial index for ordering.
 func (p *Postgres) ByProduct(ctx context.Context, productID string, limit int) ([]domain.Review, error) {
 	rows, err := p.db.QueryContext(ctx, `
-		SELECT id, product_id, customer_id, rating, body, created_at
+		SELECT id, product_id, customer_id, rating, body, created_at, status
 		FROM reviews_review
-		WHERE product_id = $1 AND deleted_at IS NULL
+		WHERE product_id = $1 AND deleted_at IS NULL AND status = 'approved'
 		ORDER BY created_at DESC
 		LIMIT $2
 	`, productID, limit)
@@ -81,13 +106,13 @@ func (p *Postgres) ByProduct(ctx context.Context, productID string, limit int) (
 
 	var out []domain.Review
 	for rows.Next() {
-		var id, productID, customerID, body string
+		var id, productID, customerID, body, status string
 		var rating int
 		var createdAt time.Time
-		if err := rows.Scan(&id, &productID, &customerID, &rating, &body, &createdAt); err != nil {
+		if err := rows.Scan(&id, &productID, &customerID, &rating, &body, &createdAt, &status); err != nil {
 			return nil, fmt.Errorf("scan review: %w", err)
 		}
-		out = append(out, domain.RebuildReview(id, productID, customerID, body, rating, createdAt, nil))
+		out = append(out, domain.RebuildReview(id, productID, customerID, body, rating, createdAt, nil, domain.Status(status)))
 	}
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("rows: %w", err)
@@ -97,7 +122,9 @@ func (p *Postgres) ByProduct(ctx context.Context, productID string, limit int) (
 
 // AggregateForProducts runs a single grouped query over the requested ids
 // (passed as a pq.Array($1::text[])) so the result set is bounded and
-// ordering doesn't matter — callers index by product id.
+// ordering doesn't matter — callers index by product id. Only approved
+// reviews participate: pending submissions and rejected entries do not
+// count towards the storefront badge.
 func (p *Postgres) AggregateForProducts(ctx context.Context, productIDs []string) (map[string]domain.Aggregate, error) {
 	if len(productIDs) == 0 {
 		return map[string]domain.Aggregate{}, nil
@@ -105,7 +132,7 @@ func (p *Postgres) AggregateForProducts(ctx context.Context, productIDs []string
 	rows, err := p.db.QueryContext(ctx, `
 		SELECT product_id, AVG(rating)::float8, COUNT(*)
 		FROM reviews_review
-		WHERE product_id = ANY($1) AND deleted_at IS NULL
+		WHERE product_id = ANY($1) AND deleted_at IS NULL AND status = 'approved'
 		GROUP BY product_id
 	`, pq.Array(productIDs))
 	if err != nil {
@@ -129,7 +156,11 @@ func (p *Postgres) AggregateForProducts(ctx context.Context, productIDs []string
 	return out, nil
 }
 
-// HasReviewed checks for any active review by the customer on the product.
+// HasReviewed checks for any active (non-deleted) review by the customer on
+// the product, regardless of moderation status. This guards the storefront
+// from showing the submit form when the customer already has a pending,
+// approved, or rejected entry in the queue — matching the partial unique
+// index's "one active row per (customer, product)" guarantee.
 func (p *Postgres) HasReviewed(ctx context.Context, productID, customerID string) (bool, error) {
 	var dummy int
 	err := p.db.QueryRowContext(ctx, `
@@ -144,4 +175,59 @@ func (p *Postgres) HasReviewed(ctx context.Context, productID, customerID string
 		return false, fmt.Errorf("has reviewed: %w", err)
 	}
 	return true, nil
+}
+
+// ListByStatus returns every non-deleted review at the given status, newest
+// first. Powers the admin "pending" / "approved" / "rejected" tabs.
+func (p *Postgres) ListByStatus(ctx context.Context, status domain.Status, limit int) ([]domain.Review, error) {
+	rows, err := p.db.QueryContext(ctx, `
+		SELECT id, product_id, customer_id, rating, body, created_at, status
+		FROM reviews_review
+		WHERE deleted_at IS NULL AND status = $1
+		ORDER BY created_at DESC
+		LIMIT $2
+	`, string(status), limit)
+	if err != nil {
+		return nil, fmt.Errorf("list reviews by status: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	return scanReviewRows(rows)
+}
+
+// ListAll returns every non-deleted review (any status), newest first.
+// Powers the admin "all" tab.
+func (p *Postgres) ListAll(ctx context.Context, limit int) ([]domain.Review, error) {
+	rows, err := p.db.QueryContext(ctx, `
+		SELECT id, product_id, customer_id, rating, body, created_at, status
+		FROM reviews_review
+		WHERE deleted_at IS NULL
+		ORDER BY created_at DESC
+		LIMIT $1
+	`, limit)
+	if err != nil {
+		return nil, fmt.Errorf("list all reviews: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	return scanReviewRows(rows)
+}
+
+// scanReviewRows drains a SELECT that produces the same column shape as
+// ListByStatus / ListAll. Pulled out so the two list queries stay short.
+func scanReviewRows(rows *sql.Rows) ([]domain.Review, error) {
+	var out []domain.Review
+	for rows.Next() {
+		var id, productID, customerID, body, status string
+		var rating int
+		var createdAt time.Time
+		if err := rows.Scan(&id, &productID, &customerID, &rating, &body, &createdAt, &status); err != nil {
+			return nil, fmt.Errorf("scan review: %w", err)
+		}
+		out = append(out, domain.RebuildReview(id, productID, customerID, body, rating, createdAt, nil, domain.Status(status)))
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("rows: %w", err)
+	}
+	return out, nil
 }

--- a/backend/reviews/app/service.go
+++ b/backend/reviews/app/service.go
@@ -29,13 +29,18 @@ var ErrNotVerifiedBuyer = errors.New("only verified buyers can leave a review")
 // Storage is the persistence port for reviews. Adapters live in
 // reviews/adapter (postgres + in-memory). The unique index on
 // (product_id, customer_id) WHERE deleted_at IS NULL is mapped to
-// ErrDuplicateReview by Insert.
+// ErrDuplicateReview by Insert. ByProduct / AggregateForProducts only
+// surface approved reviews (the storefront calls them); the admin queue
+// uses ListByStatus / ListAll to see every row.
 type Storage interface {
 	Insert(ctx context.Context, r domain.Review) error
 	SoftDelete(ctx context.Context, id string) error
+	SetStatus(ctx context.Context, id string, status domain.Status) error
 	ByProduct(ctx context.Context, productID string, limit int) ([]domain.Review, error)
 	AggregateForProducts(ctx context.Context, productIDs []string) (map[string]domain.Aggregate, error)
 	HasReviewed(ctx context.Context, productID, customerID string) (bool, error)
+	ListByStatus(ctx context.Context, status domain.Status, limit int) ([]domain.Review, error)
+	ListAll(ctx context.Context, limit int) ([]domain.Review, error)
 }
 
 // VerifiedBuyerChecker is the cross-context port used to gate Submit. The
@@ -111,7 +116,10 @@ func (s *Service) Submit(ctx context.Context, productID, customerID, body string
 		return ErrDuplicateReview
 	}
 
-	review, err := domain.NewReview(s.newID(), productID, customerID, body, rating, s.now())
+	// New submissions always land as pending — moderation policy lives
+	// here so the domain stays a pure value object and the adapters stay
+	// dumb. Admins flip the status via Approve / Reject.
+	review, err := domain.NewReview(s.newID(), productID, customerID, body, rating, s.now(), domain.StatusPending)
 	if err != nil {
 		return err
 	}
@@ -124,6 +132,25 @@ func (s *Service) Delete(ctx context.Context, id string) error {
 		return errors.New("review id is required")
 	}
 	return s.storage.SoftDelete(ctx, id)
+}
+
+// Approve flips a review's moderation state to approved. From this point
+// the row participates in ByProduct / AggregateForProducts (the storefront).
+func (s *Service) Approve(ctx context.Context, id string) error {
+	if strings.TrimSpace(id) == "" {
+		return errors.New("review id is required")
+	}
+	return s.storage.SetStatus(ctx, id, domain.StatusApproved)
+}
+
+// Reject flips a review's moderation state to rejected. The row stays in
+// storage (so the partial unique index still blocks resubmission until an
+// admin soft-deletes it) but disappears from the storefront.
+func (s *Service) Reject(ctx context.Context, id string) error {
+	if strings.TrimSpace(id) == "" {
+		return errors.New("review id is required")
+	}
+	return s.storage.SetStatus(ctx, id, domain.StatusRejected)
 }
 
 // ListForProduct returns the most recent active reviews for a product,
@@ -155,6 +182,25 @@ func (s *Service) HasReviewed(ctx context.Context, productID, customerID string)
 		return false, nil
 	}
 	return s.storage.HasReviewed(ctx, productID, customerID)
+}
+
+// ListPending returns the pending moderation queue (newest first, capped at
+// limit). Powers the default tab on the admin reviews page.
+func (s *Service) ListPending(ctx context.Context, limit int) ([]domain.Review, error) {
+	if limit <= 0 {
+		limit = 100
+	}
+	return s.storage.ListByStatus(ctx, domain.StatusPending, limit)
+}
+
+// ListAll returns every review (any status, excluding soft-deleted),
+// newest first, capped at limit. Powers the "all" tab on the admin reviews
+// page.
+func (s *Service) ListAll(ctx context.Context, limit int) ([]domain.Review, error) {
+	if limit <= 0 {
+		limit = 100
+	}
+	return s.storage.ListAll(ctx, limit)
 }
 
 // newRandomID returns a 16-byte hex string — 128 bits of randomness is well

--- a/backend/reviews/app/service_test.go
+++ b/backend/reviews/app/service_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/bkielbasa/go-ecommerce/backend/reviews/adapter"
 	"github.com/bkielbasa/go-ecommerce/backend/reviews/app"
+	"github.com/bkielbasa/go-ecommerce/backend/reviews/domain"
 )
 
 // stubBuyers is a fake VerifiedBuyerChecker driven by a static map of
@@ -68,16 +69,27 @@ func TestSubmit_RejectsDuplicate(t *testing.T) {
 		t.Fatalf("second Submit: err = %v, want ErrDuplicateReview", err)
 	}
 
-	list, err := storage.ByProduct(ctx, "prod-1", 10)
+	// ByProduct now filters to approved-only (storefront semantics) and a
+	// fresh Submit lands as pending, so the storefront query is empty.
+	visible, err := storage.ByProduct(ctx, "prod-1", 10)
 	if err != nil {
 		t.Fatalf("ByProduct: %v", err)
 	}
-	if len(list) != 1 {
-		t.Fatalf("expected exactly one stored review; got %d", len(list))
+	if len(visible) != 0 {
+		t.Fatalf("expected 0 approved reviews; got %d", len(visible))
+	}
+
+	// The pending list is the source of truth for "did the row get stored".
+	pending, err := storage.ListByStatus(ctx, domain.StatusPending, 10)
+	if err != nil {
+		t.Fatalf("ListByStatus: %v", err)
+	}
+	if len(pending) != 1 {
+		t.Fatalf("expected exactly one stored pending review; got %d", len(pending))
 	}
 }
 
-func TestSubmit_AcceptsBuyerAndComputesAggregate(t *testing.T) {
+func TestSubmit_AcceptsBuyerAndApprovalRequiredForAggregate(t *testing.T) {
 	srv, storage := newServiceFor(t, stubBuyers{purchases: map[string]bool{
 		"alice@example.com|prod-1": true,
 		"bob@example.com|prod-1":   true,
@@ -91,17 +103,51 @@ func TestSubmit_AcceptsBuyerAndComputesAggregate(t *testing.T) {
 		t.Fatalf("Submit(bob): %v", err)
 	}
 
-	list, err := storage.ByProduct(ctx, "prod-1", 10)
+	// Both reviews land as pending — invisible to storefront ByProduct.
+	visible, err := storage.ByProduct(ctx, "prod-1", 10)
 	if err != nil {
 		t.Fatalf("ByProduct: %v", err)
 	}
-	if len(list) != 2 {
-		t.Fatalf("expected 2 reviews; got %d", len(list))
+	if len(visible) != 0 {
+		t.Fatalf("expected 0 approved reviews before moderation; got %d", len(visible))
 	}
 
+	// Aggregate is empty too (only approved rows contribute).
 	agg, err := srv.AggregateForProducts(ctx, []string{"prod-1"})
 	if err != nil {
-		t.Fatalf("AggregateForProducts: %v", err)
+		t.Fatalf("AggregateForProducts (pre-approval): %v", err)
+	}
+	if _, ok := agg["prod-1"]; ok {
+		t.Fatalf("expected no aggregate row before approval; got %#v", agg)
+	}
+
+	// Two pending rows must exist in the moderation queue.
+	pending, err := srv.ListPending(ctx, 10)
+	if err != nil {
+		t.Fatalf("ListPending: %v", err)
+	}
+	if len(pending) != 2 {
+		t.Fatalf("expected 2 pending reviews; got %d", len(pending))
+	}
+
+	// Approve both — now they participate in the storefront view.
+	for _, rv := range pending {
+		if err := srv.Approve(ctx, rv.ID()); err != nil {
+			t.Fatalf("Approve(%s): %v", rv.ID(), err)
+		}
+	}
+
+	visible, err = storage.ByProduct(ctx, "prod-1", 10)
+	if err != nil {
+		t.Fatalf("ByProduct (post-approval): %v", err)
+	}
+	if len(visible) != 2 {
+		t.Fatalf("expected 2 approved reviews after approval; got %d", len(visible))
+	}
+
+	agg, err = srv.AggregateForProducts(ctx, []string{"prod-1"})
+	if err != nil {
+		t.Fatalf("AggregateForProducts (post-approval): %v", err)
 	}
 	got, ok := agg["prod-1"]
 	if !ok {
@@ -113,5 +159,80 @@ func TestSubmit_AcceptsBuyerAndComputesAggregate(t *testing.T) {
 	const wantAvg = 4.0
 	if got.Average() != wantAvg {
 		t.Errorf("aggregate Average = %v, want %v", got.Average(), wantAvg)
+	}
+}
+
+func TestApprove_FlipsVisibilityFromHidden(t *testing.T) {
+	srv, _ := newServiceFor(t, stubBuyers{purchases: map[string]bool{
+		"alice@example.com|prod-1": true,
+	}})
+
+	ctx := context.Background()
+	if err := srv.Submit(ctx, "prod-1", "alice@example.com", "great mug", 5); err != nil {
+		t.Fatalf("Submit: %v", err)
+	}
+
+	// Pre-approval: storefront sees nothing for prod-1.
+	before, err := srv.ListForProduct(ctx, "prod-1", 10)
+	if err != nil {
+		t.Fatalf("ListForProduct (pre-approval): %v", err)
+	}
+	if len(before) != 0 {
+		t.Fatalf("storefront ListForProduct should hide pending; got %d", len(before))
+	}
+
+	pending, err := srv.ListPending(ctx, 10)
+	if err != nil || len(pending) != 1 {
+		t.Fatalf("ListPending: err=%v len=%d", err, len(pending))
+	}
+	if pending[0].Status() != domain.StatusPending {
+		t.Fatalf("expected status=pending; got %q", pending[0].Status())
+	}
+
+	if err := srv.Approve(ctx, pending[0].ID()); err != nil {
+		t.Fatalf("Approve: %v", err)
+	}
+
+	after, err := srv.ListForProduct(ctx, "prod-1", 10)
+	if err != nil {
+		t.Fatalf("ListForProduct (post-approval): %v", err)
+	}
+	if len(after) != 1 {
+		t.Fatalf("storefront ListForProduct should show approved; got %d", len(after))
+	}
+	if !after[0].IsApproved() {
+		t.Fatalf("expected approved row in storefront list; got status %q", after[0].Status())
+	}
+}
+
+func TestReject_KeepsRowHidden(t *testing.T) {
+	srv, _ := newServiceFor(t, stubBuyers{purchases: map[string]bool{
+		"alice@example.com|prod-1": true,
+	}})
+
+	ctx := context.Background()
+	if err := srv.Submit(ctx, "prod-1", "alice@example.com", "spam", 1); err != nil {
+		t.Fatalf("Submit: %v", err)
+	}
+	pending, _ := srv.ListPending(ctx, 10)
+	if err := srv.Reject(ctx, pending[0].ID()); err != nil {
+		t.Fatalf("Reject: %v", err)
+	}
+
+	visible, err := srv.ListForProduct(ctx, "prod-1", 10)
+	if err != nil {
+		t.Fatalf("ListForProduct: %v", err)
+	}
+	if len(visible) != 0 {
+		t.Fatalf("rejected reviews must stay hidden; got %d", len(visible))
+	}
+
+	// ListAll still shows the rejected row for the admin "all" tab.
+	all, err := srv.ListAll(ctx, 10)
+	if err != nil {
+		t.Fatalf("ListAll: %v", err)
+	}
+	if len(all) != 1 || all[0].Status() != domain.StatusRejected {
+		t.Fatalf("expected one rejected row in ListAll; got %#v", all)
 	}
 }

--- a/backend/reviews/domain/review.go
+++ b/backend/reviews/domain/review.go
@@ -19,10 +19,39 @@ var ErrInvalidReview = errors.New("invalid review")
 // (matches the storefront textarea expectations).
 const maxBodyLen = 4000
 
+// Status models the moderation lifecycle of a review. Fresh submissions
+// always land as StatusPending; admins flip them to StatusApproved or
+// StatusRejected from the moderation queue. The set is closed (validated
+// by NewReview) and mirrors the DB CHECK constraint on reviews_review.status.
+type Status string
+
+const (
+	// StatusPending is the initial state of any new submission — invisible
+	// to the storefront until an admin approves it.
+	StatusPending Status = "pending"
+	// StatusApproved is the visible state — counted by the aggregate and
+	// listed on the product page.
+	StatusApproved Status = "approved"
+	// StatusRejected is the terminal "not visible" state — the row stays
+	// in storage (the partial unique index still blocks resubmission until
+	// an admin soft-deletes it) but is hidden from the storefront.
+	StatusRejected Status = "rejected"
+)
+
+// IsValid reports whether s is one of the three known statuses. Used by the
+// constructor to reject typo'd inputs from callers.
+func (s Status) IsValid() bool {
+	switch s {
+	case StatusPending, StatusApproved, StatusRejected:
+		return true
+	}
+	return false
+}
+
 // Review is the value object persisted in reviews_review. createdAt is set
 // by the application layer at submission time so the in-memory and postgres
 // adapters agree on ordering; deletedAt is nil for active reviews and stamped
-// by SoftDelete.
+// by SoftDelete. status models the moderation lifecycle.
 type Review struct {
 	id         string
 	productID  string
@@ -31,13 +60,16 @@ type Review struct {
 	body       string
 	createdAt  time.Time
 	deletedAt  *time.Time
+	status     Status
 }
 
 // NewReview validates inputs and returns a freshly-built Review. The body is
 // trimmed before length validation so whitespace-only submissions are
 // rejected. The createdAt comes from the caller (the service) so tests can
-// pin time.
-func NewReview(id, productID, customerID, body string, rating int, createdAt time.Time) (Review, error) {
+// pin time. The status is supplied by the caller (the application service)
+// so moderation policy lives in one place — Submit always passes
+// StatusPending today.
+func NewReview(id, productID, customerID, body string, rating int, createdAt time.Time, status Status) (Review, error) {
 	if strings.TrimSpace(id) == "" {
 		return Review{}, errors.New("review id cannot be empty")
 	}
@@ -57,6 +89,9 @@ func NewReview(id, productID, customerID, body string, rating int, createdAt tim
 	if len(trimmed) > maxBodyLen {
 		return Review{}, errors.New("review body is too long")
 	}
+	if !status.IsValid() {
+		return Review{}, errors.New("review status is invalid")
+	}
 	return Review{
 		id:         id,
 		productID:  productID,
@@ -64,12 +99,13 @@ func NewReview(id, productID, customerID, body string, rating int, createdAt tim
 		rating:     rating,
 		body:       trimmed,
 		createdAt:  createdAt,
+		status:     status,
 	}, nil
 }
 
 // RebuildReview reconstructs a Review from storage rows (skipping validation,
 // since the row has already been validated once). deletedAt may be nil.
-func RebuildReview(id, productID, customerID, body string, rating int, createdAt time.Time, deletedAt *time.Time) Review {
+func RebuildReview(id, productID, customerID, body string, rating int, createdAt time.Time, deletedAt *time.Time, status Status) Review {
 	return Review{
 		id:         id,
 		productID:  productID,
@@ -78,6 +114,7 @@ func RebuildReview(id, productID, customerID, body string, rating int, createdAt
 		body:       body,
 		createdAt:  createdAt,
 		deletedAt:  deletedAt,
+		status:     status,
 	}
 }
 
@@ -89,6 +126,12 @@ func (r Review) Body() string          { return r.body }
 func (r Review) CreatedAt() time.Time  { return r.createdAt }
 func (r Review) DeletedAt() *time.Time { return r.deletedAt }
 func (r Review) IsDeleted() bool       { return r.deletedAt != nil }
+func (r Review) Status() Status        { return r.status }
+
+// IsApproved is the convenience guard the storefront uses to decide whether
+// a review participates in the public list / aggregate. It's the only state
+// that is visible to non-admin users.
+func (r Review) IsApproved() bool { return r.status == StatusApproved }
 
 // Aggregate is the per-product summary used on the product page (e.g. the
 // "★★★★☆ 4.2 (12)" badge). Count is the number of active reviews; Average is

--- a/migrations/000030_reviews_status.down.sql
+++ b/migrations/000030_reviews_status.down.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+DROP INDEX IF EXISTS public.reviews_review_pending_idx;
+ALTER TABLE public.reviews_review DROP COLUMN IF EXISTS status;
+
+COMMIT;

--- a/migrations/000030_reviews_status.up.sql
+++ b/migrations/000030_reviews_status.up.sql
@@ -1,0 +1,20 @@
+BEGIN;
+
+-- reviews_review.status moves the context from "auto-publish" to a small
+-- moderation queue: submissions land as 'pending' and an admin flips them
+-- to 'approved' or 'rejected'. The DEFAULT here only ever applies to
+-- historical rows (which were auto-published, so 'approved' is the correct
+-- back-compat); the application layer always passes the status explicitly
+-- on Insert, so new submissions are 'pending' regardless of the default.
+ALTER TABLE public.reviews_review
+    ADD COLUMN status text NOT NULL DEFAULT 'approved'
+    CHECK (status IN ('pending','approved','rejected'));
+
+-- Partial index that powers the default admin moderation queue
+-- (status=pending, newest first). Filtering on deleted_at IS NULL keeps
+-- the index lean — soft-deleted rows don't belong to any tab.
+CREATE INDEX reviews_review_pending_idx
+    ON public.reviews_review(created_at DESC)
+    WHERE status = 'pending' AND deleted_at IS NULL;
+
+COMMIT;


### PR DESCRIPTION
Reviews no longer auto-publish. New submissions land as pending and only appear on the product page after admin approval.

- Migration 000030 adds status (pending/approved/rejected) with a CHECK constraint; historical rows default to approved for back-compat; partial index on pending rows for the moderation queue.
- Service.Submit persists status=pending. ByProduct and AggregateForProducts filter to approved only.
- Service gains Approve / Reject / ListPending / ListAll.
- /admin/reviews becomes a moderation queue: "Pending (N)" default tab + "All". Per-row buttons branch on status (Approve / Reject / Delete).
- Storefront submit flash: "Thanks — your review is pending moderation and will appear once approved."

## Test plan
- [x] build / build -tags integration / vet / tests / lint green
- [x] docker: verified buyer submits → DB row status=pending; product page hides it; flipping status=approved reveals it on the page; status=rejected hides it again