### PR TITLE
refactor(promo): eligibility rules as a Specification composition

### DIFF
--- a/backend/promo/app/service.go
+++ b/backend/promo/app/service.go
@@ -8,6 +8,12 @@
 // outright. Anonymous rejection is deliberate: per-customer caps need a
 // stable identity to be meaningful, so rather than invent a fragile
 // "anonymous bucket" we tell the user to log in. See ErrCodeAnonymous.
+//
+// The eligibility rules are implemented as composable Specifications in
+// spec.go. Service.Resolve evaluates a single composed spec
+// (defaultEligibility) so new eligibility policies can be assembled by
+// combining the exported specs (or adding new ones) without changing
+// Service.
 package app
 
 import (
@@ -113,19 +119,23 @@ func (s *Service) ListAll(ctx context.Context) ([]domain.Code, error) {
 
 // Resolve looks up the code, runs every business rule, and returns the
 // computed Discount the checkout pricing math can consume. The order is:
-//   - non-empty code text
+//   - non-empty code text (a precondition, not a spec)
 //   - customer must be signed in (anonymous use is rejected)
-//   - code exists in the catalogue
-//   - code is currently within its validity window
-//   - global max_uses not exceeded
-//   - per_customer_max not exceeded
+//   - code exists in the catalogue (a precondition: Find runs before specs)
+//   - eligibility specs: validity window, global max_uses, per_customer_max
 //   - finally, apply the code to the supplied subtotal / shipping
+//
+// The eligibility rules live in spec.go as composable Specifications. The
+// composed defaultEligibility short-circuits on the first failing rule so
+// the per-customer DB lookup is skipped when an earlier, cheaper check
+// already rejected the code.
 func (s *Service) Resolve(ctx context.Context, code, customerID string, subtotal, shippingCost int64) (domain.Discount, error) {
 	code = strings.TrimSpace(code)
 	if code == "" {
 		return domain.Discount{}, ErrCodeNotFound
 	}
-	if strings.TrimSpace(customerID) == "" {
+	customerID = strings.TrimSpace(customerID)
+	if customerID == "" {
 		return domain.Discount{}, ErrCodeAnonymous
 	}
 
@@ -133,20 +143,24 @@ func (s *Service) Resolve(ctx context.Context, code, customerID string, subtotal
 	if err != nil {
 		return domain.Discount{}, err
 	}
-	if !c.IsActiveAt(s.now()) {
-		return domain.Discount{}, ErrCodeExpired
-	}
-	if c.MaxUsesReached() {
-		return domain.Discount{}, ErrCodeMaxUsesReached
+
+	eligibility := EligibilityContext{
+		Code:         c,
+		CustomerID:   customerID,
+		Subtotal:     subtotal,
+		ShippingCost: shippingCost,
+		Now:          s.now(),
 	}
 	if c.PerCustomerMax() > 0 {
 		used, err := s.storage.CountRedemptionsByCustomer(ctx, c.CodeText(), customerID)
 		if err != nil {
 			return domain.Discount{}, err
 		}
-		if used >= c.PerCustomerMax() {
-			return domain.Discount{}, ErrCodeCustomerLimit
-		}
+		eligibility.CustomerRedemptions = used
+	}
+
+	if err := defaultEligibility.IsSatisfiedBy(eligibility); err != nil {
+		return domain.Discount{}, err
 	}
 	return c.Apply(subtotal, shippingCost), nil
 }

--- a/backend/promo/app/spec.go
+++ b/backend/promo/app/spec.go
@@ -1,0 +1,129 @@
+package app
+
+// This file implements the Specification pattern for the promo-code
+// eligibility rules. Each rule is a tiny exported struct whose
+// IsSatisfiedBy method inspects an EligibilityContext and returns nil when
+// the rule passes or the matching sentinel error when it fails.
+//
+// Why return an error instead of a bool? Service.Resolve needs to tell the
+// caller WHICH rule rejected the code (the checkout handler maps each
+// sentinel to a different flash message), not merely "something failed".
+// A bool would force a parallel error-lookup step; returning the sentinel
+// directly keeps the rule and its rejection reason in one place.
+//
+// Specifications are composed with And — the composite short-circuits on
+// the first non-nil error so we never spend a DB round-trip on a rule that
+// can't change the outcome. New eligibility policies can be assembled by
+// composing the existing specs (or new ones) without touching Service.
+
+import (
+	"time"
+
+	"github.com/bkielbasa/go-ecommerce/backend/promo/domain"
+)
+
+// EligibilityContext bundles every input a Specification might inspect.
+// Service.Resolve builds it once (a single CountRedemptionsByCustomer DB
+// call) and hands the same value to each spec, so the composed evaluation
+// is read-only and side-effect-free.
+type EligibilityContext struct {
+	Code                domain.Code
+	CustomerID          string
+	Subtotal            int64
+	ShippingCost        int64
+	Now                 time.Time
+	CustomerRedemptions int
+}
+
+// Specification is the rule contract. Implementations return nil when the
+// rule is satisfied or the matching sentinel error (ErrCodeAnonymous,
+// ErrCodeExpired, …) when it is violated.
+type Specification interface {
+	IsSatisfiedBy(ctx EligibilityContext) error
+}
+
+// NotAnonymous rejects empty CustomerIDs. Per-customer caps need a stable
+// identity to be meaningful so anonymous use is refused outright.
+type NotAnonymous struct{}
+
+// IsSatisfiedBy returns ErrCodeAnonymous when CustomerID is empty.
+func (NotAnonymous) IsSatisfiedBy(ctx EligibilityContext) error {
+	if ctx.CustomerID == "" {
+		return ErrCodeAnonymous
+	}
+	return nil
+}
+
+// WithinValidityWindow guards both ends of the validity window. nil bounds
+// are open: a code with no validFrom is "valid since forever" and a code
+// with no validUntil is "valid until further notice".
+type WithinValidityWindow struct{}
+
+// IsSatisfiedBy returns ErrCodeExpired when Now is outside [validFrom,
+// validUntil].
+func (WithinValidityWindow) IsSatisfiedBy(ctx EligibilityContext) error {
+	if !ctx.Code.IsActiveAt(ctx.Now) {
+		return ErrCodeExpired
+	}
+	return nil
+}
+
+// UnderMaxUses enforces the global redemption cap. MaxUses == 0 means
+// unlimited and always passes.
+type UnderMaxUses struct{}
+
+// IsSatisfiedBy returns ErrCodeMaxUsesReached when the global cap is hit.
+func (UnderMaxUses) IsSatisfiedBy(ctx EligibilityContext) error {
+	if ctx.Code.MaxUsesReached() {
+		return ErrCodeMaxUsesReached
+	}
+	return nil
+}
+
+// UnderPerCustomerLimit enforces the per-customer redemption cap.
+// PerCustomerMax == 0 means unlimited and always passes; the caller is
+// expected to have populated CustomerRedemptions on the context.
+type UnderPerCustomerLimit struct{}
+
+// IsSatisfiedBy returns ErrCodeCustomerLimit when this customer's tally
+// has reached the configured per-customer cap.
+func (UnderPerCustomerLimit) IsSatisfiedBy(ctx EligibilityContext) error {
+	if ctx.Code.PerCustomerMax() > 0 && ctx.CustomerRedemptions >= ctx.Code.PerCustomerMax() {
+		return ErrCodeCustomerLimit
+	}
+	return nil
+}
+
+// andSpec is the AND combinator: it evaluates its children in order and
+// returns the first non-nil error. The short-circuit is intentional —
+// callers compose cheap predicates ahead of expensive ones so a failing
+// up-front check never reaches a DB-touching predicate further down.
+type andSpec struct {
+	specs []Specification
+}
+
+// IsSatisfiedBy walks the children and returns the first error encountered.
+func (a andSpec) IsSatisfiedBy(ctx EligibilityContext) error {
+	for _, s := range a.specs {
+		if err := s.IsSatisfiedBy(ctx); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// And composes the supplied specifications into a single Specification.
+// The composite short-circuits on the first failing rule.
+func And(specs ...Specification) Specification {
+	return andSpec{specs: specs}
+}
+
+// defaultEligibility is the policy Service.Resolve enforces. New policies
+// can be assembled by composing these specs (or new ones) without
+// changing Service — the package comment documents the extension point.
+var defaultEligibility = And(
+	NotAnonymous{},
+	WithinValidityWindow{},
+	UnderMaxUses{},
+	UnderPerCustomerLimit{},
+)

--- a/backend/promo/app/spec_test.go
+++ b/backend/promo/app/spec_test.go
@@ -1,0 +1,164 @@
+package app_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/bkielbasa/go-ecommerce/backend/promo/app"
+	"github.com/bkielbasa/go-ecommerce/backend/promo/domain"
+)
+
+// fixedNow is the "current time" used by every spec unit test. It sits
+// well inside any open-ended window so the validity-window suite only
+// rejects on bounds we deliberately push past it.
+var fixedNow = time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+
+func TestNotAnonymous(t *testing.T) {
+	t.Parallel()
+	spec := app.NotAnonymous{}
+
+	if err := spec.IsSatisfiedBy(app.EligibilityContext{CustomerID: ""}); !errors.Is(err, app.ErrCodeAnonymous) {
+		t.Errorf("empty customer: err = %v, want ErrCodeAnonymous", err)
+	}
+	if err := spec.IsSatisfiedBy(app.EligibilityContext{CustomerID: "jane@example.com"}); err != nil {
+		t.Errorf("non-empty customer: err = %v, want nil", err)
+	}
+}
+
+func TestWithinValidityWindow(t *testing.T) {
+	t.Parallel()
+	past := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	future := time.Date(2027, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	type tc struct {
+		name      string
+		from, to  *time.Time
+		wantError error
+	}
+	cases := []tc{
+		{"no bounds", nil, nil, nil},
+		{"future-only from rejects", &future, nil, app.ErrCodeExpired},
+		{"past-only from passes", &past, nil, nil},
+		{"past-only until rejects", nil, &past, app.ErrCodeExpired},
+		{"future-only until passes", nil, &future, nil},
+		{"open window with both bounds", &past, &future, nil},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			code, err := domain.NewCode("CODE", domain.KindPercent, 5, "USD", c.from, c.to, 0, 0)
+			if err != nil {
+				t.Fatalf("NewCode: %v", err)
+			}
+			got := app.WithinValidityWindow{}.IsSatisfiedBy(app.EligibilityContext{Code: code, Now: fixedNow})
+			if !errors.Is(got, c.wantError) {
+				t.Errorf("err = %v, want %v", got, c.wantError)
+			}
+		})
+	}
+}
+
+func TestUnderMaxUses(t *testing.T) {
+	t.Parallel()
+
+	// Unlimited (maxUses == 0) always passes regardless of usedCount.
+	unlimited := domain.RebuildCode("U", domain.KindPercent, 5, "USD", nil, nil, 0, 0, 999, time.Now())
+	if err := (app.UnderMaxUses{}).IsSatisfiedBy(app.EligibilityContext{Code: unlimited}); err != nil {
+		t.Errorf("unlimited: err = %v, want nil", err)
+	}
+
+	// Capped but not yet hit.
+	below := domain.RebuildCode("B", domain.KindPercent, 5, "USD", nil, nil, 5, 0, 4, time.Now())
+	if err := (app.UnderMaxUses{}).IsSatisfiedBy(app.EligibilityContext{Code: below}); err != nil {
+		t.Errorf("below cap: err = %v, want nil", err)
+	}
+
+	// Capped and exactly at the limit.
+	atCap := domain.RebuildCode("C", domain.KindPercent, 5, "USD", nil, nil, 5, 0, 5, time.Now())
+	if err := (app.UnderMaxUses{}).IsSatisfiedBy(app.EligibilityContext{Code: atCap}); !errors.Is(err, app.ErrCodeMaxUsesReached) {
+		t.Errorf("at cap: err = %v, want ErrCodeMaxUsesReached", err)
+	}
+}
+
+func TestUnderPerCustomerLimit(t *testing.T) {
+	t.Parallel()
+
+	// PerCustomerMax == 0 means unlimited; tally is irrelevant.
+	unlimited := domain.RebuildCode("U", domain.KindPercent, 5, "USD", nil, nil, 0, 0, 0, time.Now())
+	if err := (app.UnderPerCustomerLimit{}).IsSatisfiedBy(app.EligibilityContext{Code: unlimited, CustomerRedemptions: 99}); err != nil {
+		t.Errorf("unlimited: err = %v, want nil", err)
+	}
+
+	// Capped at 1, customer has never redeemed → passes.
+	cap1 := domain.RebuildCode("L", domain.KindPercent, 5, "USD", nil, nil, 0, 1, 0, time.Now())
+	if err := (app.UnderPerCustomerLimit{}).IsSatisfiedBy(app.EligibilityContext{Code: cap1, CustomerRedemptions: 0}); err != nil {
+		t.Errorf("fresh customer: err = %v, want nil", err)
+	}
+
+	// Capped at 1, customer already redeemed once → rejects.
+	if err := (app.UnderPerCustomerLimit{}).IsSatisfiedBy(app.EligibilityContext{Code: cap1, CustomerRedemptions: 1}); !errors.Is(err, app.ErrCodeCustomerLimit) {
+		t.Errorf("over cap: err = %v, want ErrCodeCustomerLimit", err)
+	}
+}
+
+// stubSpec is a Specification that returns a preset error and records that
+// it was evaluated. It exists so the composition tests can prove And
+// short-circuits without leaking state from the production specs.
+type stubSpec struct {
+	err    error
+	called *bool
+}
+
+func (s stubSpec) IsSatisfiedBy(_ app.EligibilityContext) error {
+	if s.called != nil {
+		*s.called = true
+	}
+	return s.err
+}
+
+func TestAnd_ShortCircuitsOnFirstFailure(t *testing.T) {
+	t.Parallel()
+	var firstCalled, secondCalled, thirdCalled bool
+	want := errors.New("boom")
+	spec := app.And(
+		stubSpec{err: nil, called: &firstCalled},
+		stubSpec{err: want, called: &secondCalled},
+		stubSpec{err: nil, called: &thirdCalled},
+	)
+	got := spec.IsSatisfiedBy(app.EligibilityContext{})
+	if !errors.Is(got, want) {
+		t.Fatalf("err = %v, want %v", got, want)
+	}
+	if !firstCalled {
+		t.Errorf("first spec should have run")
+	}
+	if !secondCalled {
+		t.Errorf("second spec should have run (it's the failure)")
+	}
+	if thirdCalled {
+		t.Errorf("third spec must NOT run after a failure (And must short-circuit)")
+	}
+}
+
+func TestAnd_AllSatisfiedReturnsNil(t *testing.T) {
+	t.Parallel()
+	spec := app.And(
+		stubSpec{err: nil},
+		stubSpec{err: nil},
+		stubSpec{err: nil},
+	)
+	if err := spec.IsSatisfiedBy(app.EligibilityContext{}); err != nil {
+		t.Errorf("err = %v, want nil", err)
+	}
+}
+
+func TestAnd_EmptyReturnsNil(t *testing.T) {
+	t.Parallel()
+	// And() with no specs is the identity element: nothing to violate.
+	if err := app.And().IsSatisfiedBy(app.EligibilityContext{}); err != nil {
+		t.Errorf("err = %v, want nil", err)
+	}
+}


### PR DESCRIPTION
The promo-code eligibility logic in `promo.Service.Resolve` was an if-chain. Refactor it into composable Specifications — each rule a tiny testable struct, combined with `And`.

- `Specification.IsSatisfiedBy(EligibilityContext) error` returns nil on success or the matching sentinel (`ErrCodeAnonymous`, `ErrCodeExpired`, `ErrCodeMaxUsesReached`, `ErrCodeCustomerLimit`). The error-returning interface is deliberate — the checkout handler maps each sentinel to a different flash message, so the rule's identity travels with the failure.
- Concrete specs: `NotAnonymous`, `WithinValidityWindow`, `UnderMaxUses`, `UnderPerCustomerLimit`.
- `And(specs ...)` short-circuits at the first failure.
- `Resolve` becomes: empty-code/find preconditions → build `EligibilityContext` (single `CountRedemptionsByCustomer` call, only when relevant) → evaluate package-level `defaultEligibility` composition → `code.Apply(...)`.
- Future rules (min order amount, category restriction, first-time-customer) snap in by composing additional specs without touching `Service`.

## Test plan
- [x] build / build -tags integration / vet / tests / lint green
- [x] Per-spec unit tests (validity window edges, max-uses 0/at-cap, per-customer-limit unlimited/over-cap, anonymous)
- [x] Composition tests: `And` short-circuits + all-satisfied returns nil
- [x] Existing `Resolve` end-to-end tests unchanged and pass