### PR TITLE
feat(checkout): Transactional Outbox for integration events

### DIFF
--- a/backend/checkout/adapter/outbox_test.go
+++ b/backend/checkout/adapter/outbox_test.go
@@ -1,0 +1,107 @@
+package adapter
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/bkielbasa/go-ecommerce/backend/checkout/domain"
+	"github.com/bkielbasa/go-ecommerce/backend/checkout/integration"
+	"github.com/matryer/is"
+)
+
+// rehydratePaid builds an Order in StatusPaid by replaying an
+// OrderPlaced followed by a PaymentSucceeded. Lifting the rehydration
+// helper into the test keeps the fixture obvious — every field on the
+// resulting order has an explicit origin.
+func rehydratePaid(t *testing.T, orderID, sessionID, customerID string, at time.Time) (*domain.Order, domain.PaymentSucceeded) {
+	t.Helper()
+	placedAt := at.Add(-time.Minute)
+	placed := domain.OrderPlaced{
+		OrderID:    orderID,
+		UserID:     sessionID,
+		CustomerID: customerID,
+		ShipTo:     domain.Address{},
+		ShipMethod: domain.RebuildShippingMethod("pickup", "Pickup", 0),
+		PayMethod:  domain.RebuildPaymentMethod("card", "Card"),
+		Lines: []domain.Line{
+			domain.NewLine("v1", "Mug", 1, 1500, "USD"),
+		},
+		At: placedAt,
+	}
+	paid := domain.PaymentSucceeded{OrderID: orderID, At: at}
+	// Rehydrate folds the events so o.Status() ends at StatusPaid, but
+	// rehydration clears pendingEvents — extractIntegrationEvents reads
+	// pending separately, so we pass the same slice the adapter would
+	// see at Save time.
+	o := domain.RehydrateOrder([]domain.Event{placed, paid})
+	return o, paid
+}
+
+func TestExtractIntegrationEvents_PaymentSucceededProducesOrderPaid(t *testing.T) {
+	is := is.New(t)
+	at := time.Date(2026, 5, 28, 10, 0, 0, 0, time.UTC)
+	o, ps := rehydratePaid(t, "ord-42", "cart-abc", "jane@example.com", at)
+
+	records, err := extractIntegrationEvents(o, []domain.Event{ps})
+	is.NoErr(err)
+	is.Equal(len(records), 1)
+	is.Equal(records[0].Kind, integration.OrderPaid{}.EventName())
+
+	var decoded integration.OrderPaid
+	is.NoErr(json.Unmarshal(records[0].Payload, &decoded))
+	is.Equal(decoded.OrderID, "ord-42")
+	is.Equal(decoded.SessionID, "cart-abc")
+	is.Equal(decoded.CustomerID, "jane@example.com")
+	is.True(decoded.At.Equal(at))
+}
+
+func TestExtractIntegrationEvents_NotPaidEmitsNothing(t *testing.T) {
+	is := is.New(t)
+	at := time.Date(2026, 5, 28, 10, 0, 0, 0, time.UTC)
+	placed := domain.OrderPlaced{
+		OrderID:    "ord-43",
+		UserID:     "cart-abc",
+		ShipMethod: domain.RebuildShippingMethod("pickup", "Pickup", 0),
+		PayMethod:  domain.RebuildPaymentMethod("card", "Card"),
+		Lines: []domain.Line{
+			domain.NewLine("v1", "Mug", 1, 1500, "USD"),
+		},
+		At: at,
+	}
+	o := domain.RehydrateOrder([]domain.Event{placed})
+
+	// A pending order with just an OrderPlaced should NOT produce an
+	// OrderPaid outbox record — the integration event tracks the paid
+	// transition only.
+	records, err := extractIntegrationEvents(o, []domain.Event{placed})
+	is.NoErr(err)
+	is.Equal(len(records), 0)
+}
+
+func TestExtractIntegrationEvents_JSONShapeMatchesIntegrationOrderPaid(t *testing.T) {
+	// Sanity check: the JSON the adapter stages MUST round-trip back
+	// through json.Unmarshal into the very same integration.OrderPaid
+	// type the dispatcher's decode closure unmarshals into in main.go.
+	// If anyone renames a field on integration.OrderPaid without
+	// updating the producer, this assertion fails loudly.
+	is := is.New(t)
+	at := time.Date(2026, 5, 28, 11, 0, 0, 0, time.UTC)
+	o, ps := rehydratePaid(t, "ord-99", "cart-xyz", "alex@example.com", at)
+	records, err := extractIntegrationEvents(o, []domain.Event{ps})
+	is.NoErr(err)
+	is.Equal(len(records), 1)
+
+	var got integration.OrderPaid
+	is.NoErr(json.Unmarshal(records[0].Payload, &got))
+	want := integration.OrderPaid{
+		OrderID:    "ord-99",
+		SessionID:  "cart-xyz",
+		CustomerID: "alex@example.com",
+		At:         at,
+	}
+	is.Equal(got.OrderID, want.OrderID)
+	is.Equal(got.SessionID, want.SessionID)
+	is.Equal(got.CustomerID, want.CustomerID)
+	is.True(got.At.Equal(want.At))
+}

--- a/backend/checkout/adapter/postgres.go
+++ b/backend/checkout/adapter/postgres.go
@@ -3,11 +3,13 @@ package adapter
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"time"
 
 	"github.com/bkielbasa/go-ecommerce/backend/checkout/domain"
