### PR TITLE
feat(checkout): aggregate snapshots, read-model rebuild CLI, analytics projection

### DIFF
--- a/backend/checkout/adapter/events_postgres.go
+++ b/backend/checkout/adapter/events_postgres.go
@@ -3,6 +3,7 @@ package adapter
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"time"
 
@@ -41,6 +42,14 @@ func appendEventsTx(ctx context.Context, tx *sql.Tx, aggregateID string, expecte
 	}
 	return nil
 }
+
+// SnapshotEvery controls how often the adapter persists an aggregate
+// snapshot: after every N committed events, the latest folded state is
+// stored so subsequent Loads can skip replaying the early history. The
+// value is a trade-off between snapshot write cost and the longest tail
+// replay we ever pay for; ten keeps the dev event log honest while still
+// exercising the path in tests.
+const SnapshotEvery = 10
 
 // LoadEvents returns an aggregate's events in sequence order. Useful for
 // rehydrating the write-side aggregate; the read side uses the projection
@@ -94,27 +103,157 @@ func (p Postgres) LoadEvents(ctx context.Context, aggregateID string) ([]domain.
 	return events, nil
 }
 
-// Load rebuilds an order aggregate from its event history (write side).
+// LoadEventsAfter returns the events with sequence strictly greater than
+// afterVersion, in sequence order. It powers the snapshot-aware Load path:
+// the snapshot version becomes the cursor, and only the tail is replayed.
+func (p Postgres) LoadEventsAfter(ctx context.Context, aggregateID string, afterVersion int) ([]domain.Event, error) {
+	ctx, span := adapterTracer.Start(ctx, "checkout.adapter.LoadEventsAfter", trace.WithAttributes(
+		attribute.String("checkout.aggregate_id", aggregateID),
+		attribute.Int("checkout.after_version", afterVersion),
+	))
+	defer span.End()
+	start := time.Now()
+	defer func() {
+		observability.Metrics().DBQueryDurationSec.Record(ctx, time.Since(start).Seconds(),
+			metric.WithAttributes(attribute.String("query", "checkout.load_events_after")),
+		)
+	}()
+
+	rows, err := p.db.QueryContext(ctx, `
+		SELECT event_type, payload FROM checkout_events
+		WHERE aggregate_id = $1 AND sequence > $2 ORDER BY sequence
+	`, aggregateID, afterVersion)
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		return nil, fmt.Errorf("load events after: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var events []domain.Event
+	for rows.Next() {
+		var typ string
+		var payload []byte
+		if err := rows.Scan(&typ, &payload); err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, err.Error())
+			return nil, fmt.Errorf("scan event: %w", err)
+		}
+		e, err := unmarshalEvent(typ, payload)
+		if err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, err.Error())
+			return nil, err
+		}
+		events = append(events, e)
+	}
+	if err := rows.Err(); err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		return events, err
+	}
+	span.SetAttributes(attribute.Int("checkout.event_count", len(events)))
+	return events, nil
+}
+
+// Load rebuilds an order aggregate. If a snapshot exists, the aggregate is
+// seeded from it and only the events newer than the snapshot version are
+// replayed; otherwise the full history is folded. Either path produces a
+// byte-equivalent aggregate (see TestSnapshotEquivalentToFullReplay in
+// checkout/domain).
 func (p Postgres) Load(ctx context.Context, id string) (*domain.Order, error) {
-	events, err := p.LoadEvents(ctx, id)
+	snapBase, sinceVer, ok, err := p.loadFromSnapshot(ctx, id)
 	if err != nil {
 		return nil, err
 	}
-	if len(events) == 0 {
-		return nil, domain.ErrOrderNotFound
+	if !ok {
+		events, err := p.LoadEvents(ctx, id)
+		if err != nil {
+			return nil, err
+		}
+		if len(events) == 0 {
+			return nil, domain.ErrOrderNotFound
+		}
+		return domain.RehydrateOrder(events), nil
 	}
-	return domain.RehydrateOrder(events), nil
+	tail, err := p.LoadEventsAfter(ctx, id, sinceVer)
+	if err != nil {
+		return nil, err
+	}
+	domain.ApplyTail(snapBase, tail)
+	return snapBase, nil
+}
+
+// SaveSnapshot upserts an aggregate snapshot, refusing to overwrite a row
+// that is already at or beyond the supplied version. The version-guard
+// keeps a concurrent appender from regressing the snapshot pointer.
+func (p Postgres) SaveSnapshot(ctx context.Context, aggregateID string, version int, payload []byte) error {
+	_, err := p.db.ExecContext(ctx, `
+		INSERT INTO checkout_aggregate_snapshot (aggregate_id, version, payload, created_at)
+		VALUES ($1, $2, $3, now())
+		ON CONFLICT (aggregate_id) DO UPDATE
+			SET version = EXCLUDED.version,
+			    payload = EXCLUDED.payload,
+			    created_at = now()
+			WHERE checkout_aggregate_snapshot.version < EXCLUDED.version
+	`, aggregateID, version, payload)
+	if err != nil {
+		return fmt.Errorf("save snapshot: %w", err)
+	}
+	return nil
+}
+
+// LoadSnapshot returns the stored snapshot payload for an aggregate (with
+// its version), or ok=false when no row exists.
+func (p Postgres) LoadSnapshot(ctx context.Context, aggregateID string) (int, []byte, bool, error) {
+	var version int
+	var payload []byte
+	err := p.db.QueryRowContext(ctx, `
+		SELECT version, payload FROM checkout_aggregate_snapshot
+		WHERE aggregate_id = $1
+	`, aggregateID).Scan(&version, &payload)
+	if errors.Is(err, sql.ErrNoRows) {
+		return 0, nil, false, nil
+	}
+	if err != nil {
+		return 0, nil, false, fmt.Errorf("load snapshot: %w", err)
+	}
+	return version, payload, true, nil
+}
+
+// loadFromSnapshot reads the snapshot row for the aggregate and decodes it
+// into a partially-rehydrated *domain.Order. ok=false means there is no
+// snapshot row yet — callers should fall back to a full event replay.
+func (p Postgres) loadFromSnapshot(ctx context.Context, aggregateID string) (*domain.Order, int, bool, error) {
+	version, payload, ok, err := p.LoadSnapshot(ctx, aggregateID)
+	if err != nil || !ok {
+		return nil, 0, ok, err
+	}
+	snap, err := unmarshalSnapshot(payload)
+	if err != nil {
+		return nil, 0, false, err
+	}
+	// Rehydrate the aggregate at the snapshot version with no tail events;
+	// the caller folds the tail events that came after.
+	return domain.RehydrateOrderFromSnapshot(snap, nil), version, true, nil
 }
 
 // projectEventTx updates the read model (checkout_order / _item) for a single
 // event, inside the same transaction the event was appended in — so the read
 // model is always consistent with the event log.
+//
+// PaymentSucceeded also folds into analytics_daily_sales: a second projection
+// over the same event stream, demonstrating that a CQRS read side is free to
+// have multiple readers fed by independent projections.
 func projectEventTx(ctx context.Context, tx *sql.Tx, e domain.Event) error {
 	switch ev := e.(type) {
 	case domain.OrderPlaced:
 		return projectOrderPlaced(ctx, tx, ev)
 	case domain.PaymentSucceeded:
-		return setOrderStatus(ctx, tx, ev.OrderID, string(domain.StatusPaid))
+		if err := setOrderStatus(ctx, tx, ev.OrderID, string(domain.StatusPaid)); err != nil {
+			return err
+		}
+		return projectAnalyticsPaid(ctx, tx, ev.OrderID)
 	case domain.PaymentFailed:
 		return setOrderStatus(ctx, tx, ev.OrderID, string(domain.StatusFailed))
 	case domain.OrderCancelled:
@@ -128,6 +267,37 @@ func projectEventTx(ctx context.Context, tx *sql.Tx, e domain.Event) error {
 	default:
 		return fmt.Errorf("no projection for event %s", e.EventType())
 	}
+}
+
+// projectAnalyticsPaid bumps the analytics_daily_sales counter for the day
+// (in UTC) of the order's placed_at and its currency. The order's total +
+// currency + placed_at come from checkout_order, which has just been
+// written by projectOrderPlaced earlier in the same transaction (or by an
+// earlier event during a CLI rebuild). Idempotent under the UPSERT: every
+// PaymentSucceeded event for a given order_id contributes exactly one
+// (orders_count++, revenue_minor += total) increment.
+func projectAnalyticsPaid(ctx context.Context, tx *sql.Tx, orderID string) error {
+	var totalAmt int64
+	var currency string
+	var placedAt time.Time
+	err := tx.QueryRowContext(ctx, `
+		SELECT total_amount, total_currency, placed_at
+		FROM checkout_order WHERE id = $1
+	`, orderID).Scan(&totalAmt, &currency, &placedAt)
+	if err != nil {
+		return fmt.Errorf("analytics lookup order %s: %w", orderID, err)
+	}
+	day := placedAt.UTC().Truncate(24 * time.Hour)
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO analytics_daily_sales (day, currency, orders_count, revenue_minor)
+		VALUES ($1, $2, 1, $3)
+		ON CONFLICT (day, currency) DO UPDATE SET
+			orders_count = analytics_daily_sales.orders_count + 1,
+			revenue_minor = analytics_daily_sales.revenue_minor + EXCLUDED.revenue_minor
+	`, day, currency, totalAmt); err != nil {
+		return fmt.Errorf("project analytics: %w", err)
+	}
+	return nil
 }
 
 // projectOrderShipped updates the order status and stores the optional

--- a/backend/checkout/adapter/postgres.go
+++ b/backend/checkout/adapter/postgres.go
@@ -115,6 +115,22 @@ func (p Postgres) Save(ctx context.Context, order *domain.Order) error {
 	}
 
 	order.ClearPending()
+
+	// Snapshot policy: persist the folded aggregate state every N events.
+	// Best-effort, outside the tx — a snapshot failure should never block a
+	// successful command (the snapshot is an optimisation, not the source of
+	// truth). The version-guarded UPSERT in SaveSnapshot keeps a concurrent
+	// caller from regressing the pointer.
+	if v := order.Version(); v > 0 && v%SnapshotEvery == 0 {
+		payload, marshalErr := marshalSnapshot(domain.SnapshotOrder(order))
+		if marshalErr == nil {
+			if saveErr := p.SaveSnapshot(ctx, order.ID(), v, payload); saveErr != nil {
+				span.RecordError(saveErr)
+			}
+		} else {
+			span.RecordError(marshalErr)
+		}
+	}
 	return nil
 }
 
@@ -293,6 +309,40 @@ func (p Postgres) HasPurchasedProduct(ctx context.Context, customerID, productID
 		return false, fmt.Errorf("has purchased product: %w", err)
 	}
 	return true, nil
+}
+
+// TodaysSales returns the analytics_daily_sales rows for "today" in UTC,
+// keyed by currency. It reads the second projection (analytics_daily_sales),
+// which is fed by the same event stream as the checkout_order read model
+// but updated only on PaymentSucceeded. An empty map means no paid order
+// has been recorded today yet.
+func (p Postgres) TodaysSales(ctx context.Context) (map[string]query.DailySalesRow, error) {
+	today := time.Now().UTC().Truncate(24 * time.Hour)
+	rows, err := p.db.QueryContext(ctx, `
+		SELECT currency, orders_count, revenue_minor
+		FROM analytics_daily_sales
+		WHERE day = $1
+		ORDER BY currency
+	`, today)
+	if err != nil {
+		return nil, fmt.Errorf("query todays sales: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	out := map[string]query.DailySalesRow{}
+	for rows.Next() {
+		var currency string
+		var ordersCount int
+		var revenue int64
+		if err := rows.Scan(&currency, &ordersCount, &revenue); err != nil {
+			return nil, fmt.Errorf("scan todays sales: %w", err)
+		}
+		out[currency] = query.DailySalesRow{Currency: currency, OrdersCount: ordersCount, RevenueMinor: revenue}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("rows: %w", err)
+	}
+	return out, nil
 }
 
 // ListAll returns every order newest-first as list summaries, regardless of

--- a/backend/checkout/adapter/rebuild.go
+++ b/backend/checkout/adapter/rebuild.go
@@ -1,0 +1,58 @@
+package adapter
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+)
+
+// RebuildReadModels walks every row of checkout_events in (aggregate_id,
+// sequence) order, decodes each event, and applies projectEventTx to the
+// supplied transaction. Returns the number of events replayed and the
+// number of distinct aggregates encountered. The caller owns the tx — it
+// should TRUNCATE the read-model tables (checkout_order, checkout_order_item,
+// analytics_daily_sales) before invoking this and Commit on success.
+//
+// Why in-package: projectEventTx and unmarshalEvent are unexported (they
+// guard the codec/projection seam from leaking into the CLI). Exposing this
+// orchestrator keeps the truncation choice with the operator script while
+// reusing the same projection code that the live Save path uses, so the
+// rebuild is deterministic by construction.
+func RebuildReadModels(ctx context.Context, tx *sql.Tx) (int, int, error) {
+	rows, err := tx.QueryContext(ctx, `
+		SELECT aggregate_id, event_type, payload
+		FROM checkout_events
+		ORDER BY aggregate_id, sequence
+	`)
+	if err != nil {
+		return 0, 0, fmt.Errorf("query events: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	eventCount := 0
+	aggCount := 0
+	var lastAgg string
+	for rows.Next() {
+		var aggID, eventType string
+		var payload []byte
+		if err := rows.Scan(&aggID, &eventType, &payload); err != nil {
+			return eventCount, aggCount, fmt.Errorf("scan event: %w", err)
+		}
+		if aggID != lastAgg {
+			aggCount++
+			lastAgg = aggID
+		}
+		e, err := unmarshalEvent(eventType, payload)
+		if err != nil {
+			return eventCount, aggCount, err
+		}
+		if err := projectEventTx(ctx, tx, e); err != nil {
+			return eventCount, aggCount, fmt.Errorf("project %s for %s: %w", eventType, aggID, err)
+		}
+		eventCount++
+	}
+	if err := rows.Err(); err != nil {
+		return eventCount, aggCount, fmt.Errorf("rows: %w", err)
+	}
+	return eventCount, aggCount, nil
+}

--- a/backend/checkout/adapter/snapshot_codec.go
+++ b/backend/checkout/adapter/snapshot_codec.go
@@ -1,0 +1,110 @@
+package adapter
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/bkielbasa/go-ecommerce/backend/checkout/domain"
+)
+
+// This file is the only place that knows how an Order aggregate snapshot is
+// serialised for the snapshot store. The DTO mirrors domain.OrderSnapshot
+// one-to-one and uses the same value-object rebuilders the event codec
+// relies on, so an order rebuilt from a snapshot is indistinguishable from
+// one rebuilt by replaying its full event history.
+
+type orderSnapshotDTO struct {
+	ID           string            `json:"id"`
+	UserID       string            `json:"user_id"`
+	CustomerID   string            `json:"customer_id"`
+	ShipTo       addressDTO        `json:"ship_to"`
+	ShipMethod   shippingMethodDTO `json:"ship_method"`
+	PayMethod    paymentMethodDTO  `json:"pay_method"`
+	Items        []lineDTO         `json:"items"`
+	SubtotalAmt  int64             `json:"subtotal_amt"`
+	TaxAmt       int64             `json:"tax_amt"`
+	ShipCostAmt  int64             `json:"ship_cost_amt"`
+	DiscountCode string            `json:"discount_code,omitempty"`
+	DiscountAmt  int64             `json:"discount_amt,omitempty"`
+	TotalAmt     int64             `json:"total_amt"`
+	TotalCcy     string            `json:"total_ccy"`
+	Status       string            `json:"status"`
+	PlacedAt     time.Time         `json:"placed_at"`
+	Carrier      string            `json:"carrier,omitempty"`
+	TrackingCode string            `json:"tracking_code,omitempty"`
+	Version      int               `json:"version"`
+}
+
+// marshalSnapshot returns the JSON payload for a domain snapshot DTO.
+func marshalSnapshot(snap domain.OrderSnapshot) ([]byte, error) {
+	items := make([]lineDTO, 0, len(snap.Items))
+	for _, l := range snap.Items {
+		items = append(items, lineDTO{
+			ProductID:     l.ProductID(),
+			ProductName:   l.ProductName(),
+			Qty:           l.Quantity(),
+			PriceAmount:   l.PriceAmount(),
+			PriceCurrency: l.PriceCurrency(),
+		})
+	}
+	dto := orderSnapshotDTO{
+		ID:           snap.ID,
+		UserID:       snap.UserID,
+		CustomerID:   snap.CustomerID,
+		ShipTo:       toAddressDTO(snap.ShipTo),
+		ShipMethod:   shippingMethodDTO{Code: snap.ShipMethod.Code(), Label: snap.ShipMethod.Label(), Cost: snap.ShipMethod.Cost()},
+		PayMethod:    paymentMethodDTO{Code: snap.PayMethod.Code(), Label: snap.PayMethod.Label()},
+		Items:        items,
+		SubtotalAmt:  snap.SubtotalAmt,
+		TaxAmt:       snap.TaxAmt,
+		ShipCostAmt:  snap.ShipCostAmt,
+		DiscountCode: snap.DiscountCode,
+		DiscountAmt:  snap.DiscountAmt,
+		TotalAmt:     snap.TotalAmt,
+		TotalCcy:     snap.TotalCcy,
+		Status:       string(snap.Status),
+		PlacedAt:     snap.PlacedAt,
+		Carrier:      snap.Carrier,
+		TrackingCode: snap.TrackingCode,
+		Version:      snap.Version,
+	}
+	b, err := json.Marshal(dto)
+	if err != nil {
+		return nil, fmt.Errorf("marshal snapshot: %w", err)
+	}
+	return b, nil
+}
+
+// unmarshalSnapshot rebuilds a domain snapshot DTO from its stored payload.
+func unmarshalSnapshot(payload []byte) (domain.OrderSnapshot, error) {
+	var dto orderSnapshotDTO
+	if err := json.Unmarshal(payload, &dto); err != nil {
+		return domain.OrderSnapshot{}, fmt.Errorf("unmarshal snapshot: %w", err)
+	}
+	items := make([]domain.Line, 0, len(dto.Items))
+	for _, l := range dto.Items {
+		items = append(items, domain.NewLine(l.ProductID, l.ProductName, l.Qty, l.PriceAmount, l.PriceCurrency))
+	}
+	return domain.OrderSnapshot{
+		ID:           dto.ID,
+		UserID:       dto.UserID,
+		CustomerID:   dto.CustomerID,
+		ShipTo:       domain.RebuildAddress(dto.ShipTo.Name, dto.ShipTo.Street1, dto.ShipTo.Street2, dto.ShipTo.City, dto.ShipTo.Zip, dto.ShipTo.Country),
+		ShipMethod:   domain.RebuildShippingMethod(dto.ShipMethod.Code, dto.ShipMethod.Label, dto.ShipMethod.Cost),
+		PayMethod:    domain.RebuildPaymentMethod(dto.PayMethod.Code, dto.PayMethod.Label),
+		Items:        items,
+		SubtotalAmt:  dto.SubtotalAmt,
+		TaxAmt:       dto.TaxAmt,
+		ShipCostAmt:  dto.ShipCostAmt,
+		DiscountCode: dto.DiscountCode,
+		DiscountAmt:  dto.DiscountAmt,
+		TotalAmt:     dto.TotalAmt,
+		TotalCcy:     dto.TotalCcy,
+		Status:       domain.Status(dto.Status),
+		PlacedAt:     dto.PlacedAt,
+		Carrier:      dto.Carrier,
+		TrackingCode: dto.TrackingCode,
+		Version:      dto.Version,
+	}, nil
+}

--- a/backend/checkout/domain/order.go
+++ b/backend/checkout/domain/order.go
@@ -320,6 +320,12 @@ func (o *Order) ClearPending() { o.pendingEvents = nil }
 // the sequence the first pending event must follow in the store.
 func (o *Order) ExpectedVersion() int { return o.version - len(o.pendingEvents) }
 
+// Version returns the aggregate's current sequence number — i.e. the
+// sequence of the last event that has been applied (events committed +
+// events still pending). The adapter uses it to decide when to persist a
+// snapshot.
+func (o *Order) Version() int { return o.version }
+
 // RehydrateOrder rebuilds an order by folding its full event history.
 func RehydrateOrder(events []Event) *Order {
 	o := &Order{}

--- a/backend/checkout/domain/snapshot.go
+++ b/backend/checkout/domain/snapshot.go
@@ -1,0 +1,116 @@
+package domain
+
+import "time"
+
+// OrderSnapshot mirrors the domain.Order aggregate one-to-one as a plain,
+// public-shape DTO. It captures every field the apply() folder writes to,
+// so an aggregate reconstructed from a snapshot is byte-equivalent to one
+// rehydrated by replaying its full event history up to the same version.
+//
+// The DTO is intentionally exported and free of behaviour: the adapter
+// (checkout/adapter) marshals and unmarshals it as JSON. Keeping the type
+// in the domain package is what lets RehydrateOrderFromSnapshot poke the
+// aggregate's unexported fields without breaking encapsulation for the
+// rest of the codebase.
+type OrderSnapshot struct {
+	ID            string
+	UserID        string
+	CustomerID    string
+	ShipTo        Address
+	ShipMethod    ShippingMethod
+	PayMethod     PaymentMethod
+	Items         []Line
+	SubtotalAmt   int64
+	TaxAmt        int64
+	ShipCostAmt   int64
+	DiscountCode  string
+	DiscountAmt   int64
+	TotalAmt      int64
+	TotalCcy      string
+	Status        Status
+	PlacedAt      time.Time
+	Carrier       string
+	TrackingCode  string
+	Version       int
+}
+
+// SnapshotOrder builds an OrderSnapshot from the aggregate's current state
+// using the public getters. It is defined as a package-level function so
+// the adapter can encode a snapshot without reaching into unexported
+// fields — the asymmetry with the rehydration helper (which does need the
+// unexported access) is intentional.
+func SnapshotOrder(o *Order) OrderSnapshot {
+	if o == nil {
+		return OrderSnapshot{}
+	}
+	items := make([]Line, len(o.items))
+	copy(items, o.items)
+	return OrderSnapshot{
+		ID:           o.ID(),
+		UserID:       o.UserID(),
+		CustomerID:   o.CustomerID(),
+		ShipTo:       o.ShipTo(),
+		ShipMethod:   o.ShippingMethod(),
+		PayMethod:    o.PaymentMethod(),
+		Items:        items,
+		SubtotalAmt:  o.Subtotal(),
+		TaxAmt:       o.TaxAmount(),
+		ShipCostAmt:  o.ShippingCost(),
+		DiscountCode: o.DiscountCode(),
+		DiscountAmt:  o.DiscountAmount(),
+		TotalAmt:     o.TotalAmount(),
+		TotalCcy:     o.TotalCurrency(),
+		Status:       o.Status(),
+		PlacedAt:     o.PlacedAt(),
+		Carrier:      o.Carrier(),
+		TrackingCode: o.TrackingCode(),
+		Version:      o.version,
+	}
+}
+
+// RehydrateOrderFromSnapshot initialises an aggregate from a snapshot at
+// version V, then folds the supplied tail events on top. The result is the
+// same as RehydrateOrder(allEvents) — snapshots are an optimisation, not a
+// new truth. The function lives in the domain package because seeding the
+// aggregate fields without re-running apply() requires unexported access.
+func RehydrateOrderFromSnapshot(snap OrderSnapshot, tail []Event) *Order {
+	items := make([]Line, len(snap.Items))
+	copy(items, snap.Items)
+	o := &Order{
+		id:           snap.ID,
+		userID:       snap.UserID,
+		customerID:   snap.CustomerID,
+		shipTo:       snap.ShipTo,
+		shipMethod:   snap.ShipMethod,
+		payMethod:    snap.PayMethod,
+		items:        items,
+		subtotalAmt:  snap.SubtotalAmt,
+		taxAmt:       snap.TaxAmt,
+		shipCostAmt:  snap.ShipCostAmt,
+		discountCode: snap.DiscountCode,
+		discountAmt:  snap.DiscountAmt,
+		totalAmt:     snap.TotalAmt,
+		totalCcy:     snap.TotalCcy,
+		status:       snap.Status,
+		placedAt:     snap.PlacedAt,
+		carrier:      snap.Carrier,
+		trackingCode: snap.TrackingCode,
+		version:      snap.Version,
+	}
+	ApplyTail(o, tail)
+	return o
+}
+
+// ApplyTail folds a sequence of events into the aggregate as a tail update,
+// incrementing the version per event via apply. It is the adapter-facing
+// hook for snapshot-based loads: Load resolves the snapshot, fetches events
+// with sequence > snapshot.version, and lets the domain replay them.
+func ApplyTail(o *Order, events []Event) {
+	if o == nil {
+		return
+	}
+	for _, e := range events {
+		o.apply(e)
+	}
+	o.pendingEvents = nil
+}

--- a/backend/checkout/domain/snapshot_test.go
+++ b/backend/checkout/domain/snapshot_test.go
@@ -1,0 +1,58 @@
+package domain_test
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/bkielbasa/go-ecommerce/backend/checkout/domain"
+)
+
+// TestSnapshotEquivalentToFullReplay locks in the invariant that powers the
+// adapter's snapshot-aware Load: building an aggregate from a snapshot at
+// version V and folding the tail produces the exact same state as folding
+// the full event history from scratch. The aggregate compares equal under
+// reflect.DeepEqual including the unexported fields, so any drift in apply()
+// or the snapshot DTO will break this test.
+func TestSnapshotEquivalentToFullReplay(t *testing.T) {
+	at := time.Date(2026, 5, 27, 9, 0, 0, 0, time.UTC)
+	allEvents := []domain.Event{
+		domain.OrderPlaced{
+			OrderID:    "ord-snap",
+			UserID:     "cart-1",
+			CustomerID: "jane@example.com",
+			ShipTo:     domain.RebuildAddress("Jane", "1 Main", "", "PDX", "97201", "USA"),
+			ShipMethod: domain.RebuildShippingMethod("courier", "Courier", 1500),
+			PayMethod:  domain.RebuildPaymentMethod("card", "Card"),
+			Lines:      []domain.Line{domain.NewLine("v1", "Item", 2, 1000, "USD")},
+			Tax:        160,
+			At:         at,
+		},
+		domain.PaymentSucceeded{OrderID: "ord-snap", At: at.Add(time.Minute)},
+		// snapshot is taken here — version=2 covers OrderPlaced + PaymentSucceeded.
+		domain.OrderShipped{OrderID: "ord-snap", Carrier: "UPS", TrackingCode: "1Z-XYZ", At: at.Add(time.Hour)},
+		domain.OrderDelivered{OrderID: "ord-snap", At: at.Add(2 * time.Hour)},
+		domain.OrderRefunded{OrderID: "ord-snap", Reason: "return", At: at.Add(3 * time.Hour)},
+	}
+
+	// Build the snapshot from the first two events, then fold the remaining
+	// three on top via RehydrateOrderFromSnapshot.
+	base := domain.RehydrateOrder(allEvents[:2])
+	snap := domain.SnapshotOrder(base)
+	fromSnap := domain.RehydrateOrderFromSnapshot(snap, allEvents[2:])
+
+	// Reference: fold the full history from zero.
+	fromFull := domain.RehydrateOrder(allEvents)
+
+	if !reflect.DeepEqual(fromSnap, fromFull) {
+		t.Fatalf("snapshot+tail diverged from full replay\nsnap: %+v\nfull: %+v", fromSnap, fromFull)
+	}
+	// Sanity-check the visible state via getters too — DeepEqual covers it
+	// already, but this makes the intent explicit at a glance.
+	if fromSnap.Status() != domain.StatusRefunded {
+		t.Errorf("status = %q, want refunded", fromSnap.Status())
+	}
+	if fromSnap.Version() != 5 {
+		t.Errorf("version = %d, want 5", fromSnap.Version())
+	}
+}

--- a/backend/checkout/query/service.go
+++ b/backend/checkout/query/service.go
@@ -21,6 +21,10 @@ type Repository interface {
 	// of the catalog product. It exists to power the reviews context's
 	// verified-buyer gate; see the reviews bounded context for the use site.
 	HasPurchasedProduct(ctx context.Context, customerID, productID string) (bool, error)
+	// TodaysSales returns the analytics_daily_sales rows for "today" in UTC,
+	// keyed by currency. The map is empty when no paid orders have been
+	// recorded today; callers should treat that as "no card to render".
+	TodaysSales(ctx context.Context) (map[string]DailySalesRow, error)
 }
 
 // Service is the checkout query side. It is intentionally separate from the
@@ -68,4 +72,10 @@ func (s Service) HasPurchasedProduct(ctx context.Context, customerID, productID 
 		return false, nil
 	}
 	return s.repo.HasPurchasedProduct(ctx, customerID, productID)
+}
+
+// TodaysSales returns the analytics_daily_sales rows for today (UTC) by
+// currency. Powers the admin "today's revenue" card.
+func (s Service) TodaysSales(ctx context.Context) (map[string]DailySalesRow, error) {
+	return s.repo.TodaysSales(ctx)
 }

--- a/backend/checkout/query/views.go
+++ b/backend/checkout/query/views.go
@@ -137,3 +137,19 @@ func (v OrderView) DiscountDisplay() string { return money(v.discountAmount) }
 func (v OrderView) FreeShipping() bool {
 	return v.discountCode != "" && v.shipCost == 0 && v.discountAmount == 0
 }
+
+// DailySalesRow is one row of the analytics_daily_sales projection — a
+// per-currency tally of paid orders and revenue for a single day. The
+// projection lives on the same event stream as the order read model
+// (PaymentSucceeded), demonstrating that a CQRS read side can carry
+// multiple independent readers off the same source of truth.
+type DailySalesRow struct {
+	Currency     string
+	OrdersCount  int
+	RevenueMinor int64
+}
+
+// RevenueDisplay renders the row's revenue as a "X.YY" string in minor
+// units of the row's currency. Templates pair it with Currency to label
+// the value.
+func (r DailySalesRow) RevenueDisplay() string { return money(r.RevenueMinor) }

--- a/backend/cmd/cli/rebuild.go
+++ b/backend/cmd/cli/rebuild.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"database/sql"
+	"fmt"
+
+	"github.com/bkielbasa/go-ecommerce/backend/checkout/adapter"
+	"github.com/spf13/cobra"
+)
+
+// newRebuildReadModelsCmd wipes the checkout read model (checkout_order +
+// checkout_order_item) and the analytics_daily_sales projection, then
+// replays the entire checkout_events log through projectEventTx within a
+// single transaction. The exercise proves the read side is derived state:
+// dropping it and re-projecting yields the same rows the live projection
+// has been writing all along.
+//
+// The order matters: events for a given aggregate must be applied in
+// sequence order so the analytics projection can SELECT the freshly-written
+// checkout_order row when PaymentSucceeded fires. We order by aggregate_id
+// then sequence so that within each aggregate the OrderPlaced row lands
+// before any PaymentSucceeded; cross-aggregate interleaving is irrelevant
+// because each aggregate's rows are independent.
+func newRebuildReadModelsCmd(db *sql.DB) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "rebuild-readmodels",
+		Short: "Replay the checkout event log into a fresh read model + analytics projection",
+		Long: `Truncates checkout_order, checkout_order_item and
+analytics_daily_sales, then walks checkout_events in
+(aggregate_id, sequence) order, re-running the existing
+projection for each event. Demonstrates that the read side
+of a CQRS context is derived state — wiping and rebuilding
+it does not change the source of truth.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+
+			tx, err := db.BeginTx(ctx, nil)
+			if err != nil {
+				return fmt.Errorf("begin tx: %w", err)
+			}
+			defer func() {
+				if err != nil {
+					_ = tx.Rollback()
+				}
+			}()
+
+			if _, err = tx.ExecContext(ctx, `TRUNCATE TABLE checkout_order, checkout_order_item, analytics_daily_sales RESTART IDENTITY`); err != nil {
+				return fmt.Errorf("truncate read models: %w", err)
+			}
+
+			eventCount, aggCount, err := adapter.RebuildReadModels(ctx, tx)
+			if err != nil {
+				return err
+			}
+
+			if err = tx.Commit(); err != nil {
+				return fmt.Errorf("commit: %w", err)
+			}
+
+			if _, err = fmt.Fprintf(cmd.OutOrStdout(), "rebuilt read models from %d events across %d aggregates\n", eventCount, aggCount); err != nil {
+				return fmt.Errorf("write rebuild summary: %w", err)
+			}
+			return nil
+		},
+	}
+	return cmd
+}

