### PR TITLE
feat(fulfillment): Process Manager — lift operational workflow out of Order

### DIFF
--- a/backend/checkout/app/checkout.go
+++ b/backend/checkout/app/checkout.go
@@ -549,81 +549,17 @@ func (s CheckoutService) ExpirePending(ctx context.Context, orderID string) erro
 	return nil
 }
 
-// MarkShipped transitions a paid order to shipped, optionally recording the
-// carrier and tracking code. Admin-only — never wired into the customer
-// surface.
-func (s CheckoutService) MarkShipped(ctx context.Context, orderID, carrier, trackingCode string) error {
-	ctx, span := tracer.Start(ctx, "Checkout.MarkShipped", trace.WithAttributes(
-		attribute.String("order.id", orderID),
-		attribute.String("ship.carrier", carrier),
-	))
-	defer span.End()
-
-	order, err := s.storage.Load(ctx, orderID)
-	if err != nil {
-		recordSpanError(span, err)
-		return err
-	}
-	if err := order.MarkShipped(carrier, trackingCode, s.now()); err != nil {
-		recordSpanError(span, err)
-		return err
-	}
-	if err := s.storage.Save(ctx, order); err != nil {
-		recordSpanError(span, err)
-		return fmt.Errorf("save shipped: %w", err)
-	}
-	observability.OrdersFinalizedInc(ctx, string(domain.StatusShipped))
-	return nil
-}
-
-// MarkDelivered transitions a shipped order to delivered. Admin-only.
-func (s CheckoutService) MarkDelivered(ctx context.Context, orderID string) error {
-	ctx, span := tracer.Start(ctx, "Checkout.MarkDelivered", trace.WithAttributes(
-		attribute.String("order.id", orderID),
-	))
-	defer span.End()
-
-	order, err := s.storage.Load(ctx, orderID)
-	if err != nil {
-		recordSpanError(span, err)
-		return err
-	}
-	if err := order.MarkDelivered(s.now()); err != nil {
-		recordSpanError(span, err)
-		return err
-	}
-	if err := s.storage.Save(ctx, order); err != nil {
-		recordSpanError(span, err)
-		return fmt.Errorf("save delivered: %w", err)
-	}
-	observability.OrdersFinalizedInc(ctx, string(domain.StatusDelivered))
-	return nil
-}
-
-// Refund refunds a paid/shipped/delivered order and returns its stock to the
-// catalogue (refunds bring the goods back). Admin-only.
-func (s CheckoutService) Refund(ctx context.Context, orderID, reason string) error {
-	ctx, span := tracer.Start(ctx, "Checkout.Refund", trace.WithAttributes(
-		attribute.String("order.id", orderID),
-	))
-	defer span.End()
-
-	order, err := s.storage.Load(ctx, orderID)
-	if err != nil {
-		recordSpanError(span, err)
-		return err
-	}
-	if err := order.Refund(reason, s.now()); err != nil {
-		recordSpanError(span, err)
-		return err
-	}
-	if err := s.storage.Save(ctx, order); err != nil {
-		recordSpanError(span, err)
-		return fmt.Errorf("save refund: %w", err)
-	}
-	// releaseStock already increments the stock_released counter; the
-	// orders_finalized increment captures the refund as a terminal status.
-	s.releaseStock(ctx, order, "release-refund")
-	observability.OrdersFinalizedInc(ctx, string(domain.StatusRefunded))
-	return nil
-}
+// MarkShipped / MarkDelivered / Refund used to live on this service:
+// they applied the matching domain commands on the Order aggregate
+// and (for Refund) released stock back to the catalogue. That
+// behaviour now lives in the fulfillment bounded context's Process
+// Manager (backend/fulfillment), where the operational lifecycle —
+// scheduled → labeled → shipped → delivered / refunded — is modelled
+// as its own state machine. See the package doc on
+// backend/fulfillment/domain for the rationale (commercial vs
+// operational state separation).
+//
+// The Order aggregate's MarkShipped / MarkDelivered / Refund methods
+// stay on checkout/domain for replay / back-compat: historical event
+// logs that include OrderShipped / OrderDelivered / OrderRefunded
+// still apply cleanly when rebuilding read models or aggregates.

--- a/backend/cmd/web/main.go
+++ b/backend/cmd/web/main.go
@@ -15,7 +15,9 @@ import (
 	"github.com/bkielbasa/go-ecommerce/backend/checkout"
 	checkoutapp "github.com/bkielbasa/go-ecommerce/backend/checkout/app"
 	checkoutintegration "github.com/bkielbasa/go-ecommerce/backend/checkout/integration"
+	checkoutquery "github.com/bkielbasa/go-ecommerce/backend/checkout/query"
 	"github.com/bkielbasa/go-ecommerce/backend/checkout/sweeper"
+	"github.com/bkielbasa/go-ecommerce/backend/fulfillment"
 	"github.com/bkielbasa/go-ecommerce/backend/internal"
 	"github.com/bkielbasa/go-ecommerce/backend/internal/application"
 	"github.com/bkielbasa/go-ecommerce/backend/internal/dependency"
@@ -144,6 +146,15 @@ func main() {
 		FreeShippingThreshold: cfg.FreeShippingThreshold,
 	}
 	checkoutBD, checkoutSrv, checkoutQry := checkout.New(db, cartSrv, outboxStore, catalogService, catalogService, pricing)
+	// Fulfillment Process Manager: subscribes to OrderPaid, spawns a
+	// state-stored Fulfillment, and owns the operational lifecycle
+	// (ship/deliver/refund). Stock release on refund goes through the
+	// productcatalog port wired below — same seam checkout used to
+	// call directly before that flow moved.
+	fulfillmentBD, fulfillmentSrv := fulfillment.New(db, bus)
+	fulfillmentSrv = fulfillmentSrv.
+		WithStockReleaser(catalogService).
+		WithOrderLines(orderLinesAdapter{q: checkoutQry})
 	// Promo bounded context: owns promo_code + promo_redemption. The
 	// checkout service redeems through its narrow PromoRedeemer seam so
 	// the math stays inside checkout while the ledger lives here.
@@ -180,6 +191,17 @@ func main() {
 	// context empties the basket it was placed from.
 	bus.Subscribe(checkoutintegration.OrderPaid{}.EventName(), func(ctx context.Context, e eventbus.Event) error {
 		return cartSrv.Clear(ctx, e.(checkoutintegration.OrderPaid).SessionID)
+	})
+
+	// Third OrderPaid subscriber: the fulfillment Process Manager
+	// spawns a new Fulfillment record in StatusScheduled. The handler
+	// is idempotent (FindByOrder + ErrAlreadyExists no-op) so the
+	// outbox dispatcher's at-least-once redelivery cannot create
+	// duplicate fulfillments after a crash between publish and
+	// MarkSent.
+	bus.Subscribe(checkoutintegration.OrderPaid{}.EventName(), func(ctx context.Context, e eventbus.Event) error {
+		paid := e.(checkoutintegration.OrderPaid)
+		return fulfillmentSrv.OnOrderPaid(ctx, paid.OrderID, paid.At)
 	})
 
 	// Second OrderPaid subscriber: render and dispatch the order
@@ -253,7 +275,7 @@ func main() {
 	// remain stored and charged in DefaultCurrency (USD).
 	fxRates := fx.New(cfg.DefaultCurrency, cfg.SupportedCurrencies, cfg.FXRates, logger)
 
-	app.AddBoundedContext(layout.New(logger, cartSrv, catalogService, authService, checkoutSrv, checkoutQry, shipSrv, reviewsSrv, wishlistSrv, promoSrv, searchSrv, storeSrv, imgStore, cfg.UploadsDir, []byte(cfg.SessionSecret), cfg.CookieSecure, cfg.CSRFEnabled, mailerSrv, cfg.BaseURL, fxRates))
+	app.AddBoundedContext(layout.New(logger, cartSrv, catalogService, authService, checkoutSrv, checkoutQry, fulfillmentSrv, shipSrv, reviewsSrv, wishlistSrv, promoSrv, searchSrv, storeSrv, imgStore, cfg.UploadsDir, []byte(cfg.SessionSecret), cfg.CookieSecure, cfg.CSRFEnabled, mailerSrv, cfg.BaseURL, fxRates))
 	// StoreMiddleware resolves the active store per request and binds
 	// it on the request context. It MUST run before the CSRF middleware
 	// so the store is available to every handler/template — including
@@ -266,6 +288,7 @@ func main() {
 	app.AddBoundedContext(pcBD)
 	app.AddBoundedContext(authBD)
 	app.AddBoundedContext(checkoutBD)
+	app.AddBoundedContext(fulfillmentBD)
 	app.AddBoundedContext(reviewsBD)
 	app.AddBoundedContext(wishlistBD)
 	app.AddBoundedContext(promoBD)
@@ -319,6 +342,29 @@ func main() {
 	}
 
 	logrus.Infof("application stopped")
+}
+
+// orderLinesAdapter bridges the checkout query service to the
+// fulfillment service's OrderLineSource port. Refund needs to know
+// which variants/quantities to release back to the catalogue; the
+// authoritative list lives on the order's read-side projection
+// (OrderView.Items).
+type orderLinesAdapter struct {
+	q interface {
+		Find(ctx context.Context, id string) (checkoutquery.OrderView, error)
+	}
+}
+
+func (a orderLinesAdapter) OrderQuantities(ctx context.Context, orderID string) (map[string]int, error) {
+	view, err := a.q.Find(ctx, orderID)
+	if err != nil {
+		return nil, err
+	}
+	out := map[string]int{}
+	for _, ln := range view.Items() {
+		out[ln.ProductID()] += ln.Quantity()
+	}
+	return out, nil
 }
 
 // newLogger builds the process-wide structured logger.

--- a/backend/fulfillment/adapter/inmemory.go
+++ b/backend/fulfillment/adapter/inmemory.go
@@ -1,0 +1,115 @@
+package adapter
+
+import (
+	"context"
+	"sort"
+	"sync"
+
+	"github.com/bkielbasa/go-ecommerce/backend/fulfillment/app"
+	"github.com/bkielbasa/go-ecommerce/backend/fulfillment/domain"
+)
+
+// InMemory is the test-friendly Storage adapter. It mirrors the
+// postgres adapter's contract: Create returns domain.ErrAlreadyExists
+// on a duplicate order id, Update returns app.ErrOptimisticLock when
+// the expected version (Version() - 1) does not match the stored row.
+type InMemory struct {
+	mu    sync.Mutex
+	rows  map[string]domain.Fulfillment // keyed by id
+	order map[string]string             // orderID -> id index
+}
+
+// NewInMemory builds an empty in-memory store, used by service-level
+// unit tests.
+func NewInMemory() *InMemory {
+	return &InMemory{
+		rows:  map[string]domain.Fulfillment{},
+		order: map[string]string{},
+	}
+}
+
+// Create inserts a fresh row. A second Create for the same order id is
+// rejected with domain.ErrAlreadyExists — the postgres adapter relies
+// on the table's UNIQUE constraint to surface the same sentinel.
+//
+// Stored rows are stripped of pending events (via domain.Rebuild) so a
+// subsequent FindByOrder doesn't replay them as if they were freshly
+// raised by the latest command.
+func (m *InMemory) Create(ctx context.Context, f domain.Fulfillment) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if _, ok := m.order[f.OrderID()]; ok {
+		return domain.ErrAlreadyExists
+	}
+	m.rows[f.ID()] = clean(f)
+	m.order[f.OrderID()] = f.ID()
+	return nil
+}
+
+// Update writes a state transition under optimistic concurrency. The
+// expected version is Version() - 1 because each successful command
+// already bumped the in-memory version; the storage row carries the
+// previously-committed version.
+func (m *InMemory) Update(ctx context.Context, f domain.Fulfillment) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	current, ok := m.rows[f.ID()]
+	if !ok {
+		return app.ErrNotFound
+	}
+	if current.Version() != f.Version()-1 {
+		return app.ErrOptimisticLock
+	}
+	m.rows[f.ID()] = clean(f)
+	return nil
+}
+
+// clean returns a copy of f without any in-flight pending events.
+// Storage rows model the persisted state only; pending events are an
+// in-memory bridge to the publisher and must not leak across loads.
+func clean(f domain.Fulfillment) domain.Fulfillment {
+	return domain.Rebuild(
+		f.ID(), f.OrderID(),
+		f.Status(),
+		f.Carrier(), f.TrackingCode(),
+		f.ScheduledAt(), f.ShippedAt(), f.DeliveredAt(),
+		f.RefundReason(),
+		f.Version(),
+	)
+}
+
+// Find returns the row by its id.
+func (m *InMemory) Find(ctx context.Context, id string) (domain.Fulfillment, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	f, ok := m.rows[id]
+	if !ok {
+		return domain.Fulfillment{}, app.ErrNotFound
+	}
+	return f, nil
+}
+
+// FindByOrder returns the row keyed by order id.
+func (m *InMemory) FindByOrder(ctx context.Context, orderID string) (domain.Fulfillment, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	id, ok := m.order[orderID]
+	if !ok {
+		return domain.Fulfillment{}, app.ErrNotFound
+	}
+	return m.rows[id], nil
+}
+
+// ListAll returns every row, scheduled-newest first.
+func (m *InMemory) ListAll(ctx context.Context) ([]domain.Fulfillment, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]domain.Fulfillment, 0, len(m.rows))
+	for _, f := range m.rows {
+		out = append(out, f)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].ScheduledAt().After(out[j].ScheduledAt())
+	})
+	return out, nil
+}

