### PR TITLE
feat(checkout): event schema versioning + upcaster

### DIFF
--- a/backend/checkout/adapter/events_codec.go
+++ b/backend/checkout/adapter/events_codec.go
@@ -8,10 +8,30 @@ import (
 	"github.com/bkielbasa/go-ecommerce/backend/checkout/domain"
 )
 
-// This file is the only place that knows how checkout events are serialised
-// for the event store. Domain events stay pure; here we map them to/from
-// exported JSON DTOs and rebuild the value objects through their domain
-// constructors.
+// Event versioning + upcasting.
+//
+// Why this file exists: the checkout aggregate is event-sourced, so the event
+// log is the source of truth for every order — and the log lives forever.
+// When the domain learns a new fact (here: which sales channel an order came
+// in through), the wire shape of the affected event must evolve, but rows
+// written under the old shape still need to fold back into a working
+// aggregate. We resolve that tension with the textbook upcaster pattern:
+//
+//  1. Every row in checkout_events carries a payload_version int. Different
+//     versions can coexist in the same table.
+//  2. On load the codec dispatches on (event_type, version), unmarshals the
+//     matching DTO, and — if it isn't the latest version — runs an
+//     upcastXxxVN function that translates the old payload into the LATEST
+//     in-memory event shape (filling sensible defaults for new fields).
+//  3. domain.Order.apply only ever sees the latest event shape. All
+//     historical compatibility is contained here; the aggregate stays
+//     version-blind.
+//
+// Contract for adding new versions: bump the version returned by
+// marshalEvent for that event type, add a new orderXxxDTOvN, keep the old
+// DTO + write an upcastXxxVN that returns the v(N) domain event, and
+// extend the version switch in unmarshalEvent. Other event types are free
+// to evolve independently — their version space is local.
 
 type addressDTO struct {
 	Name    string `json:"name"`
@@ -41,7 +61,10 @@ type lineDTO struct {
 	PriceCurrency string `json:"price_currency"`
 }
 
-type orderPlacedDTO struct {
+// orderPlacedDTOv1 is the historical wire shape of OrderPlaced — kept around
+// purely so the upcaster can read rows that were written before the Channel
+// field existed. Do not extend this type: bump to a new vN instead.
+type orderPlacedDTOv1 struct {
 	OrderID        string            `json:"order_id"`
 	UserID         string            `json:"user_id"`
 	CustomerID     string            `json:"customer_id"`
@@ -55,6 +78,31 @@ type orderPlacedDTO struct {
 	DiscountAmount int64             `json:"discount_amount,omitempty"`
 	At             time.Time         `json:"at"`
 }
+
+// orderPlacedDTOv2 is the current wire shape of OrderPlaced and matches the
+// in-memory domain.OrderPlaced one-to-one. The Channel field is new in v2;
+// rows on the older shape are translated into this one by
+// upcastOrderPlacedV1.
+type orderPlacedDTOv2 struct {
+	OrderID        string            `json:"order_id"`
+	UserID         string            `json:"user_id"`
+	CustomerID     string            `json:"customer_id"`
+	ShipTo         addressDTO        `json:"ship_to"`
+	ShipMethod     shippingMethodDTO `json:"ship_method"`
+	PayMethod      paymentMethodDTO  `json:"pay_method"`
+	Lines          []lineDTO         `json:"lines"`
+	Tax            int64             `json:"tax,omitempty"`
+	ShippingCost   int64             `json:"shipping_cost,omitempty"`
+	DiscountCode   string            `json:"discount_code,omitempty"`
+	DiscountAmount int64             `json:"discount_amount,omitempty"`
+	Channel        string            `json:"channel,omitempty"`
+	At             time.Time         `json:"at"`
+}
+
+// orderPlacedLatestVersion is the only version marshalEvent will write going
+// forward. Bumping this constant + adding the matching DTO is how a new
+// schema rolls out.
+const orderPlacedLatestVersion = 2
 
 type paymentSucceededDTO struct {
 	OrderID string    `json:"order_id"`
@@ -91,9 +139,13 @@ type orderRefundedDTO struct {
 	At      time.Time `json:"at"`
 }
 
-// marshalEvent returns the stored type name and JSON payload for a domain event.
-func marshalEvent(e domain.Event) (string, []byte, error) {
+// marshalEvent returns the stored type name, payload version, and JSON
+// payload for a domain event. Every event type owns its own version space:
+// OrderPlaced is at v2 (Channel field added); the rest are still on v1
+// since they haven't evolved.
+func marshalEvent(e domain.Event) (string, int, []byte, error) {
 	var payload any
+	version := 1
 	switch ev := e.(type) {
 	case domain.OrderPlaced:
 		lines := make([]lineDTO, 0, len(ev.Lines))
@@ -106,7 +158,7 @@ func marshalEvent(e domain.Event) (string, []byte, error) {
 				PriceCurrency: l.PriceCurrency(),
 			})
 		}
-		payload = orderPlacedDTO{
+		payload = orderPlacedDTOv2{
 			OrderID:        ev.OrderID,
 			UserID:         ev.UserID,
 			CustomerID:     ev.CustomerID,
@@ -118,8 +170,10 @@ func marshalEvent(e domain.Event) (string, []byte, error) {
 			ShippingCost:   ev.ShippingCost,
 			DiscountCode:   ev.DiscountCode,
 			DiscountAmount: ev.DiscountAmount,
+			Channel:        ev.Channel,
 			At:             ev.At,
 		}
+		version = orderPlacedLatestVersion
 	case domain.PaymentSucceeded:
 		payload = paymentSucceededDTO{OrderID: ev.OrderID, At: ev.At}
 	case domain.PaymentFailed:
@@ -133,73 +187,88 @@ func marshalEvent(e domain.Event) (string, []byte, error) {
 	case domain.OrderRefunded:
 		payload = orderRefundedDTO{OrderID: ev.OrderID, Reason: ev.Reason, At: ev.At}
 	default:
-		return "", nil, fmt.Errorf("no codec for event %s", e.EventType())
+		return "", 0, nil, fmt.Errorf("no codec for event %s", e.EventType())
 	}
 
 	b, err := json.Marshal(payload)
 	if err != nil {
-		return "", nil, fmt.Errorf("marshal %s: %w", e.EventType(), err)
+		return "", 0, nil, fmt.Errorf("marshal %s: %w", e.EventType(), err)
 	}
-	return e.EventType(), b, nil
+	return e.EventType(), version, b, nil
 }
 
-// unmarshalEvent rebuilds a domain event from its stored type + payload.
-func unmarshalEvent(eventType string, payload []byte) (domain.Event, error) {
+// unmarshalEvent rebuilds a domain event from its stored type + version +
+// payload. The version switch is the single seam where historical payloads
+// re-enter the latest in-memory shape; everything past this function sees
+// only the latest domain event.
+func unmarshalEvent(eventType string, version int, payload []byte) (domain.Event, error) {
 	switch eventType {
 	case "OrderPlaced":
-		var dto orderPlacedDTO
-		if err := json.Unmarshal(payload, &dto); err != nil {
-			return nil, fmt.Errorf("unmarshal OrderPlaced: %w", err)
+		switch version {
+		case 1:
+			var v1 orderPlacedDTOv1
+			if err := json.Unmarshal(payload, &v1); err != nil {
+				return nil, fmt.Errorf("unmarshal OrderPlaced v1: %w", err)
+			}
+			return upcastOrderPlacedV1(v1), nil
+		case 2:
+			var v2 orderPlacedDTOv2
+			if err := json.Unmarshal(payload, &v2); err != nil {
+				return nil, fmt.Errorf("unmarshal OrderPlaced v2: %w", err)
+			}
+			return orderPlacedFromDTOv2(v2), nil
+		default:
+			return nil, fmt.Errorf("unknown OrderPlaced version %d", version)
 		}
-		lines := make([]domain.Line, 0, len(dto.Lines))
-		for _, l := range dto.Lines {
-			lines = append(lines, domain.NewLine(l.ProductID, l.ProductName, l.Qty, l.PriceAmount, l.PriceCurrency))
-		}
-		return domain.OrderPlaced{
-			OrderID:        dto.OrderID,
-			UserID:         dto.UserID,
-			CustomerID:     dto.CustomerID,
-			ShipTo:         domain.RebuildAddress(dto.ShipTo.Name, dto.ShipTo.Street1, dto.ShipTo.Street2, dto.ShipTo.City, dto.ShipTo.Zip, dto.ShipTo.Country),
-			ShipMethod:     domain.RebuildShippingMethod(dto.ShipMethod.Code, dto.ShipMethod.Label, dto.ShipMethod.Cost),
-			PayMethod:      domain.RebuildPaymentMethod(dto.PayMethod.Code, dto.PayMethod.Label),
-			Lines:          lines,
-			Tax:            dto.Tax,
-			ShippingCost:   dto.ShippingCost,
-			DiscountCode:   dto.DiscountCode,
-			DiscountAmount: dto.DiscountAmount,
-			At:             dto.At,
-		}, nil
 	case "PaymentSucceeded":
+		if version != 1 {
+			return nil, fmt.Errorf("unknown PaymentSucceeded version %d", version)
+		}
 		var dto paymentSucceededDTO
 		if err := json.Unmarshal(payload, &dto); err != nil {
 			return nil, fmt.Errorf("unmarshal PaymentSucceeded: %w", err)
 		}
 		return domain.PaymentSucceeded{OrderID: dto.OrderID, At: dto.At}, nil
 	case "PaymentFailed":
+		if version != 1 {
+			return nil, fmt.Errorf("unknown PaymentFailed version %d", version)
+		}
 		var dto paymentFailedDTO
 		if err := json.Unmarshal(payload, &dto); err != nil {
 			return nil, fmt.Errorf("unmarshal PaymentFailed: %w", err)
 		}
 		return domain.PaymentFailed{OrderID: dto.OrderID, Reason: dto.Reason, At: dto.At}, nil
 	case "OrderCancelled":
+		if version != 1 {
+			return nil, fmt.Errorf("unknown OrderCancelled version %d", version)
+		}
 		var dto orderCancelledDTO
 		if err := json.Unmarshal(payload, &dto); err != nil {
 			return nil, fmt.Errorf("unmarshal OrderCancelled: %w", err)
 		}
 		return domain.OrderCancelled{OrderID: dto.OrderID, Reason: dto.Reason, At: dto.At}, nil
 	case "OrderShipped":
+		if version != 1 {
+			return nil, fmt.Errorf("unknown OrderShipped version %d", version)
+		}
 		var dto orderShippedDTO
 		if err := json.Unmarshal(payload, &dto); err != nil {
 			return nil, fmt.Errorf("unmarshal OrderShipped: %w", err)
 		}
 		return domain.OrderShipped{OrderID: dto.OrderID, Carrier: dto.Carrier, TrackingCode: dto.TrackingCode, At: dto.At}, nil
 	case "OrderDelivered":
+		if version != 1 {
+			return nil, fmt.Errorf("unknown OrderDelivered version %d", version)
+		}
 		var dto orderDeliveredDTO
 		if err := json.Unmarshal(payload, &dto); err != nil {
 			return nil, fmt.Errorf("unmarshal OrderDelivered: %w", err)
 		}
 		return domain.OrderDelivered{OrderID: dto.OrderID, At: dto.At}, nil
 	case "OrderRefunded":
+		if version != 1 {
+			return nil, fmt.Errorf("unknown OrderRefunded version %d", version)
+		}
 		var dto orderRefundedDTO
 		if err := json.Unmarshal(payload, &dto); err != nil {
 			return nil, fmt.Errorf("unmarshal OrderRefunded: %w", err)
@@ -207,6 +276,58 @@ func unmarshalEvent(eventType string, payload []byte) (domain.Event, error) {
 		return domain.OrderRefunded{OrderID: dto.OrderID, Reason: dto.Reason, At: dto.At}, nil
 	default:
 		return nil, fmt.Errorf("unknown event type %q", eventType)
+	}
+}
+
+// upcastOrderPlacedV1 is the upcaster for the OrderPlaced v1 → v2 schema
+// jump. v1 rows pre-date the Channel field; we materialise them with
+// Channel == "unknown" so historical orders read back with an explicit,
+// auditable value rather than the zero string — making the upcast visible
+// in tests and in the read model alike.
+func upcastOrderPlacedV1(v1 orderPlacedDTOv1) domain.OrderPlaced {
+	lines := make([]domain.Line, 0, len(v1.Lines))
+	for _, l := range v1.Lines {
+		lines = append(lines, domain.NewLine(l.ProductID, l.ProductName, l.Qty, l.PriceAmount, l.PriceCurrency))
+	}
+	return domain.OrderPlaced{
+		OrderID:        v1.OrderID,
+		UserID:         v1.UserID,
+		CustomerID:     v1.CustomerID,
+		ShipTo:         domain.RebuildAddress(v1.ShipTo.Name, v1.ShipTo.Street1, v1.ShipTo.Street2, v1.ShipTo.City, v1.ShipTo.Zip, v1.ShipTo.Country),
+		ShipMethod:     domain.RebuildShippingMethod(v1.ShipMethod.Code, v1.ShipMethod.Label, v1.ShipMethod.Cost),
+		PayMethod:      domain.RebuildPaymentMethod(v1.PayMethod.Code, v1.PayMethod.Label),
+		Lines:          lines,
+		Tax:            v1.Tax,
+		ShippingCost:   v1.ShippingCost,
+		DiscountCode:   v1.DiscountCode,
+		DiscountAmount: v1.DiscountAmount,
+		Channel:        "unknown",
+		At:             v1.At,
+	}
+}
+
+// orderPlacedFromDTOv2 is the no-op-shape mapping from the latest DTO to
+// the domain event — it pairs with upcastOrderPlacedV1 so every code path
+// in unmarshalEvent ends with the same domain.OrderPlaced shape.
+func orderPlacedFromDTOv2(v2 orderPlacedDTOv2) domain.OrderPlaced {
+	lines := make([]domain.Line, 0, len(v2.Lines))
+	for _, l := range v2.Lines {
+		lines = append(lines, domain.NewLine(l.ProductID, l.ProductName, l.Qty, l.PriceAmount, l.PriceCurrency))
+	}
+	return domain.OrderPlaced{
+		OrderID:        v2.OrderID,
+		UserID:         v2.UserID,
+		CustomerID:     v2.CustomerID,
+		ShipTo:         domain.RebuildAddress(v2.ShipTo.Name, v2.ShipTo.Street1, v2.ShipTo.Street2, v2.ShipTo.City, v2.ShipTo.Zip, v2.ShipTo.Country),
+		ShipMethod:     domain.RebuildShippingMethod(v2.ShipMethod.Code, v2.ShipMethod.Label, v2.ShipMethod.Cost),
+		PayMethod:      domain.RebuildPaymentMethod(v2.PayMethod.Code, v2.PayMethod.Label),
+		Lines:          lines,
+		Tax:            v2.Tax,
+		ShippingCost:   v2.ShippingCost,
+		DiscountCode:   v2.DiscountCode,
+		DiscountAmount: v2.DiscountAmount,
+		Channel:        v2.Channel,
+		At:             v2.At,
 	}
 }
 

--- a/backend/checkout/adapter/events_codec_test.go
+++ b/backend/checkout/adapter/events_codec_test.go
@@ -1,6 +1,7 @@
 package adapter
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -23,18 +24,22 @@ func TestEventCodecRoundTrip_OrderPlaced(t *testing.T) {
 		ShippingCost:   0,
 		DiscountCode:   "SAVE10",
 		DiscountAmount: 240,
+		Channel:        "web",
 		At:             at,
 	}
 
-	typ, payload, err := marshalEvent(original)
+	typ, version, payload, err := marshalEvent(original)
 	if err != nil {
 		t.Fatalf("marshal: %v", err)
 	}
 	if typ != "OrderPlaced" {
 		t.Fatalf("type = %q, want OrderPlaced", typ)
 	}
+	if version != 2 {
+		t.Fatalf("version = %d, want 2 (latest OrderPlaced schema)", version)
+	}
 
-	got, err := unmarshalEvent(typ, payload)
+	got, err := unmarshalEvent(typ, version, payload)
 	if err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
@@ -67,6 +72,9 @@ func TestEventCodecRoundTrip_OrderPlaced(t *testing.T) {
 	if op.DiscountCode != "SAVE10" || op.DiscountAmount != 240 {
 		t.Errorf("discount round-trip mismatch: code=%q amount=%d", op.DiscountCode, op.DiscountAmount)
 	}
+	if op.Channel != "web" {
+		t.Errorf("channel round-trip mismatch: got %q want web", op.Channel)
+	}
 }
 
 func TestEventCodecRoundTrip_Fulfillment(t *testing.T) {
@@ -77,11 +85,14 @@ func TestEventCodecRoundTrip_Fulfillment(t *testing.T) {
 		domain.OrderRefunded{OrderID: "ord-1", Reason: "customer return", At: at},
 	}
 	for _, e := range cases {
-		typ, payload, err := marshalEvent(e)
+		typ, version, payload, err := marshalEvent(e)
 		if err != nil {
 			t.Fatalf("marshal %s: %v", e.EventType(), err)
 		}
-		got, err := unmarshalEvent(typ, payload)
+		if version != 1 {
+			t.Errorf("version for %s = %d, want 1 (event has not evolved yet)", typ, version)
+		}
+		got, err := unmarshalEvent(typ, version, payload)
 		if err != nil {
 			t.Fatalf("unmarshal %s: %v", typ, err)
 		}
@@ -107,11 +118,11 @@ func TestEventCodecRoundTrip_Payment(t *testing.T) {
 		domain.PaymentSucceeded{OrderID: "ord-1", At: at},
 		domain.PaymentFailed{OrderID: "ord-1", Reason: "declined", At: at},
 	} {
-		typ, payload, err := marshalEvent(e)
+		typ, version, payload, err := marshalEvent(e)
 		if err != nil {
 			t.Fatalf("marshal %s: %v", e.EventType(), err)
 		}
-		got, err := unmarshalEvent(typ, payload)
+		got, err := unmarshalEvent(typ, version, payload)
 		if err != nil {
 			t.Fatalf("unmarshal %s: %v", typ, err)
 		}
@@ -130,13 +141,120 @@ func TestEventCodecRoundTrip_Payment(t *testing.T) {
 
 func mustUnmarshal(t *testing.T, e domain.Event) domain.Event {
 	t.Helper()
-	typ, payload, err := marshalEvent(e)
+	typ, version, payload, err := marshalEvent(e)
 	if err != nil {
 		t.Fatalf("marshal: %v", err)
 	}
-	got, err := unmarshalEvent(typ, payload)
+	got, err := unmarshalEvent(typ, version, payload)
 	if err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
 	return got
+}
+
+// TestUnmarshalOrderPlacedV1 feeds a hand-built v1 payload (no channel key)
+// into unmarshalEvent and asserts the upcaster materialises Channel ==
+// "unknown" on the resulting domain event. This is the textbook upcaster
+// check: the aggregate's apply() should never see a v1 shape directly.
+func TestUnmarshalOrderPlacedV1(t *testing.T) {
+	at := time.Date(2026, 5, 27, 9, 0, 0, 0, time.UTC)
+
+	// Hand-built v1 JSON — note the deliberate ABSENCE of the "channel"
+	// key. This is exactly what rows written before the v2 migration look
+	// like in the database.
+	v1JSON := []byte(`{
+		"order_id": "ord-v1",
+		"user_id": "cart-1",
+		"customer_id": "jane@example.com",
+		"ship_to": {"name":"Jane","street1":"1 Main St","street2":"","city":"PDX","zip":"97201","country":"USA"},
+		"ship_method": {"code":"courier","label":"Courier","cost":1500},
+		"pay_method": {"code":"card","label":"Card"},
+		"lines": [{"product_id":"ceramic-mug-cream","product_name":"Mug","qty":2,"price_amount":2400,"price_currency":"USD"}],
+		"tax": 426,
+		"shipping_cost": 0,
+		"discount_code": "SAVE10",
+		"discount_amount": 240,
+		"at": "2026-05-27T09:00:00Z"
+	}`)
+
+	got, err := unmarshalEvent("OrderPlaced", 1, v1JSON)
+	if err != nil {
+		t.Fatalf("unmarshal v1: %v", err)
+	}
+	op, ok := got.(domain.OrderPlaced)
+	if !ok {
+		t.Fatalf("got %T, want domain.OrderPlaced", got)
+	}
+	if op.Channel != "unknown" {
+		t.Errorf("upcast channel = %q, want unknown (v1 default fill)", op.Channel)
+	}
+	// Sanity: the rest of the payload survived the upcast unchanged.
+	if op.OrderID != "ord-v1" || op.Tax != 426 || op.DiscountCode != "SAVE10" || op.DiscountAmount != 240 {
+		t.Errorf("v1 payload not preserved: %+v", op)
+	}
+	if !op.At.Equal(at) {
+		t.Errorf("v1 occurred-at lost: got %v want %v", op.At, at)
+	}
+	if len(op.Lines) != 1 || op.Lines[0].PriceAmount() != 2400 {
+		t.Errorf("v1 lines not preserved: %+v", op.Lines)
+	}
+}
+
+// TestRoundTripOrderPlacedV2 locks in that a v2 OrderPlaced (with Channel)
+// marshals at version 2 and round-trips back through unmarshalEvent
+// without going through the upcaster.
+func TestRoundTripOrderPlacedV2(t *testing.T) {
+	at := time.Date(2026, 5, 27, 10, 0, 0, 0, time.UTC)
+	original := domain.OrderPlaced{
+		OrderID:    "ord-2",
+		UserID:     "cart-1",
+		CustomerID: "jane@example.com",
+		ShipTo:     domain.RebuildAddress("Jane", "1 Main St", "", "PDX", "97201", "USA"),
+		ShipMethod: domain.RebuildShippingMethod("pickup", "Pickup", 0),
+		PayMethod:  domain.RebuildPaymentMethod("card", "Card"),
+		Lines:      []domain.Line{domain.NewLine("v1", "Mug", 1, 1500, "USD")},
+		Channel:    "web",
+		At:         at,
+	}
+
+	typ, version, payload, err := marshalEvent(original)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if typ != "OrderPlaced" {
+		t.Fatalf("type = %q, want OrderPlaced", typ)
+	}
+	if version != 2 {
+		t.Fatalf("version = %d, want 2", version)
+	}
+
+	// Confirm the wire payload actually carries the channel key — guards
+	// against a future regression that silently drops the field.
+	var raw map[string]any
+	if err := json.Unmarshal(payload, &raw); err != nil {
+		t.Fatalf("re-parse payload: %v", err)
+	}
+	if raw["channel"] != "web" {
+		t.Errorf("wire payload channel = %v, want web", raw["channel"])
+	}
+
+	got, err := unmarshalEvent(typ, version, payload)
+	if err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	op, ok := got.(domain.OrderPlaced)
+	if !ok {
+		t.Fatalf("got %T, want domain.OrderPlaced", got)
+	}
+	if op.Channel != "web" {
+		t.Errorf("channel lost in round-trip: got %q want web", op.Channel)
+	}
+}
+
+// TestUnmarshalOrderPlacedUnknownVersion guards the codec contract: an
+// unrecognised version is a loud failure, not a silent zero-value load.
+func TestUnmarshalOrderPlacedUnknownVersion(t *testing.T) {
+	if _, err := unmarshalEvent("OrderPlaced", 99, []byte(`{}`)); err == nil {
+		t.Fatal("expected error for unknown OrderPlaced version, got nil")
+	}
 }

--- a/backend/checkout/adapter/events_postgres.go
+++ b/backend/checkout/adapter/events_postgres.go
@@ -28,14 +28,14 @@ func appendEventsTx(ctx context.Context, tx *sql.Tx, aggregateID string, expecte
 	seq := expectedVersion
 	for _, e := range events {
 		seq++
-		eventType, payload, err := marshalEvent(e)
+		eventType, payloadVersion, payload, err := marshalEvent(e)
 		if err != nil {
 			return err
 		}
 		_, err = tx.ExecContext(ctx, `
-			INSERT INTO checkout_events (aggregate_id, sequence, event_type, payload, occurred_at)
-			VALUES ($1, $2, $3, $4, $5)
-		`, aggregateID, seq, eventType, payload, e.OccurredAt())
+			INSERT INTO checkout_events (aggregate_id, sequence, event_type, payload, payload_version, occurred_at)
+			VALUES ($1, $2, $3, $4, $5, $6)
+		`, aggregateID, seq, eventType, payload, payloadVersion, e.OccurredAt())
 		if err != nil {
 			return fmt.Errorf("append %s#%d: %w", e.EventType(), seq, err)
 		}
@@ -67,7 +67,7 @@ func (p Postgres) LoadEvents(ctx context.Context, aggregateID string) ([]domain.
 	}()
 
 	rows, err := p.db.QueryContext(ctx, `
-		SELECT event_type, payload FROM checkout_events
+		SELECT event_type, payload_version, payload FROM checkout_events
 		WHERE aggregate_id = $1 ORDER BY sequence
 	`, aggregateID)
 	if err != nil {
@@ -80,13 +80,14 @@ func (p Postgres) LoadEvents(ctx context.Context, aggregateID string) ([]domain.
 	var events []domain.Event
 	for rows.Next() {
 		var typ string
+		var version int
 		var payload []byte
-		if err := rows.Scan(&typ, &payload); err != nil {
+		if err := rows.Scan(&typ, &version, &payload); err != nil {
 			span.RecordError(err)
 			span.SetStatus(codes.Error, err.Error())
 			return nil, fmt.Errorf("scan event: %w", err)
 		}
-		e, err := unmarshalEvent(typ, payload)
+		e, err := unmarshalEvent(typ, version, payload)
 		if err != nil {
 			span.RecordError(err)
 			span.SetStatus(codes.Error, err.Error())
@@ -120,7 +121,7 @@ func (p Postgres) LoadEventsAfter(ctx context.Context, aggregateID string, after
 	}()
 
 	rows, err := p.db.QueryContext(ctx, `
-		SELECT event_type, payload FROM checkout_events
+		SELECT event_type, payload_version, payload FROM checkout_events
 		WHERE aggregate_id = $1 AND sequence > $2 ORDER BY sequence
 	`, aggregateID, afterVersion)
 	if err != nil {
@@ -133,13 +134,14 @@ func (p Postgres) LoadEventsAfter(ctx context.Context, aggregateID string, after
 	var events []domain.Event
 	for rows.Next() {
 		var typ string
+		var version int
 		var payload []byte
-		if err := rows.Scan(&typ, &payload); err != nil {
+		if err := rows.Scan(&typ, &version, &payload); err != nil {
 			span.RecordError(err)
 			span.SetStatus(codes.Error, err.Error())
 			return nil, fmt.Errorf("scan event: %w", err)
 		}
-		e, err := unmarshalEvent(typ, payload)
+		e, err := unmarshalEvent(typ, version, payload)
 		if err != nil {
 			span.RecordError(err)
 			span.SetStatus(codes.Error, err.Error())

--- a/backend/checkout/adapter/rebuild.go
+++ b/backend/checkout/adapter/rebuild.go
@@ -20,7 +20,7 @@ import (
 // rebuild is deterministic by construction.
 func RebuildReadModels(ctx context.Context, tx *sql.Tx) (int, int, error) {
 	rows, err := tx.QueryContext(ctx, `
-		SELECT aggregate_id, event_type, payload
+		SELECT aggregate_id, event_type, payload_version, payload
 		FROM checkout_events
 		ORDER BY aggregate_id, sequence
 	`)
@@ -34,15 +34,16 @@ func RebuildReadModels(ctx context.Context, tx *sql.Tx) (int, int, error) {
 	var lastAgg string
 	for rows.Next() {
 		var aggID, eventType string
+		var version int
 		var payload []byte
-		if err := rows.Scan(&aggID, &eventType, &payload); err != nil {
+		if err := rows.Scan(&aggID, &eventType, &version, &payload); err != nil {
 			return eventCount, aggCount, fmt.Errorf("scan event: %w", err)
 		}
 		if aggID != lastAgg {
 			aggCount++
 			lastAgg = aggID
 		}
-		e, err := unmarshalEvent(eventType, payload)
+		e, err := unmarshalEvent(eventType, version, payload)
 		if err != nil {
 			return eventCount, aggCount, err
 		}

--- a/backend/checkout/adapter/snapshot_codec.go
+++ b/backend/checkout/adapter/snapshot_codec.go
@@ -33,6 +33,7 @@ type orderSnapshotDTO struct {
 	PlacedAt     time.Time         `json:"placed_at"`
 	Carrier      string            `json:"carrier,omitempty"`
 	TrackingCode string            `json:"tracking_code,omitempty"`
+	Channel      string            `json:"channel,omitempty"`
 	Version      int               `json:"version"`
 }
 
@@ -67,6 +68,7 @@ func marshalSnapshot(snap domain.OrderSnapshot) ([]byte, error) {
 		PlacedAt:     snap.PlacedAt,
 		Carrier:      snap.Carrier,
 		TrackingCode: snap.TrackingCode,
+		Channel:      snap.Channel,
 		Version:      snap.Version,
 	}
 	b, err := json.Marshal(dto)
@@ -105,6 +107,7 @@ func unmarshalSnapshot(payload []byte) (domain.OrderSnapshot, error) {
 		PlacedAt:     dto.PlacedAt,
 		Carrier:      dto.Carrier,
 		TrackingCode: dto.TrackingCode,
+		Channel:      dto.Channel,
 		Version:      dto.Version,
 	}, nil
 }

--- a/backend/checkout/app/checkout.go
+++ b/backend/checkout/app/checkout.go
@@ -322,7 +322,12 @@ func (s CheckoutService) Place(ctx context.Context, sessID, customerID, cardNumb
 		attribute.Int64("order.shipping", effectiveShipping),
 	)
 
-	order, err := domain.PlaceOrder(orderID, sessID, customerID, shipTo, shipMethod, payMethod, lines, tax, effectiveShipping, discount.Code(), discountAmount, s.now())
+	// channel records the sales channel the order was placed through; the
+	// admin/checkout HTTP flow is the only producer today, so we hardcode
+	// "web". Pluggable when iOS / API channels arrive — the signature is
+	// already wired through PlaceOrder and the OrderPlaced v2 schema.
+	const channel = "web"
+	order, err := domain.PlaceOrder(orderID, sessID, customerID, shipTo, shipMethod, payMethod, lines, tax, effectiveShipping, discount.Code(), discountAmount, channel, s.now())
 	if err != nil {
 		_ = s.stock.Release(ctx, quantities)
 		for vid, qty := range quantities {

--- a/backend/checkout/domain/events.go
+++ b/backend/checkout/domain/events.go
@@ -26,6 +26,11 @@ type Event interface {
 // units that was subtracted from the subtotal before computing tax. For
 // free_shipping codes DiscountAmount stays 0 — the saving is reflected in
 // ShippingCost=0, not in the subtotal.
+//
+// Channel records the sales channel the order came in through (e.g. "web",
+// "ios", "api"). It was added in the v2 OrderPlaced schema; the codec's
+// upcaster fills "unknown" for v1 rows that predate the field so apply()
+// only ever sees the latest shape.
 type OrderPlaced struct {
 	OrderID        string
 	UserID         string
@@ -38,6 +43,7 @@ type OrderPlaced struct {
 	ShippingCost   int64
 	DiscountCode   string
 	DiscountAmount int64
+	Channel        string
 	At             time.Time
 }
 

--- a/backend/checkout/domain/order.go
+++ b/backend/checkout/domain/order.go
@@ -54,6 +54,7 @@ type Order struct {
 	placedAt     time.Time
 	carrier      string
 	trackingCode string
+	channel      string
 
 	version       int
 	pendingEvents []Event
@@ -140,6 +141,12 @@ func (o Order) TotalDisplay() string  { return money(o.totalAmt) }
 func (o Order) Carrier() string       { return o.carrier }
 func (o Order) TrackingCode() string  { return o.trackingCode }
 
+// Channel returns the sales channel the order was placed through (e.g. "web",
+// "ios", "api"). v1 OrderPlaced events lacked this field; the codec's
+// upcaster fills "unknown" on load so historical orders read back with a
+// stable, explicit value rather than the zero string.
+func (o Order) Channel() string { return o.channel }
+
 // DiscountCode returns the literal promo code applied at place time
 // (empty when no code was used). The order is event-sourced so the
 // historical value is preserved across replays.
@@ -169,7 +176,13 @@ func (o Order) DiscountDisplay() string { return money(o.discountAmt) }
 // discountCode/discountAmount carry the resolved promo code (empty / 0 when
 // none was used). The event-sourced aggregate keeps these so replaying
 // history reproduces the original totals.
-func PlaceOrder(id, userID, customerID string, shipTo Address, shipMethod ShippingMethod, payMethod PaymentMethod, lines []Line, tax, effectiveShipping int64, discountCode string, discountAmount int64, at time.Time) (*Order, error) {
+//
+// channel records the sales channel ("web", "ios", "api", ...) the order was
+// placed through. It became part of the OrderPlaced v2 schema; callers
+// today always pass "web" (the only producer) but the parameter is wired
+// through so iOS/API entry points can light it up without a second
+// schema migration.
+func PlaceOrder(id, userID, customerID string, shipTo Address, shipMethod ShippingMethod, payMethod PaymentMethod, lines []Line, tax, effectiveShipping int64, discountCode string, discountAmount int64, channel string, at time.Time) (*Order, error) {
 	if len(lines) == 0 {
 		return nil, ErrCartEmpty
 	}
@@ -186,6 +199,7 @@ func PlaceOrder(id, userID, customerID string, shipTo Address, shipMethod Shippi
 		ShippingCost:   effectiveShipping,
 		DiscountCode:   discountCode,
 		DiscountAmount: discountAmount,
+		Channel:        channel,
 		At:             at,
 	})
 	return o, nil
@@ -247,6 +261,10 @@ func (o *Order) apply(e Event) {
 		o.totalCcy = ccy
 		o.status = StatusPending
 		o.placedAt = ev.At
+		// Channel is the v2 OrderPlaced field; v1 payloads are upcast to
+		// "unknown" by the codec before they reach apply, so this is always
+		// a meaningful string.
+		o.channel = ev.Channel
 	case PaymentSucceeded:
 		o.status = StatusPaid
 	case PaymentFailed:

--- a/backend/checkout/domain/order_test.go
+++ b/backend/checkout/domain/order_test.go
@@ -100,7 +100,7 @@ func TestPlaceOrder_AppliesDiscount(t *testing.T) {
 	// discounted subtotal = 3600; caller computed tax 320 on it and kept
 	// shipping at 1500. Total = 3600 + 320 + 1500 = 5420.
 	o, err := domain.PlaceOrder("ord-d", "cart-1", "jane@example.com", domain.Address{}, method,
-		domain.RebuildPaymentMethod("card", "Card"), lines, 320, 1500, "SAVE10", 400, at)
+		domain.RebuildPaymentMethod("card", "Card"), lines, 320, 1500, "SAVE10", 400, "web", at)
 	if err != nil {
 		t.Fatalf("PlaceOrder: %v", err)
 	}
@@ -122,7 +122,7 @@ func TestPlaceOrder_AppliesTaxAndEffectiveShipping(t *testing.T) {
 
 	// Caller computed an 8.875% tax on 4000 = 355 and free shipping (threshold met).
 	o, err := domain.PlaceOrder("ord-3", "cart-1", "jane@example.com", domain.Address{}, method,
-		domain.RebuildPaymentMethod("card", "Card"), lines, 355, 0, "", 0, at)
+		domain.RebuildPaymentMethod("card", "Card"), lines, 355, 0, "", 0, "web", at)
 	if err != nil {
 		t.Fatalf("PlaceOrder: %v", err)
 	}
@@ -135,6 +135,29 @@ func TestPlaceOrder_AppliesTaxAndEffectiveShipping(t *testing.T) {
 	// subtotal 4000 + tax 355 + shipping 0.
 	if o.TotalAmount() != 4355 {
 		t.Errorf("total = %d, want 4355", o.TotalAmount())
+	}
+}
+
+// TestApplyOrderPlaced_SetsChannel locks in the v2 OrderPlaced field
+// behaviour: replaying an event whose Channel == "ios" lands on
+// o.Channel() == "ios". The codec's upcaster guarantees apply() always
+// sees a non-empty Channel; this test pins the aggregate side of that
+// contract.
+func TestApplyOrderPlaced_SetsChannel(t *testing.T) {
+	at := time.Date(2026, 5, 27, 9, 0, 0, 0, time.UTC)
+	o := domain.RehydrateOrder([]domain.Event{
+		domain.OrderPlaced{
+			OrderID:    "ord-ch",
+			UserID:     "cart-1",
+			ShipMethod: domain.RebuildShippingMethod("pickup", "Pickup", 0),
+			PayMethod:  domain.RebuildPaymentMethod("card", "Card"),
+			Lines:      []domain.Line{domain.NewLine("v1", "Mug", 1, 1500, "USD")},
+			Channel:    "ios",
+			At:         at,
+		},
+	})
+	if o.Channel() != "ios" {
+		t.Errorf("Channel() = %q, want ios", o.Channel())
 	}
 }
 

--- a/backend/checkout/domain/place_test.go
+++ b/backend/checkout/domain/place_test.go
@@ -12,7 +12,7 @@ func TestPlaceOrder_EmptyCartRejected(t *testing.T) {
 	_, err := domain.PlaceOrder("ord-1", "cart-1", "", domain.Address{},
 		domain.RebuildShippingMethod("pickup", "Personal pickup", 0),
 		domain.RebuildPaymentMethod("cod", "Cash on delivery"),
-		nil, 0, 0, "", 0, time.Now())
+		nil, 0, 0, "", 0, "web", time.Now())
 	if !errors.Is(err, domain.ErrCartEmpty) {
 		t.Errorf("err = %v, want ErrCartEmpty", err)
 	}
@@ -28,7 +28,7 @@ func TestPlaceOrder_EmitsPendingOrderPlaced(t *testing.T) {
 	o, err := domain.PlaceOrder("ord-1", "cart-1", "jane@example.com", domain.Address{},
 		method,
 		domain.RebuildPaymentMethod("card", "Credit / debit card"),
-		lines, 0, method.Cost(), "", 0, at)
+		lines, 0, method.Cost(), "", 0, "web", at)
 	if err != nil {
 		t.Fatalf("PlaceOrder: %v", err)
 	}

--- a/backend/checkout/domain/snapshot.go
+++ b/backend/checkout/domain/snapshot.go
@@ -13,25 +13,26 @@ import "time"
 // aggregate's unexported fields without breaking encapsulation for the
 // rest of the codebase.
 type OrderSnapshot struct {
-	ID            string
-	UserID        string
-	CustomerID    string
-	ShipTo        Address
-	ShipMethod    ShippingMethod
-	PayMethod     PaymentMethod
-	Items         []Line
-	SubtotalAmt   int64
-	TaxAmt        int64
-	ShipCostAmt   int64
-	DiscountCode  string
-	DiscountAmt   int64
-	TotalAmt      int64
-	TotalCcy      string
-	Status        Status
-	PlacedAt      time.Time
-	Carrier       string
-	TrackingCode  string
-	Version       int
+	ID           string
+	UserID       string
+	CustomerID   string
+	ShipTo       Address
+	ShipMethod   ShippingMethod
+	PayMethod    PaymentMethod
+	Items        []Line
+	SubtotalAmt  int64
+	TaxAmt       int64
+	ShipCostAmt  int64
+	DiscountCode string
+	DiscountAmt  int64
+	TotalAmt     int64
+	TotalCcy     string
+	Status       Status
+	PlacedAt     time.Time
+	Carrier      string
+	TrackingCode string
+	Channel      string
+	Version      int
 }
 
 // SnapshotOrder builds an OrderSnapshot from the aggregate's current state
@@ -64,6 +65,7 @@ func SnapshotOrder(o *Order) OrderSnapshot {
 		PlacedAt:     o.PlacedAt(),
 		Carrier:      o.Carrier(),
 		TrackingCode: o.TrackingCode(),
+		Channel:      o.Channel(),
 		Version:      o.version,
 	}
 }
@@ -95,6 +97,7 @@ func RehydrateOrderFromSnapshot(snap OrderSnapshot, tail []Event) *Order {
 		placedAt:     snap.PlacedAt,
 		carrier:      snap.Carrier,
 		trackingCode: snap.TrackingCode,
+		channel:      snap.Channel,
 		version:      snap.Version,
 	}
 	ApplyTail(o, tail)

--- a/migrations/000035_checkout_events_payload_version.down.sql
+++ b/migrations/000035_checkout_events_payload_version.down.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+ALTER TABLE checkout_events
+    DROP COLUMN payload_version;
+
+COMMIT;

--- a/migrations/000035_checkout_events_payload_version.up.sql
+++ b/migrations/000035_checkout_events_payload_version.up.sql
@@ -1,0 +1,11 @@
+BEGIN;
+
+-- payload_version makes the checkout event log version-aware so the codec
+-- can pick the right DTO/upcaster for each row. Existing rows were written
+-- under the v1 schema, so DEFAULT 1 captures their history correctly: an
+-- upcaster will translate them into the latest in-memory shape at load time
+-- (see backend/checkout/adapter/events_codec.go).
+ALTER TABLE checkout_events
+    ADD COLUMN payload_version int NOT NULL DEFAULT 1;
+
+COMMIT;


### PR DESCRIPTION
Demonstrates the textbook ES schema-evolution pattern: the event log carries a `payload_version`, the codec branches on it, and an **upcaster** translates old payloads to the latest shape at load time. The aggregate's `apply` only ever sees the latest version.

- **Migration 000034** adds `payload_version int NOT NULL DEFAULT 1` to `checkout_events`. Historical rows self-identify as v1 (correct — they were written under the v1 schema).
- **v2 schema change**: `OrderPlaced.Channel string` ("web" / "ios" / "api") — meaningful, additive, with a clean upcast default ("unknown") for v1 payloads. Threaded into `domain.Order.channel`, `apply`, `PlaceOrder` constructor and the single caller (`checkout/app.Place` passes "web").
- **Codec signatures**: `marshalEvent` returns `(eventType, payloadVersion, payload, err)`; `unmarshalEvent` accepts version. Dispatch on `(type, version)`. Other event types report version 1 — single switch makes per-event versioning a one-place change.
- **Upcaster** `upcastOrderPlacedV1(v1) domain.OrderPlaced` fills `Channel: "unknown"`. Hidden behind the codec; the aggregate doesn't know v1 ever existed.
- **Snapshot codec** mirrors the new field so snapshots replay equivalently.
- Tests: v1 JSON without `channel` → upcasts to "unknown"; v2 round-trip; unknown version → error; apply honors Channel.

## Test plan
- [x] build / build -tags integration / vet / tests / lint green
- [x] Codec tests for v1 unmarshal, v2 round-trip, unknown-version error
- [x] Order.apply honors Channel
- [x] Snapshot equivalence test still passes with the new field