--- a/backend/cmd/cli/rootcmd.go
+++ b/backend/cmd/cli/rootcmd.go
@@ -28,6 +28,7 @@ func Execute(db *sql.DB) {
 	rootCmd.AddCommand(newProductCatalogCmd(appServ))
 	rootCmd.AddCommand(newSeedsCmd(appServ, db))
 	rootCmd.AddCommand(newReindexCmd(db))
+	rootCmd.AddCommand(newRebuildReadModelsCmd(db))
 
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, err)

--- a/backend/layout/bounded_context.go
+++ b/backend/layout/bounded_context.go
@@ -174,6 +174,9 @@ type checkoutQueries interface {
 	// HasPurchasedProduct gates the verified-buyer rule for the reviews
 	// context; layout passes it through a tiny adapter when wiring reviews.
 	HasPurchasedProduct(ctx context.Context, customerID, productID string) (bool, error)
+	// TodaysSales returns the per-currency analytics_daily_sales row for
+	// today (UTC); the admin dashboard renders the result as a small card.
+	TodaysSales(ctx context.Context) (map[string]checkoutQuery.DailySalesRow, error)
 }
 
 // New wires the layout bounded context. It also initialises the process-wide

--- a/backend/layout/http_admin.go
+++ b/backend/layout/http_admin.go
@@ -2,6 +2,9 @@ package layout
 
 import (
 	"net/http"
+	"sort"
+
+	checkoutQuery "github.com/bkielbasa/go-ecommerce/backend/checkout/query"
 )
 
 // requireAdmin is the access gate for every admin page. It resolves the