--- a/backend/fulfillment/adapter/postgres.go
+++ b/backend/fulfillment/adapter/postgres.go
@@ -1,0 +1,229 @@
+package adapter
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/bkielbasa/go-ecommerce/backend/fulfillment/app"
+	"github.com/bkielbasa/go-ecommerce/backend/fulfillment/domain"
+	"github.com/lib/pq"
+)
+
+// pgUniqueViolation is the SQLSTATE code postgres returns when a write
+// hits a unique-constraint conflict. We map it to
+// domain.ErrAlreadyExists so callers can branch on the sentinel without
+// reaching for pq.Error themselves.
+const pgUniqueViolation = "23505"
+
+// Postgres is the production Storage adapter. Parameterised SQL
+// throughout; the only interpolation into the statement strings is
+// the placeholder index, never a value.
+type Postgres struct {
+	db *sql.DB
+}
+
+// NewPostgres builds the production adapter bound to the supplied DB
+// connection.
+func NewPostgres(db *sql.DB) *Postgres {
+	return &Postgres{db: db}
+}
+
+// Create inserts a fresh fulfillment row. A unique-constraint
+// conflict on order_id is surfaced as domain.ErrAlreadyExists —
+// callers (the application service's OnOrderPaid) treat it as the
+// idempotency guard against duplicate OrderPaid deliveries.
+func (p *Postgres) Create(ctx context.Context, f domain.Fulfillment) error {
+	_, err := p.db.ExecContext(ctx, `
+		INSERT INTO fulfillment (
+			id, order_id, status,
+			carrier, tracking_code,
+			scheduled_at, shipped_at, delivered_at,
+			refund_reason, version
+		)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+	`,
+		f.ID(), f.OrderID(), string(f.Status()),
+		f.Carrier(), f.TrackingCode(),
+		nullableTime(f.ScheduledAt()),
+		nullableTime(f.ShippedAt()),
+		nullableTime(f.DeliveredAt()),
+		f.RefundReason(), f.Version(),
+	)
+	if err != nil {
+		var pqErr *pq.Error
+		if errors.As(err, &pqErr) && string(pqErr.Code) == pgUniqueViolation {
+			return domain.ErrAlreadyExists
+		}
+		return fmt.Errorf("insert fulfillment: %w", err)
+	}
+	return nil
+}
+
+// Update writes a state transition under optimistic concurrency: the
+// UPDATE matches both the id and the previous version (current
+// Version() - 1). A 0-rows-affected result is mapped to
+// app.ErrOptimisticLock so the caller can retry against a fresh load.
+func (p *Postgres) Update(ctx context.Context, f domain.Fulfillment) error {
+	res, err := p.db.ExecContext(ctx, `
+		UPDATE fulfillment
+		SET status = $2,
+		    carrier = $3,
+		    tracking_code = $4,
+		    scheduled_at = $5,
+		    shipped_at = $6,
+		    delivered_at = $7,
+		    refund_reason = $8,
+		    version = $9
+		WHERE id = $1 AND version = $10
+	`,
+		f.ID(),
+		string(f.Status()),
+		f.Carrier(),
+		f.TrackingCode(),
+		nullableTime(f.ScheduledAt()),
+		nullableTime(f.ShippedAt()),
+		nullableTime(f.DeliveredAt()),
+		f.RefundReason(),
+		f.Version(),
+		f.Version()-1,
+	)
+	if err != nil {
+		return fmt.Errorf("update fulfillment: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("rows affected: %w", err)
+	}
+	if n == 0 {
+		return app.ErrOptimisticLock
+	}
+	return nil
+}
+
+// Find loads the row by id, mapping sql.ErrNoRows to app.ErrNotFound.
+func (p *Postgres) Find(ctx context.Context, id string) (domain.Fulfillment, error) {
+	return p.scanOne(ctx, `
+		SELECT id, order_id, status, carrier, tracking_code,
+		       scheduled_at, shipped_at, delivered_at,
+		       refund_reason, version
+		FROM fulfillment
+		WHERE id = $1
+	`, id)
+}
+
+// FindByOrder loads the row keyed by order id; sql.ErrNoRows maps to
+// app.ErrNotFound. The unique constraint on order_id guarantees at
+// most one row.
+func (p *Postgres) FindByOrder(ctx context.Context, orderID string) (domain.Fulfillment, error) {
+	return p.scanOne(ctx, `
+		SELECT id, order_id, status, carrier, tracking_code,
+		       scheduled_at, shipped_at, delivered_at,
+		       refund_reason, version
+		FROM fulfillment
+		WHERE order_id = $1
+	`, orderID)
+}
+
+// ListAll returns every row, scheduled-newest first. Used by admin
+// surfaces / future reporting; the index on (status) supports
+// status-filtered variants if/when needed.
+func (p *Postgres) ListAll(ctx context.Context) ([]domain.Fulfillment, error) {
+	rows, err := p.db.QueryContext(ctx, `
+		SELECT id, order_id, status, carrier, tracking_code,
+		       scheduled_at, shipped_at, delivered_at,
+		       refund_reason, version
+		FROM fulfillment
+		ORDER BY scheduled_at DESC
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("list fulfillments: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []domain.Fulfillment
+	for rows.Next() {
+		f, err := scanRow(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, f)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("rows: %w", err)
+	}
+	return out, nil
+}
+
+// scanOne is the shared shape behind Find / FindByOrder.
+func (p *Postgres) scanOne(ctx context.Context, q string, arg string) (domain.Fulfillment, error) {
+	row := p.db.QueryRowContext(ctx, q, arg)
+	f, err := scanFromRow(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return domain.Fulfillment{}, app.ErrNotFound
+	}
+	if err != nil {
+		return domain.Fulfillment{}, fmt.Errorf("scan fulfillment: %w", err)
+	}
+	return f, nil
+}
+
+// rowScanner is the narrow interface implemented by both *sql.Row and
+// *sql.Rows so scanFromRow / scanRow share the same code path.
+type rowScanner interface {
+	Scan(dest ...interface{}) error
+}
+
+func scanFromRow(s rowScanner) (domain.Fulfillment, error) {
+	return scanRow(s)
+}
+
+func scanRow(s rowScanner) (domain.Fulfillment, error) {
+	var (
+		id, orderID, status        string
+		carrier, trackingCode      string
+		scheduledAt                sql.NullTime
+		shippedAt, deliveredAt     sql.NullTime
+		refundReason               string
+		version                    int
+	)
+	if err := s.Scan(
+		&id, &orderID, &status,
+		&carrier, &trackingCode,
+		&scheduledAt, &shippedAt, &deliveredAt,
+		&refundReason, &version,
+	); err != nil {
+		return domain.Fulfillment{}, err
+	}
+	return domain.Rebuild(
+		id, orderID,
+		domain.Status(status),
+		carrier, trackingCode,
+		nullTimeOrZero(scheduledAt),
+		nullTimeOrZero(shippedAt),
+		nullTimeOrZero(deliveredAt),
+		refundReason,
+		version,
+	), nil
+}
+
+// nullableTime converts a zero time.Time into a NULL on the wire so
+// the schema's nullable timestamptz columns carry the operational
+// "not yet" meaning rather than a misleading epoch value.
+func nullableTime(t time.Time) interface{} {
+	if t.IsZero() {
+		return nil
+	}
+	return t
+}
+
+// nullTimeOrZero unpacks a sql.NullTime back into a regular time.Time
+// (zero when null).
+func nullTimeOrZero(n sql.NullTime) time.Time {
+	if !n.Valid {
+		return time.Time{}
+	}
+	return n.Time
+}

--- a/backend/fulfillment/app/service.go
+++ b/backend/fulfillment/app/service.go
@@ -1,0 +1,334 @@
+// Package app holds the fulfillment application service: the
+// orchestrating layer between domain commands, storage, and the
+// integration event publisher. Each command follows the same shape —
+// load the record, apply the domain command, save, then drain pending
+// events onto the bus.
+package app
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/bkielbasa/go-ecommerce/backend/fulfillment/domain"
+	"github.com/bkielbasa/go-ecommerce/backend/fulfillment/integration"
+	"github.com/bkielbasa/go-ecommerce/backend/internal/eventbus"
+)
+
+// ErrNotFound is returned by Storage.Find / FindByOrder when no row
+// matches. Mirrors the sentinel pattern used in checkout/domain so
+// callers can branch with errors.Is.
+var ErrNotFound = errors.New("fulfillment: not found")
+
+// ErrOptimisticLock is returned by Storage.Update when the row's
+// version column does not match the expected version — i.e. someone
+// else updated the row since we loaded it. Callers should reload and
+// retry; the service surface itself returns the error verbatim so the
+// HTTP layer can surface a sensible message.
+var ErrOptimisticLock = errors.New("fulfillment: optimistic lock conflict")
+
+// Storage is the persistence port for fulfillment records. The
+// adapter package supplies an in-memory implementation (tests) and a
+// Postgres-backed one (production). Update checks the row's version
+// column for optimistic concurrency: a mismatch returns
+// ErrOptimisticLock.
+type Storage interface {
+	// Create inserts a fresh fulfillment row. Adapter returns
+	// domain.ErrAlreadyExists when (order_id) collides with an
+	// existing row (unique constraint).
+	Create(ctx context.Context, f domain.Fulfillment) error
+	// Update writes a state transition. Adapter MUST match on the
+	// expected version (Version() - 1 after a command); a mismatch
+	// returns ErrOptimisticLock.
+	Update(ctx context.Context, f domain.Fulfillment) error
+	// Find returns the row by its own id, ErrNotFound if missing.
+	Find(ctx context.Context, id string) (domain.Fulfillment, error)
+	// FindByOrder returns the row keyed by order id, ErrNotFound
+	// if there is no fulfillment for the order yet.
+	FindByOrder(ctx context.Context, orderID string) (domain.Fulfillment, error)
+	// ListAll returns every fulfillment, newest-scheduled first.
+	// Used by admin / reporting surfaces.
+	ListAll(ctx context.Context) ([]domain.Fulfillment, error)
+}
+
+// EventPublisher is the seam onto which the service drains pending
+// domain events translated into integration events. The composition
+// root wires it to the in-process eventbus.Bus; tests can substitute a
+// recording publisher.
+type EventPublisher interface {
+	Publish(ctx context.Context, e eventbus.Event)
+}
+
+// nopPublisher is the default when no publisher is supplied —
+// keeps the service constructible in tests that don't care about the
+// outbound bus.
+type nopPublisher struct{}
+
+func (nopPublisher) Publish(context.Context, eventbus.Event) {}
+
+// StockReleaser is the seam onto which the refund flow releases stock
+// previously reserved at checkout time. The composition root wires it
+// to the productcatalog stock adapter — same port the checkout
+// context used to call directly before the refund flow moved here.
+// A nil StockReleaser disables the release (matches tests that don't
+// wire a catalogue at all).
+type StockReleaser interface {
+	Release(ctx context.Context, quantities map[string]int) error
+}
+
+type nopReleaser struct{}
+
+func (nopReleaser) Release(context.Context, map[string]int) error { return nil }
+
+// OrderLineSource is the seam the service uses at refund time to
+// discover which variants and quantities belong to the order being
+// refunded. Implemented by checkout's query side
+// (HasPurchasedProduct's sibling — see the adapter wired in cmd/web).
+// A nil source disables the release call (best-effort, matches the
+// historical behaviour where checkout knew the lines itself).
+type OrderLineSource interface {
+	OrderQuantities(ctx context.Context, orderID string) (map[string]int, error)
+}
+
+// Service is the application facade. Methods follow the same shape:
+//
+//  1. load the record (or no-op if missing for OnOrderPaid)
+//  2. apply the domain command
+//  3. save (Create / Update)
+//  4. publish pending events
+type Service struct {
+	storage   Storage
+	publisher EventPublisher
+	stock     StockReleaser
+	lines     OrderLineSource
+	now       func() time.Time
+	newID     func() string
+}
+
+// NewService wires the service against its storage adapter. Optional
+// dependencies (publisher, stock releaser, line source, clock, id
+// generator) are set via With… methods on the returned value.
+func NewService(storage Storage) *Service {
+	return &Service{
+		storage:   storage,
+		publisher: nopPublisher{},
+		stock:     nopReleaser{},
+		now:       func() time.Time { return time.Now().UTC() },
+		newID:     newRandomID,
+	}
+}
+
+// WithPublisher wires an integration event publisher (the in-process
+// bus in production).
+func (s *Service) WithPublisher(p EventPublisher) *Service {
+	if p == nil {
+		p = nopPublisher{}
+	}
+	s.publisher = p
+	return s
+}
+
+// WithStockReleaser wires the productcatalog stock port so Refund can
+// return reserved units to the catalogue.
+func (s *Service) WithStockReleaser(r StockReleaser) *Service {
+	if r == nil {
+		r = nopReleaser{}
+	}
+	s.stock = r
+	return s
+}
+
+// WithOrderLines wires the seam onto which Refund discovers the
+// order's quantities. Without it the stock release on refund is a
+// best-effort no-op.
+func (s *Service) WithOrderLines(src OrderLineSource) *Service {
+	s.lines = src
+	return s
+}
+
+// WithClock overrides the time source — used by tests to pin
+// transition timestamps.
+func (s *Service) WithClock(now func() time.Time) *Service {
+	s.now = now
+	return s
+}
+
+// WithIDGenerator overrides the id generator so tests can use
+// predictable ids.
+func (s *Service) WithIDGenerator(newID func() string) *Service {
+	s.newID = newID
+	return s
+}
+
+// OnOrderPaid is the subscriber the composition root binds to the
+// checkout context's OrderPaid integration event. It spawns a new
+// Fulfillment in StatusScheduled and publishes
+// FulfillmentScheduled-derived events (none today; the integration
+// surface is shipped/delivered/refunded only).
+//
+// IDEMPOTENT. The transactional outbox delivers OrderPaid
+// at-least-once: a duplicate publish (process crash between dispatch
+// and mark-sent) MUST be a no-op. We check FindByOrder first and
+// silently return nil when a record already exists — Create's unique
+// constraint is the belt-and-braces second check.
+func (s *Service) OnOrderPaid(ctx context.Context, orderID string, at time.Time) error {
+	if orderID == "" {
+		return errors.New("fulfillment: empty order id")
+	}
+	existing, err := s.storage.FindByOrder(ctx, orderID)
+	if err != nil && !errors.Is(err, ErrNotFound) {
+		return fmt.Errorf("fulfillment: find by order: %w", err)
+	}
+	if err == nil {
+		// Duplicate delivery from the outbox — silently no-op so
+		// subscribers stay safe under at-least-once.
+		_ = existing
+		return nil
+	}
+
+	f := domain.NewFulfillment(s.newID(), orderID, at)
+	if err := s.storage.Create(ctx, f); err != nil {
+		// Lost a race against another concurrent delivery — also
+		// no-op so we don't fail the bus handler.
+		if errors.Is(err, domain.ErrAlreadyExists) {
+			return nil
+		}
+		return fmt.Errorf("fulfillment: create: %w", err)
+	}
+	s.publishPending(ctx, &f)
+	return nil
+}
+
+// Label records the carrier + tracking code on a scheduled
+// fulfillment. The admin's "ship" form runs Label + Ship back-to-back
+// — keep them separate so the state machine can grow a "labeled but
+// not shipped" pause in future without changing the command surface.
+func (s *Service) Label(ctx context.Context, orderID, carrier, trackingCode string) error {
+	return s.transition(ctx, orderID, func(f *domain.Fulfillment) error {
+		return f.Label(carrier, trackingCode, s.now())
+	})
+}
+
+// Ship marks a labeled fulfillment shipped. Emits the
+// fulfillment.OrderShipped integration event.
+func (s *Service) Ship(ctx context.Context, orderID string) error {
+	return s.transition(ctx, orderID, func(f *domain.Fulfillment) error {
+		return f.Ship(s.now())
+	})
+}
+
+// Deliver marks a shipped fulfillment delivered. Emits
+// fulfillment.OrderDelivered.
+func (s *Service) Deliver(ctx context.Context, orderID string) error {
+	return s.transition(ctx, orderID, func(f *domain.Fulfillment) error {
+		return f.Deliver(s.now())
+	})
+}
+
+// Refund transitions any active fulfillment to refunded and releases
+// the reserved stock back to the catalogue. The stock-release path
+// mirrors the historical checkout.Refund flow (which used to live on
+// the checkout service); moving it here keeps the operational concern
+// inside the operational context.
+func (s *Service) Refund(ctx context.Context, orderID, reason string) error {
+	if err := s.transition(ctx, orderID, func(f *domain.Fulfillment) error {
+		return f.Refund(reason, s.now())
+	}); err != nil {
+		return err
+	}
+	s.releaseStock(ctx, orderID)
+	return nil
+}
+
+// ByOrder returns the current fulfillment for the given order id.
+// Powers the admin / customer order pages.
+func (s *Service) ByOrder(ctx context.Context, orderID string) (domain.Fulfillment, error) {
+	if orderID == "" {
+		return domain.Fulfillment{}, ErrNotFound
+	}
+	return s.storage.FindByOrder(ctx, orderID)
+}
+
+// transition loads the row by orderID, applies the supplied command,
+// persists the update, and drains pending events onto the publisher.
+// Used by Label / Ship / Deliver / Refund.
+func (s *Service) transition(ctx context.Context, orderID string, cmd func(*domain.Fulfillment) error) error {
+	f, err := s.storage.FindByOrder(ctx, orderID)
+	if err != nil {
+		return err
+	}
+	if err := cmd(&f); err != nil {
+		return err
+	}
+	if err := s.storage.Update(ctx, f); err != nil {
+		return fmt.Errorf("fulfillment: update: %w", err)
+	}
+	s.publishPending(ctx, &f)
+	return nil
+}
+
+// publishPending translates each pending domain event into the
+// matching integration event and pushes it onto the bus. Failures are
+// logged by the bus (which our caller wires); the publisher itself is
+// fire-and-forget so we don't gate the command success on a downstream
+// consumer.
+func (s *Service) publishPending(ctx context.Context, f *domain.Fulfillment) {
+	for _, e := range f.PendingEvents() {
+		switch ev := e.(type) {
+		case domain.FulfillmentShipped:
+			// Pull the carrier+tracking off the (already updated)
+			// value object — the domain event itself does not
+			// carry them, but the row's columns do.
+			s.publisher.Publish(ctx, integration.OrderShipped{
+				OrderID:      ev.OrderID,
+				Carrier:      f.Carrier(),
+				TrackingCode: f.TrackingCode(),
+				At:           ev.At,
+			})
+		case domain.FulfillmentDelivered:
+			s.publisher.Publish(ctx, integration.OrderDelivered{
+				OrderID: ev.OrderID,
+				At:      ev.At,
+			})
+		case domain.FulfillmentRefunded:
+			s.publisher.Publish(ctx, integration.OrderRefunded{
+				OrderID: ev.OrderID,
+				Reason:  ev.Reason,
+				At:      ev.At,
+			})
+		default:
+			// FulfillmentScheduled / FulfillmentLabeled are
+			// internal-only: no integration event today.
+		}
+	}
+	f.ClearPending()
+}
+
+// releaseStock pulls the order's quantities from the configured
+// OrderLineSource and hands them to the StockReleaser. Both seams are
+// optional — when either is nil the call is a no-op so the service
+// stays constructible in test setups that don't wire a catalogue.
+func (s *Service) releaseStock(ctx context.Context, orderID string) {
+	if s.lines == nil {
+		return
+	}
+	qty, err := s.lines.OrderQuantities(ctx, orderID)
+	if err != nil || len(qty) == 0 {
+		return
+	}
+	_ = s.stock.Release(ctx, qty)
+}
+
+// newRandomID returns a 16-byte hex string prefixed with "ful-". Lib-
+// free for the same reason the reviews context's id generator is:
+// avoid a UUID dep just for this.
+func newRandomID() string {
+	buf := make([]byte, 16)
+	if _, err := rand.Read(buf); err != nil {
+		return fmt.Sprintf("ful-%d", time.Now().UnixNano())
+	}
+	return "ful-" + hex.EncodeToString(buf)
+}

--- a/backend/fulfillment/app/service_test.go
+++ b/backend/fulfillment/app/service_test.go
@@ -1,0 +1,296 @@
+package app_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/bkielbasa/go-ecommerce/backend/fulfillment/adapter"
+	"github.com/bkielbasa/go-ecommerce/backend/fulfillment/app"
+	"github.com/bkielbasa/go-ecommerce/backend/fulfillment/domain"
+	"github.com/bkielbasa/go-ecommerce/backend/fulfillment/integration"
+	"github.com/bkielbasa/go-ecommerce/backend/internal/eventbus"
+)
+
+// recordingPublisher captures the integration events the service
+// emits so the tests can assert both ordering and payload contents.
+type recordingPublisher struct {
+	events []eventbus.Event
+}
+
+func (r *recordingPublisher) Publish(_ context.Context, e eventbus.Event) {
+	r.events = append(r.events, e)
+}
+
+// recordingStock captures Release() arguments so tests can verify
+// the refund flow drives the productcatalog port.
+type recordingStock struct {
+	released []map[string]int
+}
+
+func (r *recordingStock) Release(_ context.Context, q map[string]int) error {
+	r.released = append(r.released, q)
+	return nil
+}
+
+// staticLines is a tiny OrderLineSource: every order maps to the
+// same quantity table.
+type staticLines struct {
+	q map[string]int
+}
+
+func (s staticLines) OrderQuantities(_ context.Context, _ string) (map[string]int, error) {
+	return s.q, nil
+}
+
+// newServiceFixture builds a service backed by the in-memory adapter
+// with a deterministic clock and id generator so assertions are
+// stable.
+func newServiceFixture(t *testing.T) (*app.Service, *adapter.InMemory, *recordingPublisher) {
+	t.Helper()
+	storage := adapter.NewInMemory()
+	pub := &recordingPublisher{}
+	srv := app.NewService(storage).
+		WithPublisher(pub).
+		WithClock(func() time.Time {
+			return time.Date(2026, 5, 27, 12, 0, 0, 0, time.UTC)
+		}).
+		WithIDGenerator(func() string { return "ful-test-1" })
+	return srv, storage, pub
+}
+
+func TestOnOrderPaid_CreatesScheduledFulfillment(t *testing.T) {
+	srv, storage, pub := newServiceFixture(t)
+	ctx := context.Background()
+
+	if err := srv.OnOrderPaid(ctx, "ord-1", time.Now()); err != nil {
+		t.Fatalf("OnOrderPaid: %v", err)
+	}
+	f, err := storage.FindByOrder(ctx, "ord-1")
+	if err != nil {
+		t.Fatalf("FindByOrder: %v", err)
+	}
+	if f.Status() != domain.StatusScheduled {
+		t.Errorf("status = %q, want scheduled", f.Status())
+	}
+	if f.ID() != "ful-test-1" {
+		t.Errorf("id = %q, want ful-test-1", f.ID())
+	}
+	// FulfillmentScheduled is internal-only and not published.
+	if len(pub.events) != 0 {
+		t.Errorf("unexpected published events: %v", pub.events)
+	}
+}
+
+func TestOnOrderPaid_IsIdempotent(t *testing.T) {
+	srv, _, _ := newServiceFixture(t)
+	ctx := context.Background()
+
+	if err := srv.OnOrderPaid(ctx, "ord-1", time.Now()); err != nil {
+		t.Fatalf("first OnOrderPaid: %v", err)
+	}
+	// A duplicate delivery from the outbox MUST be a no-op.
+	if err := srv.OnOrderPaid(ctx, "ord-1", time.Now()); err != nil {
+		t.Errorf("second OnOrderPaid (duplicate) returned: %v", err)
+	}
+}
+
+func TestHappyPath_ScheduleLabelShipDeliver(t *testing.T) {
+	srv, _, pub := newServiceFixture(t)
+	ctx := context.Background()
+
+	if err := srv.OnOrderPaid(ctx, "ord-1", time.Now()); err != nil {
+		t.Fatalf("OnOrderPaid: %v", err)
+	}
+	if err := srv.Label(ctx, "ord-1", "UPS", "1Z-XYZ"); err != nil {
+		t.Fatalf("Label: %v", err)
+	}
+	if err := srv.Ship(ctx, "ord-1"); err != nil {
+		t.Fatalf("Ship: %v", err)
+	}
+	if err := srv.Deliver(ctx, "ord-1"); err != nil {
+		t.Fatalf("Deliver: %v", err)
+	}
+
+	got := pub.events
+	if len(got) != 2 {
+		t.Fatalf("published %d events, want 2 (Shipped, Delivered): %v", len(got), got)
+	}
+	shipped, ok := got[0].(integration.OrderShipped)
+	if !ok {
+		t.Fatalf("event[0] = %T, want OrderShipped", got[0])
+	}
+	if shipped.OrderID != "ord-1" || shipped.Carrier != "UPS" || shipped.TrackingCode != "1Z-XYZ" {
+		t.Errorf("OrderShipped = %+v, want order ord-1 / UPS / 1Z-XYZ", shipped)
+	}
+	if _, ok := got[1].(integration.OrderDelivered); !ok {
+		t.Errorf("event[1] = %T, want OrderDelivered", got[1])
+	}
+}
+
+func TestRefund_FromAnyActiveState(t *testing.T) {
+	cases := []struct {
+		name  string
+		prep  func(*testing.T, *app.Service)
+	}{
+		{
+			name: "from scheduled",
+			prep: func(t *testing.T, s *app.Service) {},
+		},
+		{
+			name: "from labeled",
+			prep: func(t *testing.T, s *app.Service) {
+				if err := s.Label(context.Background(), "ord-1", "UPS", "1Z"); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name: "from shipped",
+			prep: func(t *testing.T, s *app.Service) {
+				ctx := context.Background()
+				if err := s.Label(ctx, "ord-1", "UPS", "1Z"); err != nil {
+					t.Fatal(err)
+				}
+				if err := s.Ship(ctx, "ord-1"); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name: "from delivered",
+			prep: func(t *testing.T, s *app.Service) {
+				ctx := context.Background()
+				if err := s.Label(ctx, "ord-1", "UPS", "1Z"); err != nil {
+					t.Fatal(err)
+				}
+				if err := s.Ship(ctx, "ord-1"); err != nil {
+					t.Fatal(err)
+				}
+				if err := s.Deliver(ctx, "ord-1"); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv, storage, _ := newServiceFixture(t)
+			ctx := context.Background()
+			if err := srv.OnOrderPaid(ctx, "ord-1", time.Now()); err != nil {
+				t.Fatalf("OnOrderPaid: %v", err)
+			}
+			tc.prep(t, srv)
+			if err := srv.Refund(ctx, "ord-1", "test reason"); err != nil {
+				t.Fatalf("Refund: %v", err)
+			}
+			f, err := storage.FindByOrder(ctx, "ord-1")
+			if err != nil {
+				t.Fatalf("FindByOrder: %v", err)
+			}
+			if f.Status() != domain.StatusRefunded {
+				t.Errorf("status = %q, want refunded", f.Status())
+			}
+			if f.RefundReason() != "test reason" {
+				t.Errorf("reason = %q, want %q", f.RefundReason(), "test reason")
+			}
+		})
+	}
+}
+
+func TestRefund_ReleasesStock(t *testing.T) {
+	srv, _, _ := newServiceFixture(t)
+	stock := &recordingStock{}
+	srv.WithStockReleaser(stock).WithOrderLines(staticLines{q: map[string]int{"var-1": 2}})
+	ctx := context.Background()
+
+	if err := srv.OnOrderPaid(ctx, "ord-1", time.Now()); err != nil {
+		t.Fatalf("OnOrderPaid: %v", err)
+	}
+	if err := srv.Refund(ctx, "ord-1", "customer return"); err != nil {
+		t.Fatalf("Refund: %v", err)
+	}
+	if len(stock.released) != 1 {
+		t.Fatalf("released %d batches, want 1", len(stock.released))
+	}
+	if stock.released[0]["var-1"] != 2 {
+		t.Errorf("released[var-1] = %d, want 2", stock.released[0]["var-1"])
+	}
+}
+
+func TestRejectedTransitions(t *testing.T) {
+	cases := []struct {
+		name string
+		do   func(*app.Service) error
+	}{
+		{
+			name: "ship before label",
+			do: func(s *app.Service) error {
+				return s.Ship(context.Background(), "ord-1")
+			},
+		},
+		{
+			name: "deliver before ship",
+			do: func(s *app.Service) error {
+				return s.Deliver(context.Background(), "ord-1")
+			},
+		},
+		{
+			name: "label twice",
+			do: func(s *app.Service) error {
+				ctx := context.Background()
+				if err := s.Label(ctx, "ord-1", "UPS", "1Z"); err != nil {
+					return err
+				}
+				return s.Label(ctx, "ord-1", "FedEx", "FX")
+			},
+		},
+		{
+			name: "deliver after delivered",
+			do: func(s *app.Service) error {
+				ctx := context.Background()
+				if err := s.Label(ctx, "ord-1", "UPS", "1Z"); err != nil {
+					return err
+				}
+				if err := s.Ship(ctx, "ord-1"); err != nil {
+					return err
+				}
+				if err := s.Deliver(ctx, "ord-1"); err != nil {
+					return err
+				}
+				return s.Deliver(ctx, "ord-1")
+			},
+		},
+		{
+			name: "refund twice",
+			do: func(s *app.Service) error {
+				ctx := context.Background()
+				if err := s.Refund(ctx, "ord-1", "first"); err != nil {
+					return err
+				}
+				return s.Refund(ctx, "ord-1", "second")
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv, _, _ := newServiceFixture(t)
+			if err := srv.OnOrderPaid(context.Background(), "ord-1", time.Now()); err != nil {
+				t.Fatalf("OnOrderPaid: %v", err)
+			}
+			err := tc.do(srv)
+			if !errors.Is(err, domain.ErrInvalidTransition) {
+				t.Errorf("got %v, want ErrInvalidTransition", err)
+			}
+		})
+	}
+}
+
+func TestByOrder_NotFound(t *testing.T) {
+	srv, _, _ := newServiceFixture(t)
+	_, err := srv.ByOrder(context.Background(), "missing")
+	if !errors.Is(err, app.ErrNotFound) {
+		t.Errorf("got %v, want ErrNotFound", err)
+	}
+}

--- a/backend/fulfillment/bounded_context.go
+++ b/backend/fulfillment/bounded_context.go
@@ -1,0 +1,45 @@
+// Package fulfillment is the composition root for the fulfillment
+// (Process Manager) bounded context. It wires the Postgres storage
+// adapter and the in-process eventbus publisher into the application
+// service, and exposes both the application.BoundedContext envelope
+// and the concrete *app.Service so the layout package can declare a
+// narrow interface against its public methods without leaking the
+// storage type.
+package fulfillment
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/bkielbasa/go-ecommerce/backend/fulfillment/adapter"
+	"github.com/bkielbasa/go-ecommerce/backend/fulfillment/app"
+	"github.com/bkielbasa/go-ecommerce/backend/internal/application"
+	"github.com/bkielbasa/go-ecommerce/backend/internal/eventbus"
+)
+
+// New wires the production adapter onto the supplied *sql.DB and binds
+// the application service to the in-process bus. The returned *app
+// .Service is intentionally exposed so the composition root can call
+// the optional With… seams (stock releaser, order line source)
+// without re-importing storage types.
+func New(db *sql.DB, bus *eventbus.Bus) (application.BoundedContext, *app.Service) {
+	storage := adapter.NewPostgres(db)
+	srv := app.NewService(storage).WithPublisher(busPublisher{bus: bus})
+	return &boundedContext{}, srv
+}
+
+// busPublisher is the trivial adapter from app.EventPublisher onto the
+// eventbus.Bus's Publish signature (Publish on the bus returns no
+// error; the bus logs handler failures itself).
+type busPublisher struct {
+	bus *eventbus.Bus
+}
+
+func (p busPublisher) Publish(ctx context.Context, e eventbus.Event) {
+	if p.bus == nil {
+		return
+	}
+	p.bus.Publish(ctx, e)
+}
+
+type boundedContext struct{}

--- a/backend/fulfillment/domain/fulfillment.go
+++ b/backend/fulfillment/domain/fulfillment.go
@@ -1,0 +1,356 @@
+// Package domain is the fulfillment bounded context's heart: the
+// Fulfillment value object and the small state machine that drives it
+// through the operational lifecycle of an order (scheduled → labeled →
+// shipped → delivered, with a refund branch terminal from any active
+// state).
+//
+// PROCESS MANAGER PATTERN
+//
+// Why does this context exist at all when the checkout context's Order
+// aggregate already carries MarkShipped / MarkDelivered / Refund?
+//
+// Two different lifecycles were entangled on one aggregate:
+//
+//  1. Commercial state — pending → paid (or failed / cancelled). Owned by
+//     finance: did we ever charge the customer's card?
+//  2. Operational state — scheduled → labeled → shipped → delivered (or
+//     refunded). Owned by the warehouse: where is the box?
+//
+// Conflating both on `Order` worked for a single-team demo but it ties
+// changes to the shipping workflow to the checkout/event log, makes the
+// state machine harder to reason about (transitions and rejections are
+// status-by-status guards instead of one table), and prevents the
+// fulfillment workflow from evolving on its own cadence.
+//
+// The Fulfillment Process Manager fixes that:
+//
+//   - It is a SEPARATE bounded context (different store, different
+//     events, different ubiquitous language). The Order aggregate keeps
+//     its old methods for replay / back-compat but the admin UI no
+//     longer drives them.
+//   - It SUBSCRIBES to the published OrderPaid integration event and
+//     spawns a Fulfillment record in StatusScheduled. From there the
+//     warehouse drives it forward via Label / Ship / Deliver / Refund —
+//     each transition validated by an explicit allowed-source-state
+//     check rather than a sea of status-specific errors.
+//   - It is STATE-STORED, not event-sourced. The Order aggregate is
+//     event-sourced; the Fulfillment is a row in a table with an
+//     optimistic-concurrency `version` column. Demonstrating BOTH
+//     persistence styles inside one codebase is intentional: an
+//     event-sourced aggregate is the right call when the audit trail
+//     matters (money moved), while a state-stored aggregate is fine for
+//     a flat operational record — and the read/write code is shorter.
+//
+// Pending integration events are accumulated on the value object during
+// command execution and drained by the service layer once the row has
+// committed, so subscribers in other bounded contexts see only events
+// that actually persisted.
+package domain
+
+import (
+	"errors"
+	"time"
+)
+
+// Status is the operational stage of a Fulfillment. It is deliberately
+// distinct from checkout/domain.Status (which carries the commercial
+// state); the two state machines run in parallel.
+type Status string
+
+const (
+	// StatusScheduled is the initial state: OnOrderPaid has just
+	// created the record but the warehouse hasn't touched it yet.
+	StatusScheduled Status = "scheduled"
+	// StatusLabeled means a shipping label has been printed and the
+	// carrier + tracking code recorded — the parcel exists but
+	// hasn't been collected by the carrier yet.
+	StatusLabeled Status = "labeled"
+	// StatusShipped means the carrier has accepted the parcel.
+	StatusShipped Status = "shipped"
+	// StatusDelivered is the happy-path terminal state.
+	StatusDelivered Status = "delivered"
+	// StatusReturned is reserved for the inbound return flow
+	// (parcel arrived back at the warehouse). Not driven by any
+	// command in this iteration — the column accepts it so a future
+	// "return scanned" flow doesn't need a migration.
+	StatusReturned Status = "returned"
+	// StatusRefunded is the refund-terminal state, reachable from
+	// any active (non-terminal-happy-path) state.
+	StatusRefunded Status = "refunded"
+)
+
+// ErrInvalidTransition is returned by Schedule / Label / Ship / Deliver
+// / Refund when the current status does not permit the requested
+// command (e.g. shipping an already-delivered fulfillment).
+var ErrInvalidTransition = errors.New("fulfillment: invalid state transition")
+
+// ErrAlreadyExists is returned by Schedule when invoked on a record
+// that has already been spawned for the order. OnOrderPaid uses this
+// to stay idempotent under outbox redelivery — duplicate OrderPaid
+// publishes from the at-least-once dispatcher are silently no-ops.
+var ErrAlreadyExists = errors.New("fulfillment: already exists for order")
+
+// Event is an internal domain event raised by a state transition. Each
+// event mirrors a command and carries just enough payload for the
+// service layer to translate it into an integration event for other
+// bounded contexts. Events on this aggregate are NOT persisted (the
+// Fulfillment is state-stored, not event-sourced); they exist purely
+// as the in-flight bridge to the bus.
+type Event interface {
+	eventMarker()
+}
+
+// FulfillmentScheduled is raised by Schedule.
+type FulfillmentScheduled struct {
+	ID      string
+	OrderID string
+	At      time.Time
+}
+
+func (FulfillmentScheduled) eventMarker() {}
+
+// FulfillmentLabeled is raised by Label.
+type FulfillmentLabeled struct {
+	ID           string
+	OrderID      string
+	Carrier      string
+	TrackingCode string
+	At           time.Time
+}
+
+func (FulfillmentLabeled) eventMarker() {}
+
+// FulfillmentShipped is raised by Ship.
+type FulfillmentShipped struct {
+	ID      string
+	OrderID string
+	At      time.Time
+}
+
+func (FulfillmentShipped) eventMarker() {}
+
+// FulfillmentDelivered is raised by Deliver.
+type FulfillmentDelivered struct {
+	ID      string
+	OrderID string
+	At      time.Time
+}
+
+func (FulfillmentDelivered) eventMarker() {}
+
+// FulfillmentRefunded is raised by Refund.
+type FulfillmentRefunded struct {
+	ID      string
+	OrderID string
+	Reason  string
+	At      time.Time
+}
+
+func (FulfillmentRefunded) eventMarker() {}
+
+// Fulfillment is the state-stored aggregate root for one shipment.
+// Construct fresh records via NewFulfillment / Schedule; rebuild
+// existing rows via Rebuild. The value object is immutable in spirit:
+// the command methods mutate the receiver only after validating the
+// transition.
+type Fulfillment struct {
+	id           string
+	orderID      string
+	status       Status
+	carrier      string
+	trackingCode string
+	scheduledAt  time.Time
+	shippedAt    time.Time
+	deliveredAt  time.Time
+	refundReason string
+	version      int
+
+	pendingEvents []Event
+}
+
+// NewFulfillment constructs a fresh, unsaved Fulfillment in the
+// StatusScheduled state and raises FulfillmentScheduled. Used by the
+// service's OnOrderPaid handler — most callers should go through
+// Schedule, which is a thin wrapper that takes the same arguments and
+// makes the call site read like the rest of the command surface.
+func NewFulfillment(id, orderID string, at time.Time) Fulfillment {
+	f := Fulfillment{
+		id:          id,
+		orderID:     orderID,
+		status:      StatusScheduled,
+		scheduledAt: at,
+		version:     1,
+	}
+	f.pendingEvents = append(f.pendingEvents, FulfillmentScheduled{
+		ID:      id,
+		OrderID: orderID,
+		At:      at,
+	})
+	return f
+}
+
+// Rebuild reconstructs a Fulfillment from a storage row. No events are
+// raised — this is purely for reading a persisted record back into
+// memory.
+func Rebuild(
+	id, orderID string,
+	status Status,
+	carrier, trackingCode string,
+	scheduledAt, shippedAt, deliveredAt time.Time,
+	refundReason string,
+	version int,
+) Fulfillment {
+	return Fulfillment{
+		id:           id,
+		orderID:      orderID,
+		status:       status,
+		carrier:      carrier,
+		trackingCode: trackingCode,
+		scheduledAt:  scheduledAt,
+		shippedAt:    shippedAt,
+		deliveredAt:  deliveredAt,
+		refundReason: refundReason,
+		version:      version,
+	}
+}
+
+// ID returns the record's stable identifier (separate from OrderID so a
+// single order could in principle spawn multiple fulfillments — split
+// shipments — without changing the type).
+func (f Fulfillment) ID() string { return f.id }
+
+// OrderID returns the checkout order id this fulfillment belongs to.
+func (f Fulfillment) OrderID() string { return f.orderID }
+
+// Status returns the current operational stage.
+func (f Fulfillment) Status() Status { return f.status }
+
+// Carrier is the chosen carrier label (e.g. "UPS"). Empty until Label
+// runs.
+func (f Fulfillment) Carrier() string { return f.carrier }
+
+// TrackingCode is the carrier's tracking number. Empty until Label
+// runs.
+func (f Fulfillment) TrackingCode() string { return f.trackingCode }
+
+// ScheduledAt is when the record was first created (OnOrderPaid).
+func (f Fulfillment) ScheduledAt() time.Time { return f.scheduledAt }
+
+// ShippedAt is when Ship was applied; zero time when not yet shipped.
+func (f Fulfillment) ShippedAt() time.Time { return f.shippedAt }
+
+// DeliveredAt is when Deliver was applied; zero time when not yet
+// delivered.
+func (f Fulfillment) DeliveredAt() time.Time { return f.deliveredAt }
+
+// RefundReason is the operator-supplied reason recorded by Refund.
+func (f Fulfillment) RefundReason() string { return f.refundReason }
+
+// Version is the optimistic-concurrency counter incremented on every
+// successful transition. Storage UPDATEs match on the expected
+// version; a mismatch returns ErrOptimisticLock from the adapter so
+// callers can retry against a fresh load.
+func (f Fulfillment) Version() int { return f.version }
+
+// PendingEvents returns the events raised by command methods since the
+// record was loaded (or constructed). The service drains these after a
+// successful save and publishes them on the integration bus.
+func (f Fulfillment) PendingEvents() []Event { return f.pendingEvents }
+
+// ClearPending discards any uncommitted events. Called by the service
+// once they've been handed off to the publisher.
+func (f *Fulfillment) ClearPending() { f.pendingEvents = nil }
+
+// Schedule is the constructor-style command paired with NewFulfillment
+// — included so the command surface reads symmetrically with the rest
+// (Label / Ship / Deliver / Refund all live on the value). Returns
+// ErrAlreadyExists when called on a non-zero receiver.
+func (f *Fulfillment) Schedule(orderID string, at time.Time) error {
+	if f.status != "" {
+		return ErrAlreadyExists
+	}
+	*f = NewFulfillment(f.id, orderID, at)
+	return nil
+}
+
+// Label records the carrier + tracking code and transitions the
+// record from StatusScheduled to StatusLabeled. Empty carrier or
+// trackingCode are accepted by the domain (the adapter persists them
+// verbatim); enforcing minimum content is the service / HTTP layer's
+// job.
+func (f *Fulfillment) Label(carrier, trackingCode string, at time.Time) error {
+	if f.status != StatusScheduled {
+		return ErrInvalidTransition
+	}
+	f.carrier = carrier
+	f.trackingCode = trackingCode
+	f.status = StatusLabeled
+	f.version++
+	f.pendingEvents = append(f.pendingEvents, FulfillmentLabeled{
+		ID:           f.id,
+		OrderID:      f.orderID,
+		Carrier:      carrier,
+		TrackingCode: trackingCode,
+		At:           at,
+	})
+	return nil
+}
+
+// Ship transitions a labeled record to StatusShipped. The carrier
+// MUST have been recorded first (i.e. Label must have run).
+func (f *Fulfillment) Ship(at time.Time) error {
+	if f.status != StatusLabeled {
+		return ErrInvalidTransition
+	}
+	f.status = StatusShipped
+	f.shippedAt = at
+	f.version++
+	f.pendingEvents = append(f.pendingEvents, FulfillmentShipped{
+		ID:      f.id,
+		OrderID: f.orderID,
+		At:      at,
+	})
+	return nil
+}
+
+// Deliver transitions a shipped record to StatusDelivered (the
+// happy-path terminal state).
+func (f *Fulfillment) Deliver(at time.Time) error {
+	if f.status != StatusShipped {
+		return ErrInvalidTransition
+	}
+	f.status = StatusDelivered
+	f.deliveredAt = at
+	f.version++
+	f.pendingEvents = append(f.pendingEvents, FulfillmentDelivered{
+		ID:      f.id,
+		OrderID: f.orderID,
+		At:      at,
+	})
+	return nil
+}
+
+// Refund transitions any active state (scheduled / labeled / shipped /
+// delivered) to StatusRefunded. The refund branch is reachable from
+// every non-terminal active state because a refund can be issued at
+// any point in the lifecycle: before the label is printed, after the
+// parcel ships, or after delivery. Already-refunded fulfillments
+// reject the second call so the integration event isn't double-fired.
+func (f *Fulfillment) Refund(reason string, at time.Time) error {
+	switch f.status {
+	case StatusScheduled, StatusLabeled, StatusShipped, StatusDelivered:
+		// allowed
+	default:
+		return ErrInvalidTransition
+	}
+	f.status = StatusRefunded
+	f.refundReason = reason
+	f.version++
+	f.pendingEvents = append(f.pendingEvents, FulfillmentRefunded{
+		ID:      f.id,
+		OrderID: f.orderID,
+		Reason:  reason,
+		At:      at,
+	})
+	return nil
+}

--- a/backend/fulfillment/integration/events.go
+++ b/backend/fulfillment/integration/events.go
@@ -1,0 +1,48 @@
+// Package integration holds the fulfillment context's published
+// language: the integration events other bounded contexts may
+// subscribe to. They are deliberately distinct from the internal
+// fulfillment/domain events (which are an in-memory bridge to the bus
+// only). The names are prefixed with "fulfillment." so they cannot
+// collide with the checkout context's existing OrderShipped /
+// OrderDelivered / OrderRefunded domain events (which live in
+// checkout/domain and continue to be written to the event log for
+// replay).
+//
+// Other contexts (e.g. a future email-on-shipment subscriber) wire
+// onto these names without depending on checkout.
+package integration
+
+import "time"
+
+// OrderShipped is published when a fulfillment transitions to
+// shipped. Carrier + TrackingCode mirror what was recorded by Label.
+type OrderShipped struct {
+	OrderID      string
+	Carrier      string
+	TrackingCode string
+	At           time.Time
+}
+
+// EventName returns the wire name used by the outbox decoder / bus
+// subscribers. The "fulfillment." prefix makes the publishing context
+// obvious from the name alone.
+func (OrderShipped) EventName() string { return "fulfillment.OrderShipped" }
+
+// OrderDelivered is published when a fulfillment reaches the delivered
+// terminal state.
+type OrderDelivered struct {
+	OrderID string
+	At      time.Time
+}
+
+func (OrderDelivered) EventName() string { return "fulfillment.OrderDelivered" }
+
+// OrderRefunded is published when a fulfillment is refunded. Reason
+// is the operator-supplied note recorded at refund time.
+type OrderRefunded struct {
+	OrderID string
+	Reason  string
+	At      time.Time
+}
+
+func (OrderRefunded) EventName() string { return "fulfillment.OrderRefunded" }

--- a/backend/layout/bounded_context.go
+++ b/backend/layout/bounded_context.go
@@ -3,11 +3,13 @@ package layout
 import (
 	"context"
 	_ "embed"
+	"time"
 
 	authDomain "github.com/bkielbasa/go-ecommerce/backend/auth/domain"
 	"github.com/bkielbasa/go-ecommerce/backend/cart/domain"
 	checkoutDomain "github.com/bkielbasa/go-ecommerce/backend/checkout/domain"
 	checkoutQuery "github.com/bkielbasa/go-ecommerce/backend/checkout/query"
+	fulfillmentDomain "github.com/bkielbasa/go-ecommerce/backend/fulfillment/domain"
 	"github.com/bkielbasa/go-ecommerce/backend/internal/application"
 	"github.com/bkielbasa/go-ecommerce/backend/internal/fx"
 	"github.com/bkielbasa/go-ecommerce/backend/internal/imagestore"
@@ -95,13 +97,29 @@ type shippingService interface {
 }
 
 // checkoutCommands is the write side of the checkout context (CQRS).
+// MarkShipped / MarkDelivered / Refund used to live here too; they
+// moved to the fulfillment Process Manager (fulfillmentService below)
+// because shipping/delivery/refund are operational concerns, not
+// commercial ones. The Order aggregate's matching methods stay on the
+// domain for replay/back-compat but the admin UI no longer drives them
+// directly.
 type checkoutCommands interface {
 	Place(ctx context.Context, sessID, customerID, cardNumber string, shipTo checkoutDomain.Address, shipMethod checkoutDomain.ShippingMethod, payMethod checkoutDomain.PaymentMethod, discount promodomain.Discount) (checkoutDomain.Order, error)
 	Cancel(ctx context.Context, orderID, customerID string) error
 	AdminCancel(ctx context.Context, orderID string) error
-	MarkShipped(ctx context.Context, orderID, carrier, trackingCode string) error
-	MarkDelivered(ctx context.Context, orderID string) error
+}
+
+// fulfillmentService is the narrow seam onto the fulfillment Process
+// Manager. The admin's "ship/deliver/refund" controls drive it
+// directly; the customer order page reads ByOrder to render the
+// fulfillment summary alongside the commercial status.
+type fulfillmentService interface {
+	OnOrderPaid(ctx context.Context, orderID string, at time.Time) error
+	Label(ctx context.Context, orderID, carrier, trackingCode string) error
+	Ship(ctx context.Context, orderID string) error
+	Deliver(ctx context.Context, orderID string) error
 	Refund(ctx context.Context, orderID, reason string) error
+	ByOrder(ctx context.Context, orderID string) (fulfillmentDomain.Fulfillment, error)
 }
 
 // promoService is the narrow seam the layout package needs from the
@@ -187,27 +205,28 @@ type checkoutQueries interface {
 // csrfEnabled toggles the request-level CSRF check; production always wants
 // true, and only local debugging should ever flip it to false (see
 // cmd/web/config.go CSRFEnabled for the operator-facing knob).
-func New(logger logrus.FieldLogger, cartSrv cartService, catalogSrv catalogService, authSrv authService, checkoutSrv checkoutCommands, checkoutQry checkoutQueries, shipSrv shippingService, reviewsSrv reviewsService, wishlistSrv wishlistService, promoSrv promoService, searchSrv searchService, storeSrv storeService, imageStore imagestore.Store, uploadsDir string, sessionSecret []byte, cookieSecure, csrfEnabled bool, mailerSrv mailer.Mailer, baseURL string, rates fx.Rates) application.BoundedContext {
+func New(logger logrus.FieldLogger, cartSrv cartService, catalogSrv catalogService, authSrv authService, checkoutSrv checkoutCommands, checkoutQry checkoutQueries, fulfillmentSrv fulfillmentService, shipSrv shippingService, reviewsSrv reviewsService, wishlistSrv wishlistService, promoSrv promoService, searchSrv searchService, storeSrv storeService, imageStore imagestore.Store, uploadsDir string, sessionSecret []byte, cookieSecure, csrfEnabled bool, mailerSrv mailer.Mailer, baseURL string, rates fx.Rates) application.BoundedContext {
 	store = newCookieStore(sessionSecret, cookieSecure)
 	setCSRFEnabled(csrfEnabled)
 	return &boundedContext{
 		handler: httpHandler{
-			cartSrv:     cartSrv,
-			catalogSrv:  catalogSrv,
-			authSrv:     authSrv,
-			checkoutSrv: checkoutSrv,
-			checkoutQry: checkoutQry,
-			shipSrv:     shipSrv,
-			reviewsSrv:  reviewsSrv,
-			wishlistSrv: wishlistSrv,
-			promoSrv:    promoSrv,
-			searchSrv:   searchSrv,
-			storeSrv:    storeSrv,
-			imageStore:  imageStore,
-			mailer:      mailerSrv,
-			baseURL:     baseURL,
-			rates:       rates,
-			logger:      logger,
+			cartSrv:        cartSrv,
+			catalogSrv:     catalogSrv,
+			authSrv:        authSrv,
+			checkoutSrv:    checkoutSrv,
+			checkoutQry:    checkoutQry,
+			fulfillmentSrv: fulfillmentSrv,
+			shipSrv:        shipSrv,
+			reviewsSrv:     reviewsSrv,
+			wishlistSrv:    wishlistSrv,
+			promoSrv:       promoSrv,
+			searchSrv:      searchSrv,
+			storeSrv:       storeSrv,
+			imageStore:     imageStore,
+			mailer:         mailerSrv,
+			baseURL:        baseURL,
+			rates:          rates,
+			logger:         logger,
 		},
 		uploadsDir: uploadsDir,
 		logger:     logger,

--- a/backend/layout/http.go
+++ b/backend/layout/http.go
@@ -41,20 +41,21 @@ func newCookieStore(key []byte, secure bool) *sessions.CookieStore {
 }
 
 type httpHandler struct {
-	cartSrv     cartService
-	catalogSrv  catalogService
-	authSrv     authService
-	checkoutSrv checkoutCommands
-	checkoutQry checkoutQueries
-	shipSrv     shippingService
-	reviewsSrv  reviewsService
-	wishlistSrv wishlistService
-	promoSrv    promoService
-	searchSrv   searchService
-	storeSrv    storeService
-	imageStore  imagestore.Store
-	mailer      mailer.Mailer
-	baseURL     string
+	cartSrv        cartService
+	catalogSrv     catalogService
+	authSrv        authService
+	checkoutSrv    checkoutCommands
+	checkoutQry    checkoutQueries
+	fulfillmentSrv fulfillmentService
+	shipSrv        shippingService
+	reviewsSrv     reviewsService
+	wishlistSrv    wishlistService
+	promoSrv       promoService
+	searchSrv      searchService
+	storeSrv       storeService
+	imageStore     imagestore.Store
+	mailer         mailer.Mailer
+	baseURL        string
 	// rates is the static, operator-configured FX table. It is shared
 	// across every render through the `money` template helper. The
 	// active currency comes from the request-bound store, but the

--- a/backend/layout/http_admin_orders.go
+++ b/backend/layout/http_admin_orders.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 
 	checkoutDomain "github.com/bkielbasa/go-ecommerce/backend/checkout/domain"
+	fulfillmentApp "github.com/bkielbasa/go-ecommerce/backend/fulfillment/app"
+	fulfillmentDomain "github.com/bkielbasa/go-ecommerce/backend/fulfillment/domain"
 	"github.com/bkielbasa/go-ecommerce/backend/internal/https"
 	"github.com/gorilla/mux"
 )
@@ -29,9 +31,11 @@ func (handler httpHandler) AdminOrders(w http.ResponseWriter, r *http.Request) {
 }
 
 // AdminOrderDetail renders a single order's detail with the admin
-// fulfillment controls — buttons appropriate to the order's current status
-// (cancel/ship for paid, mark-delivered for shipped, refund for any paid
-// or fulfilled order).
+// fulfillment controls — buttons appropriate to the fulfillment's
+// current operational status (ship for scheduled, deliver for shipped,
+// refund for any active state). Commercial state (paid / cancelled)
+// comes from the order; operational state comes from the fulfillment
+// record (which is spawned by the OnOrderPaid subscriber).
 func (handler httpHandler) AdminOrderDetail(w http.ResponseWriter, r *http.Request) {
 	email, ok := handler.requireAdmin(w, r)
 	if !ok {
@@ -47,18 +51,47 @@ func (handler httpHandler) AdminOrderDetail(w http.ResponseWriter, r *http.Reque
 		https.InternalError(w, "internal-error", err.Error())
 		return
 	}
-	status := order.Status()
-	canRefund := status == checkoutDomain.StatusPaid ||
-		status == checkoutDomain.StatusShipped ||
-		status == checkoutDomain.StatusDelivered
+
+	// Fulfillment is spawned by the OnOrderPaid subscriber; for orders
+	// that never paid (pending / failed / cancelled) there is no row
+	// yet, which is fine — the template renders the operational
+	// section conditionally.
+	var (
+		fulfillment    fulfillmentDomain.Fulfillment
+		hasFulfillment bool
+	)
+	if handler.fulfillmentSrv != nil {
+		ff, ferr := handler.fulfillmentSrv.ByOrder(r.Context(), orderID)
+		switch {
+		case errors.Is(ferr, fulfillmentApp.ErrNotFound):
+			// not paid yet / process manager hasn't reacted yet
+		case ferr != nil:
+			https.InternalError(w, "internal-error", ferr.Error())
+			return
+		default:
+			fulfillment = ff
+			hasFulfillment = true
+		}
+	}
+
+	commercial := order.Status()
+	canCancel := commercial == checkoutDomain.StatusPaid && !hasFulfillment
+	// Once a fulfillment exists, ship/deliver/refund are gated on its
+	// operational status rather than the order's commercial status.
+	canShip := hasFulfillment && fulfillment.Status() == fulfillmentDomain.StatusScheduled
+	canDeliver := hasFulfillment && fulfillment.Status() == fulfillmentDomain.StatusShipped
+	canRefund := hasFulfillment && fulfillment.Status() != fulfillmentDomain.StatusRefunded &&
+		fulfillment.Status() != fulfillmentDomain.StatusReturned
 	handler.renderAdminTemplate(w, r, "admin/order_detail", map[string]any{
-		"Active":       "orders",
-		"Email":        email,
-		"Order":        order,
-		"CanCancel":    status == checkoutDomain.StatusPaid,
-		"CanShip":      status == checkoutDomain.StatusPaid,
-		"CanDeliver":   status == checkoutDomain.StatusShipped,
-		"CanRefund":    canRefund,
+		"Active":         "orders",
+		"Email":          email,
+		"Order":          order,
+		"Fulfillment":    fulfillment,
+		"HasFulfillment": hasFulfillment,
+		"CanCancel":      canCancel,
+		"CanShip":        canShip,
+		"CanDeliver":     canDeliver,
+		"CanRefund":      canRefund,
 	})
 }
 
@@ -85,8 +118,12 @@ func (handler httpHandler) AdminCancelOrder(w http.ResponseWriter, r *http.Reque
 	http.Redirect(w, r, "/admin/orders/"+orderID, http.StatusSeeOther)
 }
 
-// AdminShipOrder marks a paid order as shipped, optionally recording the
-// carrier and tracking code submitted on the form.
+// AdminShipOrder drives the fulfillment Process Manager: it records
+// the carrier + tracking code on the scheduled fulfillment (Label)
+// and then transitions it to shipped (Ship). Two calls back-to-back
+// because the underlying state machine keeps Label and Ship distinct
+// — a future "labeled but not yet handed to carrier" pause can land
+// without changing this handler shape.
 func (handler httpHandler) AdminShipOrder(w http.ResponseWriter, r *http.Request) {
 	if _, ok := handler.requireAdmin(w, r); !ok {
 		return
@@ -98,36 +135,48 @@ func (handler httpHandler) AdminShipOrder(w http.ResponseWriter, r *http.Request
 	orderID := mux.Vars(r)["orderID"]
 	carrier := r.FormValue("carrier")
 	tracking := r.FormValue("tracking_code")
-	err := handler.checkoutSrv.MarkShipped(r.Context(), orderID, carrier, tracking)
-	switch {
-	case errors.Is(err, checkoutDomain.ErrOrderNotFound):
-		handler.flash(w, r, "Order not found.", "error")
-		http.Redirect(w, r, "/admin/orders", http.StatusSeeOther)
-		return
-	case errors.Is(err, checkoutDomain.ErrOrderNotShippable):
-		handler.flash(w, r, "This order cannot be shipped from its current status.", "error")
-	case err != nil:
-		https.InternalError(w, "internal-error", err.Error())
-		return
-	default:
+	if err := handler.fulfillmentSrv.Label(r.Context(), orderID, carrier, tracking); err != nil {
+		switch {
+		case errors.Is(err, fulfillmentApp.ErrNotFound):
+			handler.flash(w, r, "Fulfillment not found for this order.", "error")
+			http.Redirect(w, r, "/admin/orders/"+orderID, http.StatusSeeOther)
+			return
+		case errors.Is(err, fulfillmentDomain.ErrInvalidTransition):
+			handler.flash(w, r, "This order cannot be shipped from its current status.", "error")
+			http.Redirect(w, r, "/admin/orders/"+orderID, http.StatusSeeOther)
+			return
+		default:
+			https.InternalError(w, "internal-error", err.Error())
+			return
+		}
+	}
+	if err := handler.fulfillmentSrv.Ship(r.Context(), orderID); err != nil {
+		switch {
+		case errors.Is(err, fulfillmentDomain.ErrInvalidTransition):
+			handler.flash(w, r, "This order cannot be shipped from its current status.", "error")
+		default:
+			https.InternalError(w, "internal-error", err.Error())
+			return
+		}
+	} else {
 		handler.flash(w, r, "Order marked as shipped.", "info")
 	}
 	http.Redirect(w, r, "/admin/orders/"+orderID, http.StatusSeeOther)
 }
 
-// AdminDeliverOrder marks a shipped order as delivered.
+// AdminDeliverOrder transitions a shipped fulfillment to delivered.
 func (handler httpHandler) AdminDeliverOrder(w http.ResponseWriter, r *http.Request) {
 	if _, ok := handler.requireAdmin(w, r); !ok {
 		return
 	}
 	orderID := mux.Vars(r)["orderID"]
-	err := handler.checkoutSrv.MarkDelivered(r.Context(), orderID)
+	err := handler.fulfillmentSrv.Deliver(r.Context(), orderID)
 	switch {
-	case errors.Is(err, checkoutDomain.ErrOrderNotFound):
-		handler.flash(w, r, "Order not found.", "error")
+	case errors.Is(err, fulfillmentApp.ErrNotFound):
+		handler.flash(w, r, "Fulfillment not found for this order.", "error")
 		http.Redirect(w, r, "/admin/orders", http.StatusSeeOther)
 		return
-	case errors.Is(err, checkoutDomain.ErrOrderNotDeliverable):
+	case errors.Is(err, fulfillmentDomain.ErrInvalidTransition):
 		handler.flash(w, r, "This order cannot be marked delivered from its current status.", "error")
 	case err != nil:
 		https.InternalError(w, "internal-error", err.Error())
@@ -159,8 +208,9 @@ func (handler httpHandler) AdminInventory(w http.ResponseWriter, r *http.Request
 	})
 }
 
-// AdminRefundOrder refunds a paid/shipped/delivered order; the underlying
-// service also releases the reserved stock back to the catalogue.
+// AdminRefundOrder refunds the fulfillment for an order; the
+// fulfillment service also releases the reserved stock back to the
+// catalogue via the wired StockReleaser port.
 func (handler httpHandler) AdminRefundOrder(w http.ResponseWriter, r *http.Request) {
 	if _, ok := handler.requireAdmin(w, r); !ok {
 		return
@@ -171,13 +221,13 @@ func (handler httpHandler) AdminRefundOrder(w http.ResponseWriter, r *http.Reque
 	}
 	orderID := mux.Vars(r)["orderID"]
 	reason := r.FormValue("reason")
-	err := handler.checkoutSrv.Refund(r.Context(), orderID, reason)
+	err := handler.fulfillmentSrv.Refund(r.Context(), orderID, reason)
 	switch {
-	case errors.Is(err, checkoutDomain.ErrOrderNotFound):
-		handler.flash(w, r, "Order not found.", "error")
+	case errors.Is(err, fulfillmentApp.ErrNotFound):
+		handler.flash(w, r, "Fulfillment not found for this order.", "error")
 		http.Redirect(w, r, "/admin/orders", http.StatusSeeOther)
 		return
-	case errors.Is(err, checkoutDomain.ErrOrderNotRefundable):
+	case errors.Is(err, fulfillmentDomain.ErrInvalidTransition):
 		handler.flash(w, r, "This order cannot be refunded from its current status.", "error")
 	case err != nil:
 		https.InternalError(w, "internal-error", err.Error())

--- a/backend/layout/http_checkout.go
+++ b/backend/layout/http_checkout.go
@@ -7,6 +7,8 @@ import (
 
 	cartDomain "github.com/bkielbasa/go-ecommerce/backend/cart/domain"
 	checkoutDomain "github.com/bkielbasa/go-ecommerce/backend/checkout/domain"
+	fulfillmentApp "github.com/bkielbasa/go-ecommerce/backend/fulfillment/app"
+	fulfillmentDomain "github.com/bkielbasa/go-ecommerce/backend/fulfillment/domain"
 	"github.com/bkielbasa/go-ecommerce/backend/internal/https"
 	pcdomain "github.com/bkielbasa/go-ecommerce/backend/productcatalog/domain"
 	promoapp "github.com/bkielbasa/go-ecommerce/backend/promo/app"
@@ -198,14 +200,43 @@ func (handler httpHandler) Order(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// The owner may cancel a paid order.
+	// The owner may cancel a paid order. Cancellation is only sensible
+	// before the fulfillment Process Manager has shipped the parcel —
+	// the admin's refund flow takes over after that.
 	customerID := handler.currentCustomerID(r)
 	canCancel := order.Status() == checkoutDomain.StatusPaid &&
 		customerID != "" && order.CustomerID() == customerID
 
+	// Fulfillment summary: shown alongside the commercial status when
+	// the OnOrderPaid subscriber has spawned a record. Anonymous /
+	// unpaid orders simply have no fulfillment to display.
+	var (
+		fulfillment    fulfillmentDomain.Fulfillment
+		hasFulfillment bool
+	)
+	if handler.fulfillmentSrv != nil {
+		ff, ferr := handler.fulfillmentSrv.ByOrder(r.Context(), orderID)
+		switch {
+		case errors.Is(ferr, fulfillmentApp.ErrNotFound):
+			// not yet spawned
+		case ferr != nil:
+			handler.logger.WithError(ferr).Warn("cannot load fulfillment for order page")
+		default:
+			fulfillment = ff
+			hasFulfillment = true
+			// Once a shipment is in flight (labeled or later) the
+			// customer can no longer cancel from this page.
+			if fulfillment.Status() != fulfillmentDomain.StatusScheduled {
+				canCancel = false
+			}
+		}
+	}
+
 	handler.renderTemplate(w, r, "order/show", map[string]any{
-		"Order":     order,
-		"CanCancel": canCancel,
+		"Order":          order,
+		"Fulfillment":    fulfillment,
+		"HasFulfillment": hasFulfillment,
+		"CanCancel":      canCancel,
 	})
 }
 

--- a/backend/layout/tmpl/admin/order_detail.gohtml
+++ b/backend/layout/tmpl/admin/order_detail.gohtml
@@ -82,7 +82,31 @@
           </section>
         {{end}}
 
-        {{if or .Order.Carrier .Order.TrackingCode}}
+        {{if .HasFulfillment}}
+          <section class="order__ship">
+            <h2 class="order__ship-heading">fulfillment</h2>
+            <p>
+              status: <span class="order-status order-status--{{.Fulfillment.Status}}">{{.Fulfillment.Status}}</span>
+            </p>
+            {{if eq (printf "%s" .Fulfillment.Status) "shipped"}}
+              <p>
+                {{with .Fulfillment.Carrier}}carrier: {{.}}{{end}}
+                {{if and .Fulfillment.Carrier .Fulfillment.TrackingCode}} &middot; {{end}}
+                {{with .Fulfillment.TrackingCode}}tracking: <code>{{.}}</code>{{end}}
+              </p>
+            {{else if eq (printf "%s" .Fulfillment.Status) "delivered"}}
+              <p>
+                {{with .Fulfillment.Carrier}}carrier: {{.}} &middot; {{end}}
+                {{with .Fulfillment.TrackingCode}}tracking: <code>{{.}}</code> &middot; {{end}}
+                delivered {{.Fulfillment.DeliveredAt.Format "Jan 2, 2006 15:04 MST"}}
+              </p>
+            {{else if eq (printf "%s" .Fulfillment.Status) "refunded"}}
+              <p>
+                refunded{{with .Fulfillment.RefundReason}} &middot; reason: {{.}}{{end}}
+              </p>
+            {{end}}
+          </section>
+        {{else if or .Order.Carrier .Order.TrackingCode}}
           <section class="order__ship">
             <h2 class="order__ship-heading">fulfillment</h2>
             <p>

--- a/backend/layout/tmpl/order/show.gohtml
+++ b/backend/layout/tmpl/order/show.gohtml
@@ -105,7 +105,31 @@
       </section>
     {{end}}
 
-    {{if or (eq .Order.Status "shipped") (eq .Order.Status "delivered")}}
+    {{if .HasFulfillment}}
+      <section class="order__ship">
+        <h2 class="order__ship-heading">fulfillment</h2>
+        <p>
+          status: <span class="order-status order-status--{{.Fulfillment.Status}}">{{.Fulfillment.Status}}</span>
+        </p>
+        {{if eq (printf "%s" .Fulfillment.Status) "shipped"}}
+          <p>
+            {{with .Fulfillment.Carrier}}carrier: {{.}}{{end}}
+            {{if and .Fulfillment.Carrier .Fulfillment.TrackingCode}} &middot; {{end}}
+            {{with .Fulfillment.TrackingCode}}tracking: <code>{{.}}</code>{{end}}
+          </p>
+        {{else if eq (printf "%s" .Fulfillment.Status) "delivered"}}
+          <p>
+            {{with .Fulfillment.Carrier}}carrier: {{.}} &middot; {{end}}
+            {{with .Fulfillment.TrackingCode}}tracking: <code>{{.}}</code> &middot; {{end}}
+            delivered {{.Fulfillment.DeliveredAt.Format "Jan 2, 2006 15:04 MST"}}
+          </p>
+        {{else if eq (printf "%s" .Fulfillment.Status) "refunded"}}
+          <p>
+            refunded{{with .Fulfillment.RefundReason}} &middot; reason: {{.}}{{end}}
+          </p>
+        {{end}}
+      </section>
+    {{else if or (eq .Order.Status "shipped") (eq .Order.Status "delivered")}}
       <section class="order__ship">
         <h2 class="order__ship-heading">fulfillment</h2>
         <p>

--- a/migrations/000034_fulfillment.down.sql
+++ b/migrations/000034_fulfillment.down.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+DROP INDEX IF EXISTS fulfillment_status_idx;
+DROP TABLE IF EXISTS fulfillment;
+
+COMMIT;

--- a/migrations/000034_fulfillment.up.sql
+++ b/migrations/000034_fulfillment.up.sql
@@ -1,0 +1,32 @@
+BEGIN;
+
+-- fulfillment is the state-stored projection driven by the
+-- fulfillment bounded context (Process Manager pattern). Each row is
+-- spawned by the OnOrderPaid subscriber (one per order, enforced by
+-- the unique constraint on order_id) and advances through the
+-- operational lifecycle scheduled -> labeled -> shipped -> delivered,
+-- with a refund branch reachable from any active state. The version
+-- column drives optimistic concurrency: the adapter's UPDATE matches
+-- on the expected previous version and a mismatch surfaces as
+-- app.ErrOptimisticLock.
+--
+-- The 'returned' status value is reserved for a future inbound-return
+-- flow (parcel scanned back into the warehouse); accepting it in the
+-- CHECK constraint today means that flow can land without a follow-up
+-- migration.
+CREATE TABLE fulfillment (
+    id            text        PRIMARY KEY,
+    order_id      text        NOT NULL UNIQUE,
+    status        text        NOT NULL CHECK (status IN ('scheduled','labeled','shipped','delivered','returned','refunded')),
+    carrier       text        NOT NULL DEFAULT '',
+    tracking_code text        NOT NULL DEFAULT '',
+    scheduled_at  timestamptz,
+    shipped_at    timestamptz,
+    delivered_at  timestamptz,
+    refund_reason text        NOT NULL DEFAULT '',
+    version       int         NOT NULL DEFAULT 1
+);
+
+CREATE INDEX fulfillment_status_idx ON fulfillment(status);
+
+COMMIT;


### PR DESCRIPTION
The Order aggregate carried BOTH commercial state (paid/refunded) AND operational state (shipped/delivered) via methods/events that mixed two concerns. This PR lifts the operational workflow into a dedicated **Process Manager** that subscribes to OrderPaid (via the Outbox) and runs its own state machine.

- New **fulfillment/** bounded context (domain/app/adapter, state-stored aggregate with OCC).
  - Status: scheduled → labeled → shipped → delivered (terminal); any active → refunded (terminal).
  - Commands: Schedule / Label / Ship / Deliver / Refund, each gating allowed source states.
  - Integration events fulfillment.OrderShipped / Delivered / Refunded (distinct from checkout's legacy events).
- **Migration 000034** (will renumber if it collides with the in-flight event-versioning migration).
- **Composition root** subscribes a third OrderPaid handler that calls `fulfillmentSrv.OnOrderPaid` — idempotent (FindByOrder + no-op).
- **Admin** ship/deliver/refund handlers now route through the fulfillment service. The admin order detail page shows BOTH the order's commercial status and the fulfillment record's operational status (carrier/tracking/deliveredAt/reason).
- **CheckoutService.MarkShipped/MarkDelivered/Refund deleted** (the only callers were admin handlers). Old Order aggregate methods + events kept untouched for replay back-compat (per non-overlap constraint with the event-versioning branch).
- Refund releases stock through the same productcatalog port the old path used, wired at the composition root via a small OrderLines adapter that reads from the checkout query side.

## Test plan
- [x] build / build -tags integration / vet / tests / lint green
- [x] Service tests: each transition, each rejection, idempotent OnOrderPaid, stock release on refund