+	"github.com/bkielbasa/go-ecommerce/backend/checkout/integration"
 	"github.com/bkielbasa/go-ecommerce/backend/checkout/query"
 	"github.com/bkielbasa/go-ecommerce/backend/internal/observability"
 	"go.opentelemetry.io/otel/attribute"
@@ -16,12 +18,27 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
-type Postgres struct {
-	db *sql.DB
+// OutboxAppender is the narrow seam through which the checkout
+// adapter stages integration events into the Transactional Outbox.
+// The outbox row is INSERTed inside the same *sql.Tx that appends the
+// domain events and projects them — so the integration event commits
+// atomically with the business write. A nil OutboxAppender disables
+// the integration; older test wiring that doesn't need it stays
+// compatible.
+type OutboxAppender interface {
+	AppendTx(ctx context.Context, tx *sql.Tx, kind string, payload []byte) error
 }
 
-func NewPostgres(db *sql.DB) Postgres {
-	return Postgres{db: db}
+type Postgres struct {
+	db     *sql.DB
+	outbox OutboxAppender
+}
+
+// NewPostgres builds the checkout Postgres adapter. outbox may be nil
+// — Save then writes events + projections only, matching the previous
+// behaviour (used by tests that don't exercise the integration path).
+func NewPostgres(db *sql.DB, outbox OutboxAppender) Postgres {
+	return Postgres{db: db, outbox: outbox}
 }
 
 // Save appends the aggregate's pending events to the event store and projects
@@ -67,6 +84,27 @@ func (p Postgres) Save(ctx context.Context, order *domain.Order) error {
 			span.RecordError(err)
 			span.SetStatus(codes.Error, err.Error())
 			return err
+		}
+	}
+
+	// Stage integration events into the outbox INSIDE the same
+	// transaction. The DB guarantees the business write and the
+	// outbox row commit (or roll back) together — that atomicity is
+	// the whole point of the pattern. A separate dispatcher will
+	// publish each row onto the in-process bus shortly after commit.
+	if p.outbox != nil {
+		records, err := extractIntegrationEvents(order, pending)
+		if err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, err.Error())
+			return err
+		}
+		for _, rec := range records {
+			if err = p.outbox.AppendTx(ctx, tx, rec.Kind, rec.Payload); err != nil {
+				span.RecordError(err)
+				span.SetStatus(codes.Error, err.Error())
+				return err
+			}
 		}
 	}
 
@@ -291,4 +329,52 @@ func (p Postgres) ListAll(ctx context.Context) ([]query.OrderSummary, error) {
 		return nil, fmt.Errorf("rows: %w", err)
 	}
 	return summaries, nil