@@ -72,6 +75,18 @@ func (handler httpHandler) AdminDashboard(w http.ResponseWriter, r *http.Request
 	if err != nil {
 		orders = nil
 	}
+	// TodaysSales reads the analytics_daily_sales projection — the second
+	// reader on the checkout event stream. A lookup error is swallowed
+	// (the card is best-effort) and the dashboard simply omits the card.
+	sales, err := handler.checkoutQry.TodaysSales(r.Context())
+	if err != nil {
+		sales = nil
+	}
+	todays := make([]checkoutQuery.DailySalesRow, 0, len(sales))
+	for _, row := range sales {
+		todays = append(todays, row)
+	}
+	sort.Slice(todays, func(i, j int) bool { return todays[i].Currency < todays[j].Currency })
 
 	handler.renderAdminTemplate(w, r, "admin/dashboard", map[string]any{
 		"Active":        "dashboard",
@@ -79,5 +94,6 @@ func (handler httpHandler) AdminDashboard(w http.ResponseWriter, r *http.Request
 		"ProductCount":  len(products),
 		"CategoryCount": len(categories),
 		"OrderCount":    len(orders),
+		"TodaysSales":   todays,
 	})
 }

--- a/backend/layout/static/admin.css
+++ b/backend/layout/static/admin.css
@@ -226,6 +226,8 @@ code {
   color: var(--a-muted);
 }
 .admin-stat__link { font-size: 0.9rem; font-weight: 500; }
+.admin-stat__list { margin: 0; padding: 0; list-style: none; font-size: 0.95rem; }
+.admin-stat__list li { margin: 4px 0; }
 
 /* --- Tables -------------------------------------------------------------- */
 .admin-table,

--- a/backend/layout/tmpl/admin/dashboard.gohtml
+++ b/backend/layout/tmpl/admin/dashboard.gohtml
@@ -17,5 +17,15 @@
       <h2 class="admin-stat__label">orders</h2>
       <a href="/admin/orders" class="admin-stat__link">manage &rarr;</a>
     </section>
+    {{if .TodaysSales}}
+    <section class="admin-stat">
+      <h2 class="admin-stat__label">today's revenue</h2>
+      <ul class="admin-stat__list">
+        {{range .TodaysSales}}
+          <li>{{.Currency}}: {{.OrdersCount}} orders, {{.RevenueDisplay}}</li>
+        {{end}}
+      </ul>
+    </section>
+    {{end}}
   </div>
 {{end}}

--- a/migrations/000032_checkout_aggregate_snapshot.down.sql
+++ b/migrations/000032_checkout_aggregate_snapshot.down.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+DROP TABLE IF EXISTS checkout_aggregate_snapshot;
+
+COMMIT;

--- a/migrations/000032_checkout_aggregate_snapshot.up.sql
+++ b/migrations/000032_checkout_aggregate_snapshot.up.sql
@@ -1,0 +1,16 @@
+BEGIN;
+
+-- checkout_aggregate_snapshot caches the folded state of an order aggregate
+-- at a known event version, so Load can skip replaying the entire event log
+-- for long-lived aggregates. payload is a JSON-encoded DTO (see the
+-- checkout/adapter snapshot codec) that mirrors the domain.Order's getters
+-- one-to-one. The snapshot is best-effort: if it goes missing the adapter
+-- still falls back to a full replay of checkout_events.
+CREATE TABLE checkout_aggregate_snapshot (
+    aggregate_id text PRIMARY KEY,
+    version int NOT NULL,
+    payload bytea NOT NULL,
+    created_at timestamptz NOT NULL DEFAULT now()
+);
+
+COMMIT;

--- a/migrations/000033_analytics_daily_sales.down.sql
+++ b/migrations/000033_analytics_daily_sales.down.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+DROP TABLE IF EXISTS analytics_daily_sales;
+
+COMMIT;

--- a/migrations/000033_analytics_daily_sales.up.sql
+++ b/migrations/000033_analytics_daily_sales.up.sql
@@ -1,0 +1,17 @@
+BEGIN;
+
+-- analytics_daily_sales is a second projection over the checkout event log:
+-- a per-day, per-currency revenue counter incremented once for every
+-- PaymentSucceeded event. The row is keyed on (day, currency) so multi-store
+-- multi-currency revenue can be displayed separately. The table is fully
+-- derived state — the rebuild-readmodels CLI truncates and re-projects it
+-- from scratch in the same way as the checkout_order / _item read model.
+CREATE TABLE analytics_daily_sales (
+    day date NOT NULL,
+    currency text NOT NULL,
+    orders_count int NOT NULL DEFAULT 0,
+    revenue_minor bigint NOT NULL DEFAULT 0,
+    PRIMARY KEY (day, currency)
+);
+
+COMMIT;


### PR DESCRIPTION
Three event-sourcing showcases on the checkout context — all things you can do BECAUSE you have an event log.

- **Aggregate snapshots** (migration 000031, new file `checkout_aggregate_snapshot`). Every 10 events, the adapter persists a JSON snapshot of the `Order` state outside the tx (best-effort). `Load` reads the latest snapshot + tail events (`LoadEventsAfter`) and folds the tail via a new `domain.ApplyTail`. Caps replay cost for long-lived aggregates. Version-guarded UPSERT can't regress.
- **`cli rebuild-readmodels`** TRUNCATEs the read-model + analytics tables and replays the entire `checkout_events` log through the existing `projectEventTx`. Proves the read model is derived state. Prints `rebuilt read models from N events across M aggregates`.
- **Analytics projection** (migration 000032, `analytics_daily_sales(day,currency,orders_count,revenue_minor)`). Same `OrderPaid` event drives a second projection alongside `checkout_order`. `query.Service.TodaysSales` powers a new "today's revenue" card on the admin dashboard.

A `checkout/domain/snapshot_test.go::TestSnapshotEquivalentToFullReplay` snapshots at version 2 of a 5-event history, folds the remaining 3 via the snapshot path, and asserts `reflect.DeepEqual` against the full-replay aggregate.

## Test plan
- [x] build (incl. -tags integration) / vet / tests / lint green
- [x] Domain equivalence test: snapshot+tail ≡ full replay