+}
+
+// outboxRecord is the already-encoded integration event the adapter
+// is about to stage into the outbox table. Kind is the wire name (it
+// MUST match integration.X{}.EventName() so the dispatcher's decoder
+// reaches the right Unmarshal); Payload is the JSON body.
+type outboxRecord struct {
+	Kind    string
+	Payload []byte
+}
+
+// extractIntegrationEvents maps the aggregate's pending domain events
+// into the integration events checkout publishes outward. Keeping
+// this mapping inside the adapter (next to the rest of the
+// persistence layer) means the application service stays oblivious to
+// the outbox — its only contract with the storage is still
+// Save(order).
+//
+// The current rule is intentionally narrow: a single
+// PaymentSucceeded on a paid order emits one integration.OrderPaid.
+// The aggregate's projection (apply()) has already moved Status to
+// StatusPaid by the time we run, so reading o.Status() here is the
+// final post-apply state.
+func extractIntegrationEvents(o *domain.Order, pending []domain.Event) ([]outboxRecord, error) {
+	if o.Status() != domain.StatusPaid {
+		return nil, nil
+	}
+	var out []outboxRecord
+	for _, e := range pending {
+		ps, ok := e.(domain.PaymentSucceeded)
+		if !ok {
+			continue
+		}
+		payload, err := json.Marshal(integration.OrderPaid{
+			OrderID:    o.ID(),
+			SessionID:  o.UserID(),
+			CustomerID: o.CustomerID(),
+			At:         ps.At,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("encode OrderPaid: %w", err)
+		}
+		out = append(out, outboxRecord{
+			Kind:    integration.OrderPaid{}.EventName(),
+			Payload: payload,
+		})
+	}
+	return out, nil
 }

--- a/backend/checkout/app/checkout.go
+++ b/backend/checkout/app/checkout.go
@@ -9,8 +9,6 @@ import (
 
 	cartDomain "github.com/bkielbasa/go-ecommerce/backend/cart/domain"
 	"github.com/bkielbasa/go-ecommerce/backend/checkout/domain"
-	"github.com/bkielbasa/go-ecommerce/backend/checkout/integration"
-	"github.com/bkielbasa/go-ecommerce/backend/internal/eventbus"
 	"github.com/bkielbasa/go-ecommerce/backend/internal/observability"
 	promodomain "github.com/bkielbasa/go-ecommerce/backend/promo/domain"
 	"go.opentelemetry.io/otel/attribute"
@@ -20,8 +18,11 @@ import (
 
 // tracer is the package-level tracer for the checkout application service.
 // The parent Place span and its named child spans (cart.get, stock.reserve,
-// payment.charge, order.save, events.publish) all flow through this scope so
-// they share a single instrumentation name in the trace backend.
+// payment.charge, order.save) all flow through this scope so they share a
+// single instrumentation name in the trace backend. The previous
+// events.publish span has been retired with the inline event bus call —
+// integration events are now staged into the outbox inside order.save and
+// published asynchronously by the outbox dispatcher.
 var tracer = observability.Tracer("github.com/bkielbasa/go-ecommerce/backend/checkout/app")
 
 // recordSpanError marks the span errored and attaches the underlying error so
@@ -49,13 +50,6 @@ func totalReservedUnits(quantities map[string]int) int64 {
 // minimal.
 type CartReader interface {
 	Get(ctx context.Context, sessID string) (*cartDomain.Cart, error)
-}
-
-// EventPublisher publishes integration events for other bounded contexts.
-// Checkout uses it instead of calling other contexts directly — e.g. it
-// announces that an order was paid rather than reaching into the cart.
-type EventPublisher interface {
-	Publish(ctx context.Context, e eventbus.Event)
 }
 
 type OrderStorage interface {
@@ -154,20 +148,25 @@ type CheckoutService struct {
 	payment   PaymentProcessor
 	stock     StockReserver
 	movements StockMovements
-	events    EventPublisher
 	promo     PromoRedeemer
 	newID     IDGenerator
 	now       func() time.Time
 	pricing   PricingPolicy
 }
 
+// NewCheckoutService constructs the checkout command service.
+//
+// Note: there is no EventPublisher dependency. Integration events
+// (e.g. OrderPaid) are staged into the Transactional Outbox by the
+// storage layer inside Save's own transaction, then published by a
+// separate dispatcher. The application service is intentionally
+// oblivious to that wiring — it only knows how to call Save.
 func NewCheckoutService(
 	cart CartReader,
 	storage OrderStorage,
 	payment PaymentProcessor,
 	stock StockReserver,
 	movements StockMovements,
-	events EventPublisher,
 	newID IDGenerator,
 	pricing PricingPolicy,
 ) CheckoutService {
@@ -180,7 +179,6 @@ func NewCheckoutService(
 		payment:   payment,
 		stock:     stock,
 		movements: movements,
-		events:    events,
 		promo:     nopPromoRedeemer{},
 		newID:     newID,
 		now:       func() time.Time { return time.Now().UTC() },
@@ -418,19 +416,12 @@ func (s CheckoutService) Place(ctx context.Context, sessID, customerID, cardNumb
 		}
 	}
 
-	// Announce the paid order. Subscribers (e.g. the cart context emptying the
-	// basket) react best-effort; their failures never block the confirmation.
-	publishCtx, publishSpan := tracer.Start(ctx, "events.publish", trace.WithAttributes(
-		attribute.String("event.name", integration.OrderPaid{}.EventName()),
-		attribute.String("order.id", orderID),
-	))
-	s.events.Publish(publishCtx, integration.OrderPaid{
-		OrderID:    order.ID(),
-		SessionID:  sessID,
-		CustomerID: customerID,
-		At:         s.now(),
-	})
-	publishSpan.End()
+	// Integration events are no longer announced inline. The Save above
+	// has already staged an OrderPaid row into the outbox inside the
+	// same transaction that committed the domain events — the
+	// background dispatcher will publish it to the bus. That's what
+	// makes the hand-off durable across crashes between commit and
+	// publish.
 
 	return *order, nil
 }

--- a/backend/checkout/bounded_context.go
+++ b/backend/checkout/bounded_context.go
@@ -11,7 +11,6 @@ import (
 	"github.com/bkielbasa/go-ecommerce/backend/checkout/app"
 	"github.com/bkielbasa/go-ecommerce/backend/checkout/query"
 	"github.com/bkielbasa/go-ecommerce/backend/internal/application"
-	"github.com/bkielbasa/go-ecommerce/backend/internal/eventbus"
 )
 
 // CartReader and CartClearer let New accept the cart service from the cart
@@ -37,18 +36,26 @@ type StockMovements interface {
 
 // New wires the checkout context and returns its command service (write side,
 // event-sourced) and query service (read side, projection-backed) separately,
-// keeping the CQRS split explicit at the composition root. Cross-context side
-// effects (e.g. clearing the cart) are driven by integration events published
-// on bus, not by direct calls.
+// keeping the CQRS split explicit at the composition root.
+//
+// Cross-context side effects (e.g. clearing the cart, sending the order
+// confirmation email) are driven by integration events published via the
+// Transactional Outbox: Save stages them into outbox_event inside the same
+// transaction that commits the domain events, and the outbox dispatcher
+// (wired in cmd/web) republishes them onto the in-process bus.
+//
+// outbox is the seam through which the adapter stages those rows; pass nil
+// to disable the integration entirely (matches the previous behaviour and
+// what older tests expect).
 //
 // movements may be nil — checkout then runs without writing audit rows, which
 // is the historical behaviour. pricing carries tax + free-shipping config; a
 // zero-value PricingPolicy disables both, again matching the historical
 // behaviour.
-func New(db *sql.DB, cart CartReader, bus *eventbus.Bus, stock StockReserver, movements StockMovements, pricing app.PricingPolicy) (application.BoundedContext, app.CheckoutService, query.Service) {
-	storage := adapter.NewPostgres(db)
+func New(db *sql.DB, cart CartReader, outbox adapter.OutboxAppender, stock StockReserver, movements StockMovements, pricing app.PricingPolicy) (application.BoundedContext, app.CheckoutService, query.Service) {
+	storage := adapter.NewPostgres(db, outbox)
 	payment := adapter.NewFakePayment()
-	cmd := app.NewCheckoutService(cart, storage, payment, stock, movements, bus, newOrderID, pricing)
+	cmd := app.NewCheckoutService(cart, storage, payment, stock, movements, newOrderID, pricing)
 	queries := query.NewService(storage)
 	return &boundedContext{}, cmd, queries
 }

--- a/backend/cmd/web/config.go
+++ b/backend/cmd/web/config.go
@@ -61,6 +61,13 @@ type config struct {
 	// runs. Set to 0 (or any non-positive value) to disable the sweeper
 	// entirely. Default keeps lag low without hammering the read side.
 	ReservationSweepInterval time.Duration `conf:"default:5m"`
+	// OutboxInterval is how often the Transactional Outbox dispatcher
+	// polls outbox_event for unsent rows and republishes them onto the
+	// in-process bus. A non-positive value disables the dispatcher
+	// entirely (integration events stay durable in the table but no
+	// subscriber will be notified — useful only for offline diagnostics).
+	// Default keeps the publish lag sub-second under normal load.
+	OutboxInterval time.Duration `conf:"default:1s"`
 	// TaxRatePercent is the flat tax rate applied to every order's subtotal
 	// at checkout time, expressed as a percentage (e.g. 8.875 for 8.875%).
 	// Defaults to 0, i.e. tax-free; tax is applied to the subtotal and is

--- a/backend/cmd/web/main.go
+++ b/backend/cmd/web/main.go
@@ -2,9 +2,11 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
+	"sync"
 	"time"
 
 	"github.com/ardanlabs/conf"
@@ -22,6 +24,7 @@ import (
 	"github.com/bkielbasa/go-ecommerce/backend/internal/imagestore"
 	"github.com/bkielbasa/go-ecommerce/backend/internal/mailer"
 	"github.com/bkielbasa/go-ecommerce/backend/internal/observability"
+	"github.com/bkielbasa/go-ecommerce/backend/internal/outbox"
 	"github.com/bkielbasa/go-ecommerce/backend/layout"
 	"github.com/bkielbasa/go-ecommerce/backend/productcatalog"
 	"github.com/bkielbasa/go-ecommerce/backend/promo"
@@ -125,6 +128,10 @@ func main() {
 
 	app.AddDependency(dependency.NewSQL(db))
 	bus := eventbus.New(logger)
+	// Transactional Outbox store: same DB, used both as the writer (the
+	// checkout adapter calls AppendTx inside its own tx) and as the
+	// dispatcher's source of unsent rows.
+	outboxStore := outbox.NewPostgres(db)
 	// Search OHS: published-language storage + service. The same *app.Service
 	// instance is wired as both productcatalog's SearchIndexer (write side)
 	// and layout's searchService (read side) — one struct, two roles.
@@ -136,7 +143,7 @@ func main() {
 		TaxRatePercent:        cfg.TaxRatePercent,
 		FreeShippingThreshold: cfg.FreeShippingThreshold,
 	}
-	checkoutBD, checkoutSrv, checkoutQry := checkout.New(db, cartSrv, bus, catalogService, catalogService, pricing)
+	checkoutBD, checkoutSrv, checkoutQry := checkout.New(db, cartSrv, outboxStore, catalogService, catalogService, pricing)
 	// Promo bounded context: owns promo_code + promo_redemption. The
 	// checkout service redeems through its narrow PromoRedeemer seam so
 	// the math stays inside checkout while the ledger lives here.
@@ -181,11 +188,43 @@ func main() {
 	// subscriber is returned (and logged by the bus) but never aborts
 	// the publisher's own transaction; the cart-clearing subscriber
 	// above is unaffected.
+	//
+	// IDEMPOTENCY. The outbox dispatcher delivers integration events
+	// at-least-once: a process crash between Publish and MarkSent will
+	// republish the same OrderPaid on the next tick, and we'd send the
+	// confirmation email twice. Sending Clear() twice on a cart is a
+	// no-op so the cart-clear handler above is naturally safe, but
+	// duplicate emails are user-visible spam. The in-memory dedupe
+	// below remembers recently-seen OrderIDs and drops the duplicate
+	// publish.
+	//
+	// TRADE-OFF. This dedupe only survives within a single process —
+	// a restart wipes the map. That is acceptable for a demo because
+	// the outbox dispatcher won't republish a sent row (sent_at is
+	// set) once MarkSent has committed. The narrow remaining window
+	// is: crash AFTER publish, BEFORE MarkSent, then restart — in
+	// which case the row republishes and the in-memory dedupe is
+	// empty, so a duplicate email goes out. A real implementation
+	// would replace this with a persistent dedupe key (a
+	// sent_emails(order_id, kind) table, or wiring the order's
+	// confirmation_email_sent_at via a domain command) so the
+	// duplicate is suppressed across restarts too.
+	var (
+		sentEmailsMu sync.Mutex
+		sentEmails   = map[string]struct{}{}
+	)
 	bus.Subscribe(checkoutintegration.OrderPaid{}.EventName(), func(ctx context.Context, e eventbus.Event) error {
 		paid := e.(checkoutintegration.OrderPaid)
 		if paid.CustomerID == "" {
 			return nil
 		}
+		sentEmailsMu.Lock()
+		if _, dup := sentEmails[paid.OrderID]; dup {
+			sentEmailsMu.Unlock()
+			return nil
+		}
+		sentEmails[paid.OrderID] = struct{}{}
+		sentEmailsMu.Unlock()
 		view, err := checkoutQry.Find(ctx, paid.OrderID)
 		if err != nil {
 			return fmt.Errorf("order confirmation: load view: %w", err)
@@ -239,6 +278,25 @@ func main() {
 	// context; cancel triggers a clean exit.
 	reservationSweeper := sweeper.New(checkoutQry, checkoutSrv, cfg.ReservationTTL, cfg.ReservationSweepInterval, logger)
 	go reservationSweeper.Run(ctx)
+
+	// Transactional Outbox dispatcher. The decode closure is the
+	// content-aware bridge from a stored (kind, payload) row back to
+	// the integration event the bus's subscribers consume — the
+	// outbox package itself stays type-agnostic so it can serve any
+	// bounded context without imports.
+	decode := func(kind string, payload []byte) (eventbus.Event, error) {
+		switch kind {
+		case checkoutintegration.OrderPaid{}.EventName():
+			var e checkoutintegration.OrderPaid
+			if err := json.Unmarshal(payload, &e); err != nil {
+				return nil, fmt.Errorf("decode OrderPaid: %w", err)
+			}
+			return e, nil
+		}
+		return nil, fmt.Errorf("unknown outbox kind: %s", kind)
+	}
+	outboxDispatcher := outbox.NewDispatcher(outboxStore, bus, decode, logger, cfg.OutboxInterval)
+	go outboxDispatcher.Run(ctx)
 
 	go func() {
 		_ = app.Run()

--- a/backend/internal/outbox/dispatcher.go
+++ b/backend/internal/outbox/dispatcher.go
@@ -1,0 +1,152 @@
+package outbox
+
+import (
+	"context"
+	"time"
+
+	"github.com/bkielbasa/go-ecommerce/backend/internal/eventbus"
+	"github.com/sirupsen/logrus"
+)
+
+// Store is the narrow read/update seam the dispatcher needs. It is
+// satisfied by Postgres but kept as an interface so the dispatcher is
+// trivially fakeable in unit tests.
+type Store interface {
+	Unsent(ctx context.Context, limit int) ([]Row, error)
+	MarkSent(ctx context.Context, id int64) error
+}
+
+// Publisher is the subset of *eventbus.Bus the dispatcher uses. The
+// concrete bus satisfies it; tests pass a fake to assert what was
+// published.
+type Publisher interface {
+	Publish(ctx context.Context, e eventbus.Event)
+}
+
+// Decoder turns a stored (kind, payload) row back into the integration
+// event the in-process subscribers expect. The dispatcher is
+// content-agnostic — the composition root supplies a closure that
+// switches on kind and unmarshals into the matching Go type.
+type Decoder func(kind string, payload []byte) (eventbus.Event, error)
+
+// Dispatcher polls the outbox table and publishes unsent rows onto
+// the in-process bus. It exits cleanly on ctx.Done().
+//
+// The polling loop is intentionally simple: one batch per tick,
+// sequential publish, no parallelism. The pattern's value is the
+// SHAPE (durable hand-off, at-least-once), not throughput; a real
+// deployment with high event volume would add a worker pool and/or
+// SKIP LOCKED row leasing, both of which are out of scope here.
+type Dispatcher struct {
+	store    Store
+	bus      Publisher
+	decode   Decoder
+	logger   logrus.FieldLogger
+	interval time.Duration
+	limit    int
+}
+
+// dispatchBatchLimit is the per-tick row cap. Small on purpose — the
+// dispatcher's job is steady drain, not bulk replay.
+const dispatchBatchLimit = 100
+
+// NewDispatcher builds a Dispatcher. interval is how often the loop
+// polls for unsent rows; a non-positive value disables the dispatcher
+// at Run time so a misconfigured deployment can't spin.
+func NewDispatcher(store Store, bus Publisher, decode Decoder, logger logrus.FieldLogger, interval time.Duration) *Dispatcher {
+	return &Dispatcher{
+		store:    store,
+		bus:      bus,
+		decode:   decode,
+		logger:   logger,
+		interval: interval,
+		limit:    dispatchBatchLimit,
+	}
+}
+
+// Run blocks until ctx is cancelled, dispatching every interval. The
+// first dispatch happens after one tick — never immediately — so the
+// process has a beat to settle (DB connection, subscribers
+// registered) before the loop starts. If interval is non-positive the
+// dispatcher logs a warning and returns without scheduling anything.
+func (d *Dispatcher) Run(ctx context.Context) {
+	if d.interval <= 0 {
+		if d.logger != nil {
+			d.logger.WithField("interval", d.interval.String()).Warn("outbox dispatcher disabled: non-positive interval")
+		}
+		return
+	}
+
+	if d.logger != nil {
+		d.logger.WithField("interval", d.interval.String()).Info("outbox dispatcher started")
+	}
+
+	ticker := time.NewTicker(d.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			if d.logger != nil {
+				d.logger.Info("outbox dispatcher stopped")
+			}
+			return
+		case <-ticker.C:
+			d.dispatchOnce(ctx)
+		}
+	}
+}
+
+// dispatchOnce drains up to one batch of unsent rows. Split out from
+// Run so tests can drive a single tick deterministically without a
+// real ticker.
+//
+// Per-row failure modes:
+//   - decode error: row is logged and skipped (left unsent so a code
+//     fix can rerun it; nothing in the queue would unblock by retrying
+//     the same broken bytes).
+//   - publish: the bus's Publish only logs handler errors, it never
+//     returns one, so this step always succeeds from our point of
+//     view. A subscriber failure means the row is still considered
+//     dispatched here; idempotency in subscribers is what makes that
+//     safe across retries.
+//   - mark-sent error: row stays unsent and the next tick will see it
+//     again. Subscribers MUST tolerate the duplicate publish that
+//     produces.
+func (d *Dispatcher) dispatchOnce(ctx context.Context) {
+	rows, err := d.store.Unsent(ctx, d.limit)
+	if err != nil {
+		if d.logger != nil {
+			d.logger.WithError(err).Warn("outbox dispatcher: list unsent failed")
+		}
+		return
+	}
+	for _, r := range rows {
+		if err := ctx.Err(); err != nil {
+			return
+		}
+		event, err := d.decode(r.Kind, r.Payload)
+		if err != nil {
+			if d.logger != nil {
+				d.logger.WithError(err).WithFields(logrus.Fields{
+					"outbox.id":   r.ID,
+					"outbox.kind": r.Kind,
+				}).Warn("outbox dispatcher: decode failed")
+			}
+			continue
+		}
+		d.bus.Publish(ctx, event)
+		if err := d.store.MarkSent(ctx, r.ID); err != nil {
+			if d.logger != nil {
+				d.logger.WithError(err).WithFields(logrus.Fields{
+					"outbox.id":   r.ID,
+					"outbox.kind": r.Kind,
+				}).Warn("outbox dispatcher: mark sent failed; will retry next tick")
+			}
+			// Leave the row unsent. The next tick re-publishes it —
+			// subscribers must be idempotent. This is the
+			// at-least-once contract in action.
+			continue
+		}
+	}
+}

--- a/backend/internal/outbox/dispatcher_test.go
+++ b/backend/internal/outbox/dispatcher_test.go
@@ -1,0 +1,189 @@
+package outbox
+
+import (
+	"context"
+	"errors"
+	"io"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/bkielbasa/go-ecommerce/backend/internal/eventbus"
+	"github.com/matryer/is"
+	"github.com/sirupsen/logrus"
+)
+
+// testEvent is a tiny eventbus.Event used only by the dispatcher unit
+// tests so they stay independent of any bounded context.
+type testEvent struct {
+	Name string
+	ID   string
+}
+
+func (e testEvent) EventName() string { return e.Name }
+
+type fakeStore struct {
+	mu       sync.Mutex
+	rows     []Row
+	sent     []int64
+	markErrs map[int64]error
+	unsentEr error
+}
+
+func (s *fakeStore) Unsent(_ context.Context, _ int) ([]Row, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.unsentEr != nil {
+		return nil, s.unsentEr
+	}
+	out := make([]Row, 0, len(s.rows))
+	out = append(out, s.rows...)
+	return out, nil
+}
+
+func (s *fakeStore) MarkSent(_ context.Context, id int64) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if err, ok := s.markErrs[id]; ok {
+		return err
+	}
+	s.sent = append(s.sent, id)
+	// Remove the row from the queue so a subsequent Unsent does not
+	// re-return it.
+	kept := s.rows[:0]
+	for _, r := range s.rows {
+		if r.ID != id {
+			kept = append(kept, r)
+		}
+	}
+	s.rows = kept
+	return nil
+}
+
+type fakeBus struct {
+	mu        sync.Mutex
+	published []eventbus.Event
+}
+
+func (b *fakeBus) Publish(_ context.Context, e eventbus.Event) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.published = append(b.published, e)
+}
+
+func discardLogger() logrus.FieldLogger {
+	l := logrus.New()
+	l.SetOutput(io.Discard)
+	return l
+}
+
+func decodeTest(kind string, payload []byte) (eventbus.Event, error) {
+	return testEvent{Name: kind, ID: string(payload)}, nil
+}
+
+func TestDispatchOnce_PublishesAndMarksSent(t *testing.T) {
+	is := is.New(t)
+	store := &fakeStore{
+		rows: []Row{
+			{ID: 1, Kind: "test.A", Payload: []byte("one"), CreatedAt: time.Now()},
+			{ID: 2, Kind: "test.A", Payload: []byte("two"), CreatedAt: time.Now()},
+		},
+	}
+	bus := &fakeBus{}
+	d := NewDispatcher(store, bus, decodeTest, discardLogger(), time.Second)
+
+	d.dispatchOnce(context.Background())
+
+	is.Equal(len(bus.published), 2)
+	is.Equal(bus.published[0].(testEvent).ID, "one")
+	is.Equal(bus.published[1].(testEvent).ID, "two")
+	is.Equal(store.sent, []int64{1, 2})
+	is.Equal(len(store.rows), 0)
+}
+
+func TestDispatchOnce_MarkSentFailure_RowReplayedNextTick(t *testing.T) {
+	is := is.New(t)
+	store := &fakeStore{
+		rows: []Row{
+			{ID: 7, Kind: "test.A", Payload: []byte("retry-me"), CreatedAt: time.Now()},
+		},
+		markErrs: map[int64]error{7: errors.New("db transient")},
+	}
+	bus := &fakeBus{}
+	d := NewDispatcher(store, bus, decodeTest, discardLogger(), time.Second)
+
+	// First tick: publish succeeds but MarkSent fails — row stays unsent.
+	d.dispatchOnce(context.Background())
+	is.Equal(len(bus.published), 1)
+	is.Equal(len(store.sent), 0)
+	is.Equal(len(store.rows), 1) // row still queued
+
+	// Second tick: clear the transient failure; row gets republished
+	// (at-least-once contract) and finally marked sent.
+	store.markErrs = nil
+	d.dispatchOnce(context.Background())
+	is.Equal(len(bus.published), 2) // re-published
+	is.Equal(store.sent, []int64{7})
+	is.Equal(len(store.rows), 0)
+}
+
+func TestDispatchOnce_DecodeError_RowSkippedNotMarked(t *testing.T) {
+	is := is.New(t)
+	store := &fakeStore{
+		rows: []Row{
+			{ID: 11, Kind: "unknown", Payload: []byte("x"), CreatedAt: time.Now()},
+			{ID: 12, Kind: "test.A", Payload: []byte("ok"), CreatedAt: time.Now()},
+		},
+	}
+	bus := &fakeBus{}
+	decode := func(kind string, payload []byte) (eventbus.Event, error) {
+		if kind == "unknown" {
+			return nil, errors.New("no decoder")
+		}
+		return testEvent{Name: kind, ID: string(payload)}, nil
+	}
+	d := NewDispatcher(store, bus, decode, discardLogger(), time.Second)
+
+	d.dispatchOnce(context.Background())
+
+	is.Equal(len(bus.published), 1)
+	is.Equal(bus.published[0].(testEvent).ID, "ok")
+	is.Equal(store.sent, []int64{12})
+	// The broken row is still in the queue (not marked sent), exactly
+	// what we want: a code fix later can drain it.
+	is.Equal(len(store.rows), 1)
+	is.Equal(store.rows[0].ID, int64(11))
+}
+
+func TestRun_StopsOnContextCancel(t *testing.T) {
+	store := &fakeStore{}
+	bus := &fakeBus{}
+	d := NewDispatcher(store, bus, decodeTest, discardLogger(), 20*time.Millisecond)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		d.Run(ctx)
+		close(done)
+	}()
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Run did not return after context cancel")
+	}
+}
+
+func TestRun_DisabledOnNonPositiveInterval(t *testing.T) {
+	is := is.New(t)
+	store := &fakeStore{rows: []Row{{ID: 1, Kind: "test.A", Payload: []byte("x")}}}
+	bus := &fakeBus{}
+	d := NewDispatcher(store, bus, decodeTest, discardLogger(), 0)
+
+	// Run returns immediately when disabled — no goroutine, no ticker.
+	d.Run(context.Background())
+
+	is.Equal(len(bus.published), 0)
+	is.Equal(len(store.sent), 0)
+}

--- a/backend/internal/outbox/event.go
+++ b/backend/internal/outbox/event.go
@@ -1,0 +1,23 @@
+// Package outbox implements the Transactional Outbox pattern: producers
+// stage integration events into a database table inside their own write
+// transaction, and a separate dispatcher publishes those rows onto the
+// in-process event bus after the commit succeeds.
+//
+// The package is content-agnostic — it only deals with a kind (event
+// name) and an already-encoded JSON payload. The producer is
+// responsible for encoding; the dispatcher is given a decode callback
+// by the composition root so it can rebuild the integration event from
+// (kind, payload).
+package outbox
+
+import "time"
+
+// Event is the in-package representation of a single staged integration
+// event. Kind is the wire name (matches eventbus.Event.EventName());
+// Payload is its JSON-encoded body. CreatedAt is when the producer
+// staged the row.
+type Event struct {
+	Kind      string
+	Payload   []byte
+	CreatedAt time.Time
+}

--- a/backend/internal/outbox/postgres.go
+++ b/backend/internal/outbox/postgres.go
@@ -1,0 +1,116 @@
+// Package outbox — Postgres storage adapter.
+//
+// WHY. The in-process eventbus.Bus is at-most-once: Publish dispatches
+// to subscribers synchronously and forgets the event the moment it
+// returns. If the publisher's own transaction has committed but the
+// process crashes before Publish (or before a subscriber finishes),
+// the integration event is lost forever. That's the at-most-once gap
+// the Transactional Outbox pattern closes.
+//
+// HOW. The producer's transaction is extended with one extra INSERT
+// into outbox_event (same DB, same tx — guaranteed by Postgres to
+// commit or roll back together with the business write). A separate
+// background dispatcher polls unsent rows, publishes each one to the
+// in-process bus, and marks the row sent. A crash between commit and
+// dispatch is harmless: the next poll picks the row up again.
+//
+// CONTRACT. The pattern upgrades delivery from at-most-once to
+// at-least-once. Subscribers MUST therefore be idempotent — they may
+// see the same event twice (e.g. on a process restart between
+// publish-to-bus and mark-sent). Idempotency strategies range from
+// natural-id no-ops (clearing a cart twice clears nothing the second
+// time) to dedupe tables keyed by the integration event's order id.
+package outbox
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+)
+
+// Row is a single outbox record loaded for dispatch. ID is the primary
+// key the dispatcher passes back to MarkSent.
+type Row struct {
+	ID        int64
+	Kind      string
+	Payload   []byte
+	CreatedAt time.Time
+}
+
+// Postgres is the durable outbox store backed by the outbox_event
+// table. It deliberately does NOT open its own transactions for
+// AppendTx — the producer's tx is supplied by the caller so the
+// business write and the outbox INSERT share one atomic commit.
+type Postgres struct {
+	db *sql.DB
+}
+
+// NewPostgres builds a Postgres outbox store from an *sql.DB. The DB
+// is only used by Unsent/MarkSent; AppendTx works against a
+// caller-supplied *sql.Tx.
+func NewPostgres(db *sql.DB) Postgres {
+	return Postgres{db: db}
+}
+
+// AppendTx stages an integration event inside the caller's
+// transaction. kind is the event name (used later by the dispatcher
+// to pick the right decoder); payload is the JSON body. Returning an
+// error from this call MUST cause the caller to roll their tx back —
+// otherwise the business write would commit without the outbox row
+// and the at-most-once gap would reappear.
+func (p Postgres) AppendTx(ctx context.Context, tx *sql.Tx, kind string, payload []byte) error {
+	_, err := tx.ExecContext(ctx, `
+		INSERT INTO outbox_event (kind, payload)
+		VALUES ($1, $2)
+	`, kind, payload)
+	if err != nil {
+		return fmt.Errorf("outbox: append %s: %w", kind, err)
+	}
+	return nil
+}
+
+// Unsent returns up to limit unsent rows, oldest first. The partial
+// index outbox_event_unsent_idx keeps this query cheap regardless of
+// how many already-sent rows have accumulated.
+func (p Postgres) Unsent(ctx context.Context, limit int) ([]Row, error) {
+	if limit <= 0 {
+		return nil, nil
+	}
+	rows, err := p.db.QueryContext(ctx, `
+		SELECT id, kind, payload, created_at
+		FROM outbox_event
+		WHERE sent_at IS NULL
+		ORDER BY created_at
+		LIMIT $1
+	`, limit)
+	if err != nil {
+		return nil, fmt.Errorf("outbox: query unsent: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []Row
+	for rows.Next() {
+		var r Row
+		if err := rows.Scan(&r.ID, &r.Kind, &r.Payload, &r.CreatedAt); err != nil {
+			return nil, fmt.Errorf("outbox: scan unsent: %w", err)
+		}
+		out = append(out, r)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("outbox: rows unsent: %w", err)
+	}
+	return out, nil
+}
+
+// MarkSent records that the row with the given id has been published.
+// A row marked sent will never be picked up by Unsent again.
+func (p Postgres) MarkSent(ctx context.Context, id int64) error {
+	_, err := p.db.ExecContext(ctx, `
+		UPDATE outbox_event SET sent_at = now() WHERE id = $1
+	`, id)
+	if err != nil {
+		return fmt.Errorf("outbox: mark sent %d: %w", id, err)
+	}
+	return nil
+}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -28,6 +28,12 @@ services:
       # released. Defaults: 30m / 5m. Override here for dev/testing.
       RESERVATION_TTL: ${RESERVATION_TTL:-30m}
       RESERVATION_SWEEP_INTERVAL: ${RESERVATION_SWEEP_INTERVAL:-5m}
+      # Transactional Outbox dispatcher poll cadence. The dispatcher
+      # drains unsent integration events from outbox_event and
+      # republishes them onto the in-process bus. Lower values cut
+      # publish lag at the cost of more idle SELECTs; the default keeps
+      # lag sub-second under normal load.
+      OUTBOX_INTERVAL: ${OUTBOX_INTERVAL:-1s}
       # Tax rate (percent, e.g. 8.875 for 8.875%) and the free-shipping
       # threshold in MINOR units (cents). Both default to zero (disabled).
       TAX_RATE_PERCENT: ${TAX_RATE_PERCENT:-0}

--- a/migrations/000031_outbox_event.down.sql
+++ b/migrations/000031_outbox_event.down.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+DROP INDEX IF EXISTS public.outbox_event_unsent_idx;
+DROP TABLE IF EXISTS public.outbox_event;
+
+COMMIT;

--- a/migrations/000031_outbox_event.up.sql
+++ b/migrations/000031_outbox_event.up.sql
@@ -1,0 +1,26 @@
+BEGIN;
+
+-- outbox_event is the durability backbone of the Transactional Outbox
+-- pattern. Producers INSERT a row into this table inside the SAME
+-- transaction that mutates their own state (here: appending checkout
+-- events and projecting them), so the integration message and the
+-- business fact share a single atomic commit. A separate dispatcher
+-- polls unsent rows and publishes them onto the in-process bus,
+-- giving at-least-once delivery across crashes between commit and
+-- publish.
+CREATE TABLE outbox_event (
+    id bigserial PRIMARY KEY,
+    kind text NOT NULL,
+    payload bytea NOT NULL,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    sent_at timestamptz
+);
+
+-- Partial index for the dispatcher's hot path: oldest unsent first.
+-- WHERE sent_at IS NULL keeps the index tiny — once a row is marked
+-- sent it falls out of the index entirely.
+CREATE INDEX outbox_event_unsent_idx
+    ON outbox_event(created_at)
+    WHERE sent_at IS NULL;
+
+COMMIT;


### PR DESCRIPTION
Replaces the lossy in-process Publish path with a durable outbox so a process crash between commit and notify can no longer drop integration events.

- **Migration 000031**: `outbox_event(id, kind, payload, created_at, sent_at)` + partial index on unsent rows.
- **New `internal/outbox`**: a Postgres adapter (`AppendTx` writes inside a caller-owned tx; `Unsent`/`MarkSent` for the dispatcher) and a Dispatcher (ticker-loop, content-agnostic decoder closure, batch size 100). At-least-once delivery.
- **`checkout/adapter` Save** extracts integration events from pending domain events (today: `OrderPaid` on each `PaymentSucceeded` that lands the order in `Paid`) and writes them to the outbox in the **same transaction** as the event-log append and the read-model projection. JSON shape matches the in-process `checkoutintegration.OrderPaid` struct so subscribers are unchanged.
- **Removed**: the `EventPublisher` dependency and the inline `events.Publish` call in `Place`.
- Dispatcher wired in main; existing subscribers (cart-clear, order-confirmation email) keep their place. Cart Clear is naturally idempotent; the email subscriber wraps with an in-process dedupe by OrderID (code comment points at a persistent sent-emails table for a real fix).
- `OUTBOX_INTERVAL` env knob (default 1s); surfaced in docker-compose.

## Test plan
- [x] build (incl. -tags integration) / vet / tests / lint green
- [x] Unit tests: dispatcher unsent→published→marked-sent + retry-on-mark-sent-failure; extractIntegrationEvents JSON shape