### PR TITLE
feat(messaging): Inbox pattern for subscriber dedupe

### DIFF
--- a/backend/cmd/web/main.go
+++ b/backend/cmd/web/main.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"sync"
 	"time"
 
 	"github.com/ardanlabs/conf"
@@ -24,6 +23,7 @@ import (
 	"github.com/bkielbasa/go-ecommerce/backend/internal/eventbus"
 	"github.com/bkielbasa/go-ecommerce/backend/internal/fx"
 	"github.com/bkielbasa/go-ecommerce/backend/internal/imagestore"
+	"github.com/bkielbasa/go-ecommerce/backend/internal/inbox"
 	"github.com/bkielbasa/go-ecommerce/backend/internal/mailer"
 	"github.com/bkielbasa/go-ecommerce/backend/internal/observability"
 	"github.com/bkielbasa/go-ecommerce/backend/internal/outbox"
@@ -134,6 +134,11 @@ func main() {
 	// checkout adapter calls AppendTx inside its own tx) and as the
 	// dispatcher's source of unsent rows.
 	outboxStore := outbox.NewPostgres(db)
+	// Inbox store: per-subscriber dedupe of redelivered Outbox events.
+	// Each Outbox-driven subscriber is wrapped via inbox.Wrap below so
+	// the at-least-once contract from the Outbox becomes effectively
+	// exactly-once at the subscriber boundary. See internal/inbox.
+	inboxStore := inbox.NewPostgres(db)
 	// Search OHS: published-language storage + service. The same *app.Service
 	// instance is wired as both productcatalog's SearchIndexer (write side)
 	// and layout's searchService (read side) — one struct, two roles.
@@ -187,83 +192,86 @@ func main() {
 		From:     cfg.MailFrom,
 	}, logger)
 
-	// Cross-context integration: when checkout reports an order paid, the cart
-	// context empties the basket it was placed from.
-	bus.Subscribe(checkoutintegration.OrderPaid{}.EventName(), func(ctx context.Context, e eventbus.Event) error {
-		return cartSrv.Clear(ctx, e.(checkoutintegration.OrderPaid).SessionID)
-	})
+	// Cross-context integration: the three OrderPaid subscribers are
+	// registered with SubscribeWithID and wrapped through inbox.Wrap
+	// so the outbox dispatcher's at-least-once redelivery becomes
+	// effectively exactly-once at each subscriber. The subscriber
+	// names are stable strings — they are the natural key in the
+	// inbox_handled table, so renaming them is a migration concern.
 
-	// Third OrderPaid subscriber: the fulfillment Process Manager
-	// spawns a new Fulfillment record in StatusScheduled. The handler
-	// is idempotent (FindByOrder + ErrAlreadyExists no-op) so the
-	// outbox dispatcher's at-least-once redelivery cannot create
-	// duplicate fulfillments after a crash between publish and
-	// MarkSent.
-	bus.Subscribe(checkoutintegration.OrderPaid{}.EventName(), func(ctx context.Context, e eventbus.Event) error {
-		paid := e.(checkoutintegration.OrderPaid)
-		return fulfillmentSrv.OnOrderPaid(ctx, paid.OrderID, paid.At)
-	})
-
-	// Second OrderPaid subscriber: render and dispatch the order
-	// confirmation email. Anonymous orders (CustomerID == "") are
-	// skipped — there is no inbox to mail. Any failure inside the
-	// subscriber is returned (and logged by the bus) but never aborts
-	// the publisher's own transaction; the cart-clearing subscriber
-	// above is unaffected.
-	//
-	// IDEMPOTENCY. The outbox dispatcher delivers integration events
-	// at-least-once: a process crash between Publish and MarkSent will
-	// republish the same OrderPaid on the next tick, and we'd send the
-	// confirmation email twice. Sending Clear() twice on a cart is a
-	// no-op so the cart-clear handler above is naturally safe, but
-	// duplicate emails are user-visible spam. The in-memory dedupe
-	// below remembers recently-seen OrderIDs and drops the duplicate
-	// publish.
-	//
-	// TRADE-OFF. This dedupe only survives within a single process —
-	// a restart wipes the map. That is acceptable for a demo because
-	// the outbox dispatcher won't republish a sent row (sent_at is
-	// set) once MarkSent has committed. The narrow remaining window
-	// is: crash AFTER publish, BEFORE MarkSent, then restart — in
-	// which case the row republishes and the in-memory dedupe is
-	// empty, so a duplicate email goes out. A real implementation
-	// would replace this with a persistent dedupe key (a
-	// sent_emails(order_id, kind) table, or wiring the order's
-	// confirmation_email_sent_at via a domain command) so the
-	// duplicate is suppressed across restarts too.
-	var (
-		sentEmailsMu sync.Mutex
-		sentEmails   = map[string]struct{}{}
+	// 1. cart.clear-on-orderpaid — empty the basket the order was
+	//    placed from. Clear() is a natural-id no-op the second time
+	//    around, so the inbox wrap is belt-and-braces here: cheaper
+	//    than the cart round-trip, and uniform with the other two.
+	bus.SubscribeWithID(
+		checkoutintegration.OrderPaid{}.EventName(),
+		inbox.Wrap("cart.clear-on-orderpaid", inboxStore,
+			func(ctx context.Context, _ int64, e eventbus.Event) error {
+				return cartSrv.Clear(ctx, e.(checkoutintegration.OrderPaid).SessionID)
+			},
+		),
 	)
-	bus.Subscribe(checkoutintegration.OrderPaid{}.EventName(), func(ctx context.Context, e eventbus.Event) error {
-		paid := e.(checkoutintegration.OrderPaid)
-		if paid.CustomerID == "" {
-			return nil
-		}
-		sentEmailsMu.Lock()
-		if _, dup := sentEmails[paid.OrderID]; dup {
-			sentEmailsMu.Unlock()
-			return nil
-		}
-		sentEmails[paid.OrderID] = struct{}{}
-		sentEmailsMu.Unlock()
-		view, err := checkoutQry.Find(ctx, paid.OrderID)
-		if err != nil {
-			return fmt.Errorf("order confirmation: load view: %w", err)
-		}
-		msg, err := layout.RenderOrderConfirmation(view, cfg.BaseURL)
-		if err != nil {
-			return fmt.Errorf("order confirmation: render: %w", err)
-		}
-		// Make sure the recipient is the actual customer email even
-		// if RenderOrderConfirmation derived it from the view; the
-		// integration event is the authoritative source.
-		msg.To = paid.CustomerID
-		if err := mailerSrv.Send(ctx, msg); err != nil {
-			return fmt.Errorf("order confirmation: send: %w", err)
-		}
-		return nil
-	})
+
+	// 2. fulfillment.on-orderpaid — the fulfillment Process Manager
+	//    spawns a new Fulfillment record in StatusScheduled. The
+	//    handler is itself idempotent (FindByOrder + ErrAlreadyExists
+	//    no-op); the inbox wrap stops the redelivery before it ever
+	//    reaches the service.
+	bus.SubscribeWithID(
+		checkoutintegration.OrderPaid{}.EventName(),
+		inbox.Wrap("fulfillment.on-orderpaid", inboxStore,
+			func(ctx context.Context, _ int64, e eventbus.Event) error {
+				paid := e.(checkoutintegration.OrderPaid)
+				return fulfillmentSrv.OnOrderPaid(ctx, paid.OrderID, paid.At)
+			},
+		),
+	)
+
+	// 3. email.order-confirmation — render and dispatch the order
+	//    confirmation email. Anonymous orders (CustomerID == "") are
+	//    skipped — there is no inbox to mail. Any failure inside the
+	//    subscriber is returned (and logged by the bus) but never
+	//    aborts the publisher's own transaction; the cart-clearing
+	//    subscriber above is unaffected.
+	//
+	//    IDEMPOTENCY. The Outbox dispatcher delivers integration
+	//    events at-least-once: a process crash between Publish and
+	//    MarkSent will republish the same OrderPaid on the next tick.
+	//    Sending the confirmation email twice would be user-visible
+	//    spam. Previously this subscriber kept an in-memory
+	//    sync.Map dedupe set which did not survive process restarts
+	//    (the only window where the redelivery actually happens).
+	//    inbox.Wrap replaces it with a persistent
+	//    (subscriber, event_id) row in inbox_handled keyed on the
+	//    outbox row id, so the dedupe survives crashes.
+	bus.SubscribeWithID(
+		checkoutintegration.OrderPaid{}.EventName(),
+		inbox.Wrap("email.order-confirmation", inboxStore,
+			func(ctx context.Context, _ int64, e eventbus.Event) error {
+				paid := e.(checkoutintegration.OrderPaid)
+				if paid.CustomerID == "" {
+					return nil
+				}
+				view, err := checkoutQry.Find(ctx, paid.OrderID)
+				if err != nil {
+					return fmt.Errorf("order confirmation: load view: %w", err)
+				}
+				msg, err := layout.RenderOrderConfirmation(view, cfg.BaseURL)
+				if err != nil {
+					return fmt.Errorf("order confirmation: render: %w", err)
+				}
+				// Make sure the recipient is the actual customer
+				// email even if RenderOrderConfirmation derived it
+				// from the view; the integration event is the
+				// authoritative source.
+				msg.To = paid.CustomerID
+				if err := mailerSrv.Send(ctx, msg); err != nil {
+					return fmt.Errorf("order confirmation: send: %w", err)
+				}
+				return nil
+			},
+		),
+	)
 
 	app.AddBoundedContext(cartBD)
 

--- a/backend/internal/eventbus/eventbus.go
+++ b/backend/internal/eventbus/eventbus.go
@@ -23,15 +23,38 @@ type Event interface {
 // best-effort side effects, decoupled from the publisher's own transaction.
 type Handler func(ctx context.Context, e Event) error
 
+// HandlerWithID is the Outbox-aware variant of Handler. It receives the
+// originating event's durable id alongside the event, so the subscriber
+// (or a wrapper such as internal/inbox.Wrap) can use it as a stable
+// dedupe key across redeliveries.
+//
+// When the publisher cannot supply a meaningful id — direct in-process
+// Publish calls, anything that did not originate from the Outbox — the
+// id is 0. Wrappers that depend on the id for dedupe MUST treat 0 as
+// "no id available" and pass the event through unfiltered; otherwise
+// every direct publish would dedupe against the same zero key.
+type HandlerWithID func(ctx context.Context, eventID int64, e Event) error
+
 // Bus is a synchronous, in-process publish/subscribe dispatcher.
+//
+// The Bus keeps two parallel handler lists per event name: classic
+// Handler closures registered via Subscribe and HandlerWithID closures
+// registered via SubscribeWithID. Both lists fire on every publish; the
+// id-aware list also receives the supplied event id (or 0 from the
+// compat Publish path).
 type Bus struct {
-	mu       sync.RWMutex
-	handlers map[string][]Handler
-	logger   logrus.FieldLogger
+	mu             sync.RWMutex
+	handlers       map[string][]Handler
+	handlersWithID map[string][]HandlerWithID
+	logger         logrus.FieldLogger
 }
 
 func New(logger logrus.FieldLogger) *Bus {
-	return &Bus{handlers: map[string][]Handler{}, logger: logger}
+	return &Bus{
+		handlers:       map[string][]Handler{},
+		handlersWithID: map[string][]HandlerWithID{},
+		logger:         logger,
+	}
 }
 
 // Subscribe registers a handler for an event name. Handlers fire in
@@ -42,15 +65,49 @@ func (b *Bus) Subscribe(eventName string, h Handler) {
 	b.handlers[eventName] = append(b.handlers[eventName], h)
 }
 
+// SubscribeWithID registers an id-aware handler for an event name.
+// Handlers fire in registration order within their own list; the
+// classic id-less Subscribe list always runs before the id-aware list
+// for the same event name, matching the order Publish iterates them.
+func (b *Bus) SubscribeWithID(eventName string, h HandlerWithID) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.handlersWithID[eventName] = append(b.handlersWithID[eventName], h)
+}
+
 // Publish dispatches an event to all subscribed handlers synchronously.
+// This is the backwards-compatible entry point for in-process publishers
+// that have no Outbox row id to share — it forwards to PublishWithID
+// with eventID==0, the documented "no dedupe id available" sentinel.
 func (b *Bus) Publish(ctx context.Context, e Event) {
+	b.PublishWithID(ctx, 0, e)
+}
+
+// PublishWithID dispatches an event to all subscribed handlers
+// synchronously and threads the supplied originating event id through
+// the id-aware handler list. eventID==0 means "no id available"; the
+// classic id-less handlers always receive only (ctx, e).
+//
+// The Outbox dispatcher calls this with the outbox_event.id of the row
+// it is draining so id-aware wrappers (internal/inbox.Wrap) can use the
+// id as a content-stable dedupe key across redeliveries.
+func (b *Bus) PublishWithID(ctx context.Context, eventID int64, e Event) {
 	b.mu.RLock()
 	hs := b.handlers[e.EventName()]
+	hsID := b.handlersWithID[e.EventName()]
 	b.mu.RUnlock()
 
 	for _, h := range hs {
 		if err := h(ctx, e); err != nil && b.logger != nil {
 			b.logger.WithError(err).WithField("event", e.EventName()).Error("event handler failed")
+		}
+	}
+	for _, h := range hsID {
+		if err := h(ctx, eventID, e); err != nil && b.logger != nil {
+			b.logger.WithError(err).WithFields(logrus.Fields{
+				"event":    e.EventName(),
+				"event.id": eventID,
+			}).Error("event handler failed")
 		}
 	}
 }

--- a/backend/internal/inbox/dedupe.go
+++ b/backend/internal/inbox/dedupe.go
@@ -1,0 +1,89 @@
+package inbox
+
+import (
+	"context"
+	"io"
+
+	"github.com/bkielbasa/go-ecommerce/backend/internal/eventbus"
+	"github.com/bkielbasa/go-ecommerce/backend/internal/observability"
+	"github.com/sirupsen/logrus"
+)
+
+// MarkHandler is the narrow seam Wrap depends on, satisfied by
+// *Postgres. Keeping it an interface (and not the concrete *Postgres)
+// lets dedupe_test.go drop in a tiny in-memory fake without a real DB.
+type MarkHandler interface {
+	MarkHandled(ctx context.Context, subscriber string, eventID int64) (alreadyHandled bool, err error)
+}
+
+// discardLogger is the package-level fallback used when no context
+// logger is available. Each entry it produces goes to io.Discard so a
+// background subscriber firing outside the HTTP middleware (which is
+// what binds observability.Logger) does not silently nil-panic.
+var discardLogger logrus.FieldLogger = func() logrus.FieldLogger {
+	l := logrus.New()
+	l.SetOutput(io.Discard)
+	return l
+}()
+
+// Wrap turns an Outbox-driven HandlerWithID into one that dedupes on
+// (subscriber, eventID) using the supplied store before invoking the
+// underlying handler.
+//
+// Behaviour by eventID:
+//   - eventID == 0  -> the publisher had no durable id (the compat
+//     Publish path on eventbus.Bus); dedupe cannot apply, so the
+//     wrapper passes the event straight through to h. Callers that
+//     register through SubscribeWithID and rely on Wrap MUST drive
+//     deliveries through the Outbox — otherwise this branch silently
+//     disables dedupe and you have at-least-once again.
+//   - eventID != 0  -> MarkHandled is called. On alreadyHandled the
+//     wrapper logs an info-level "skip duplicate delivery" and
+//     returns nil (success: the side effect has already happened). On
+//     a storage error MarkHandled's err is returned and h is NOT
+//     called; the Outbox dispatcher will retry the same row next
+//     tick. On a fresh insert the wrapper invokes h and returns its
+//     error verbatim.
+//
+// Logging routes through observability.Logger(ctx), which the HTTP
+// middleware binds. The Outbox dispatcher runs in a background
+// goroutine without that middleware, so observability.Logger falls
+// back to a fresh logrus.Logger and we route to a package-level
+// io.Discard sink — the dedupe path is hot and not normally
+// interesting. Errors from MarkHandled and the underlying handler
+// still propagate to the bus, which logs them at Error.
+func Wrap(subscriber string, store MarkHandler, h eventbus.HandlerWithID) eventbus.HandlerWithID {
+	return func(ctx context.Context, eventID int64, e eventbus.Event) error {
+		if eventID == 0 {
+			// Documented pass-through: no dedupe key, no dedupe.
+			return h(ctx, eventID, e)
+		}
+		alreadyHandled, err := store.MarkHandled(ctx, subscriber, eventID)
+		if err != nil {
+			return err
+		}
+		if alreadyHandled {
+			logger(ctx).WithFields(logrus.Fields{
+				"inbox.subscriber": subscriber,
+				"event":            e.EventName(),
+				"event.id":         eventID,
+			}).Info("inbox: skip duplicate delivery")
+			return nil
+		}
+		return h(ctx, eventID, e)
+	}
+}
+
+// logger returns the context logger bound by the HTTP middleware (or
+// by tests). When no logger is bound observability.Logger falls back
+// to a fresh logrus.Logger writing to stderr — useful in the HTTP
+// path but noisy in the background Outbox dispatcher path, where
+// there is no middleware. A nil context (only really seen in tests
+// that call the wrapper directly) routes to the package-level
+// io.Discard sink so the wrapper stays panic-free.
+func logger(ctx context.Context) logrus.FieldLogger {
+	if ctx == nil {
+		return discardLogger
+	}
+	return observability.Logger(ctx)
+}

--- a/backend/internal/inbox/dedupe_test.go
+++ b/backend/internal/inbox/dedupe_test.go
@@ -1,0 +1,191 @@
+package inbox
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/bkielbasa/go-ecommerce/backend/internal/eventbus"
+	"github.com/matryer/is"
+)
+
+// testEvent is a tiny eventbus.Event used to keep the inbox tests
+// independent of any bounded context's published language.
+type testEvent struct{ name string }
+
+func (e testEvent) EventName() string {
+	if e.name == "" {
+		return "test.Event"
+	}
+	return e.name
+}
+
+// fakeStore is an in-memory MarkHandler implementation. It stays in
+// the same package as inbox.Wrap so the test does not need to widen
+// any interface, and it lets us assert calls without a real DB.
+type fakeStore struct {
+	mu        sync.Mutex
+	seen      map[string]struct{} // "subscriber|eventID"
+	failNext  error               // returned once, then cleared
+	callCount int
+}
+
+func newFakeStore() *fakeStore { return &fakeStore{seen: map[string]struct{}{}} }
+
+func (s *fakeStore) MarkHandled(_ context.Context, subscriber string, eventID int64) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.callCount++
+	if s.failNext != nil {
+		err := s.failNext
+		s.failNext = nil
+		return false, err
+	}
+	key := keyOf(subscriber, eventID)
+	if _, dup := s.seen[key]; dup {
+		return true, nil
+	}
+	s.seen[key] = struct{}{}
+	return false, nil
+}
+
+func keyOf(subscriber string, eventID int64) string {
+	// A tiny inline join keeps the fake dependency-free.
+	return subscriber + "|" + itoa(eventID)
+}
+
+func itoa(n int64) string {
+	if n == 0 {
+		return "0"
+	}
+	var b [20]byte
+	i := len(b)
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	for n > 0 {
+		i--
+		b[i] = byte('0' + n%10)
+		n /= 10
+	}
+	if neg {
+		i--
+		b[i] = '-'
+	}
+	return string(b[i:])
+}
+
+func TestWrap_FirstDelivery_HandlerCalled(t *testing.T) {
+	is := is.New(t)
+	store := newFakeStore()
+	var called int
+	wrapped := Wrap("sub", store, func(_ context.Context, _ int64, _ eventbus.Event) error {
+		called++
+		return nil
+	})
+
+	err := wrapped(context.Background(), 42, testEvent{})
+
+	is.NoErr(err)
+	is.Equal(called, 1)
+	is.Equal(store.callCount, 1)
+}
+
+func TestWrap_DuplicateDelivery_HandlerSkipped(t *testing.T) {
+	is := is.New(t)
+	store := newFakeStore()
+	var called int
+	wrapped := Wrap("sub", store, func(_ context.Context, _ int64, _ eventbus.Event) error {
+		called++
+		return nil
+	})
+
+	is.NoErr(wrapped(context.Background(), 42, testEvent{}))
+	is.NoErr(wrapped(context.Background(), 42, testEvent{}))
+
+	is.Equal(called, 1)          // handler ran once, duplicate skipped at the wrapper
+	is.Equal(store.callCount, 2) // MarkHandled still consulted both times
+}
+
+func TestWrap_DifferentEventID_HandlerCalledAgain(t *testing.T) {
+	is := is.New(t)
+	store := newFakeStore()
+	var called int
+	wrapped := Wrap("sub", store, func(_ context.Context, _ int64, _ eventbus.Event) error {
+		called++
+		return nil
+	})
+
+	is.NoErr(wrapped(context.Background(), 1, testEvent{}))
+	is.NoErr(wrapped(context.Background(), 2, testEvent{}))
+
+	is.Equal(called, 2)
+	is.Equal(store.callCount, 2)
+}
+
+func TestWrap_ZeroEventID_PassesThrough(t *testing.T) {
+	is := is.New(t)
+	store := newFakeStore()
+	var called int
+	wrapped := Wrap("sub", store, func(_ context.Context, _ int64, _ eventbus.Event) error {
+		called++
+		return nil
+	})
+
+	// Two zero-id deliveries: both must reach the handler — eventID==0
+	// is the "no dedupe id available" sentinel.
+	is.NoErr(wrapped(context.Background(), 0, testEvent{}))
+	is.NoErr(wrapped(context.Background(), 0, testEvent{}))
+
+	is.Equal(called, 2)
+	is.Equal(store.callCount, 0) // store is bypassed entirely
+}
+
+func TestWrap_StorageError_HandlerNotCalled(t *testing.T) {
+	is := is.New(t)
+	store := newFakeStore()
+	store.failNext = errors.New("db transient")
+	var called int
+	wrapped := Wrap("sub", store, func(_ context.Context, _ int64, _ eventbus.Event) error {
+		called++
+		return nil
+	})
+
+	err := wrapped(context.Background(), 42, testEvent{})
+
+	is.True(err != nil)              // storage error surfaces to the caller
+	is.Equal(called, 0)              // handler MUST NOT run on storage failure
+	is.Equal(store.callCount, 1)
+
+	// Retry semantics: the next tick from the Outbox dispatcher
+	// presents the same row again; the store has cleared its
+	// failure and the handler now runs exactly once.
+	is.NoErr(wrapped(context.Background(), 42, testEvent{}))
+	is.Equal(called, 1)
+	is.Equal(store.callCount, 2)
+}
+
+func TestWrap_DifferentSubscribers_DedupeIsScopedToSubscriber(t *testing.T) {
+	is := is.New(t)
+	store := newFakeStore()
+	var aCalls, bCalls int
+	wrapA := Wrap("sub.a", store, func(_ context.Context, _ int64, _ eventbus.Event) error {
+		aCalls++
+		return nil
+	})
+	wrapB := Wrap("sub.b", store, func(_ context.Context, _ int64, _ eventbus.Event) error {
+		bCalls++
+		return nil
+	})
+
+	// Both subscribers see the same originating event id. Each runs
+	// once — dedupe is per-(subscriber, event_id), exactly the table
+	// shape says.
+	is.NoErr(wrapA(context.Background(), 7, testEvent{}))
+	is.NoErr(wrapB(context.Background(), 7, testEvent{}))
+
+	is.Equal(aCalls, 1)
+	is.Equal(bCalls, 1)
+}

--- a/backend/internal/inbox/postgres.go
+++ b/backend/internal/inbox/postgres.go
@@ -1,0 +1,87 @@
+// Package inbox implements the Inbox pattern — the consumer-side
+// complement to the Transactional Outbox (see internal/outbox).
+//
+// PROBLEM. The Outbox upgrades publisher-to-bus delivery from
+// at-most-once to at-least-once: a crash between Publish and MarkSent
+// in the outbox dispatcher will republish the same row on the next
+// tick. That puts the burden of idempotency on every subscriber —
+// each one has to find its own per-event dedupe story (a natural-id
+// no-op like cart Clear, a sent_emails ledger, an in-memory map that
+// doesn't survive restarts, …). The shapes drift, the guarantees
+// rot, and the at-least-once contract leaks into business code.
+//
+// SOLUTION. A single persistent table — inbox_handled — records, per
+// subscriber, which originating event ids have already been
+// processed. The dispatcher passes the outbox row id through to each
+// id-aware subscriber (eventbus.HandlerWithID); a thin wrapper
+// (inbox.Wrap) calls MarkHandled before invoking the underlying
+// handler. A redelivery short-circuits at the wrapper and the
+// business handler never runs twice.
+//
+// CONTRACT. Combined with a content-stable event id (the outbox row
+// id satisfies that — same row → same id across redeliveries) the
+// Inbox gives you effectively exactly-once at the subscriber
+// boundary. The classic caveat applies: this is exactly-once
+// PROCESSING (the inbox row is written in its own transaction, the
+// side effect runs separately), not the impossible exactly-once
+// DELIVERY. Side effects that themselves emit further events should
+// stage those into their own Outbox so the chain stays durable.
+package inbox
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+)
+
+// Postgres is the durable inbox store backed by the inbox_handled
+// table. The table is content-agnostic: the package only deals with a
+// subscriber name (a stable string the composition root assigns) and
+// an event id (the outbox row id supplied by the dispatcher).
+type Postgres struct {
+	db *sql.DB
+}
+
+// NewPostgres builds a Postgres inbox store from an *sql.DB. The
+// returned value is intentionally a value type so the composition
+// root passes it around by copy (it is just a thin wrapper over the
+// pool handle; no per-store state to share).
+func NewPostgres(db *sql.DB) Postgres {
+	return Postgres{db: db}
+}
+
+// MarkHandled records that (subscriber, eventID) has been processed.
+//
+// Return contract:
+//   - alreadyHandled == false, err == nil  -> the row was newly
+//     inserted; the caller MUST invoke the underlying handler.
+//   - alreadyHandled == true,  err == nil  -> a row for the same
+//     (subscriber, eventID) already existed (ON CONFLICT DO NOTHING
+//     suppressed the insert); the caller MUST skip the handler.
+//   - err != nil                            -> storage failure; the
+//     caller MUST NOT invoke the handler. The Outbox dispatcher will
+//     retry the same row on the next tick and MarkHandled will get
+//     another shot.
+//
+// Detection uses RowsAffected() rather than a CTE/xmax trick. The two
+// give the same answer for this query shape but RowsAffected is the
+// portable, ordinary-looking option a future maintainer recognises
+// immediately.
+func (p Postgres) MarkHandled(ctx context.Context, subscriber string, eventID int64) (alreadyHandled bool, err error) {
+	res, err := p.db.ExecContext(ctx, `
+		INSERT INTO inbox_handled (subscriber, event_id)
+		VALUES ($1, $2)
+		ON CONFLICT (subscriber, event_id) DO NOTHING
+	`, subscriber, eventID)
+	if err != nil {
+		return false, fmt.Errorf("inbox: mark handled (%s, %d): %w", subscriber, eventID, err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return false, fmt.Errorf("inbox: rows affected (%s, %d): %w", subscriber, eventID, err)
+	}
+	// n == 0 means ON CONFLICT DO NOTHING fired — the row already
+	// existed, i.e. this is a duplicate delivery. n == 1 means the
+	// insert took effect and the caller now owns the side effect.
+	return n == 0, nil
+}

--- a/backend/internal/outbox/dispatcher.go
+++ b/backend/internal/outbox/dispatcher.go
@@ -19,8 +19,14 @@ type Store interface {
 // Publisher is the subset of *eventbus.Bus the dispatcher uses. The
 // concrete bus satisfies it; tests pass a fake to assert what was
 // published.
+//
+// PublishWithID threads the outbox row's id through to id-aware
+// subscribers (eventbus.HandlerWithID) — that id is what
+// internal/inbox uses as a content-stable dedupe key, completing the
+// at-least-once -> effectively exactly-once story at the subscriber
+// boundary.
 type Publisher interface {
-	Publish(ctx context.Context, e eventbus.Event)
+	PublishWithID(ctx context.Context, eventID int64, e eventbus.Event)
 }
 
 // Decoder turns a stored (kind, payload) row back into the integration
@@ -135,7 +141,7 @@ func (d *Dispatcher) dispatchOnce(ctx context.Context) {
 			}
 			continue
 		}
-		d.bus.Publish(ctx, event)
+		d.bus.PublishWithID(ctx, r.ID, event)
 		if err := d.store.MarkSent(ctx, r.ID); err != nil {
 			if d.logger != nil {
 				d.logger.WithError(err).WithFields(logrus.Fields{

--- a/backend/internal/outbox/dispatcher_test.go
+++ b/backend/internal/outbox/dispatcher_test.go
@@ -63,12 +63,14 @@ func (s *fakeStore) MarkSent(_ context.Context, id int64) error {
 type fakeBus struct {
 	mu        sync.Mutex
 	published []eventbus.Event
+	ids       []int64
 }
 
-func (b *fakeBus) Publish(_ context.Context, e eventbus.Event) {
+func (b *fakeBus) PublishWithID(_ context.Context, eventID int64, e eventbus.Event) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	b.published = append(b.published, e)
+	b.ids = append(b.ids, eventID)
 }
 
 func discardLogger() logrus.FieldLogger {
@@ -97,6 +99,9 @@ func TestDispatchOnce_PublishesAndMarksSent(t *testing.T) {
 	is.Equal(len(bus.published), 2)
 	is.Equal(bus.published[0].(testEvent).ID, "one")
 	is.Equal(bus.published[1].(testEvent).ID, "two")
+	// The dispatcher threads the outbox row id through to the bus so
+	// id-aware subscribers (internal/inbox.Wrap) can dedupe on it.
+	is.Equal(bus.ids, []int64{1, 2})
 	is.Equal(store.sent, []int64{1, 2})
 	is.Equal(len(store.rows), 0)
 }

--- a/migrations/000036_inbox_handled.down.sql
+++ b/migrations/000036_inbox_handled.down.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+DROP INDEX IF EXISTS public.inbox_handled_subscriber_idx;
+DROP TABLE IF EXISTS public.inbox_handled;
+
+COMMIT;

--- a/migrations/000036_inbox_handled.up.sql
+++ b/migrations/000036_inbox_handled.up.sql
@@ -1,0 +1,29 @@
+BEGIN;
+
+-- inbox_handled is the durability backbone of the Inbox pattern, the
+-- consumer-side mirror of the Transactional Outbox table. The outbox
+-- guarantees at-least-once delivery from the producer; the inbox
+-- records per-subscriber which originating event ids have already
+-- been processed so a redelivery is a cheap no-op instead of a
+-- repeated side effect.
+--
+-- (subscriber, event_id) is the composite primary key: each
+-- subscriber sees the same event id at most once, but two different
+-- subscribers can independently handle the same originating event.
+-- event_id is the outbox_event.id of the originating row so the key
+-- is content-stable across redeliveries and process restarts.
+CREATE TABLE inbox_handled (
+    subscriber text NOT NULL,
+    event_id bigint NOT NULL,
+    handled_at timestamptz NOT NULL DEFAULT now(),
+    PRIMARY KEY (subscriber, event_id)
+);
+
+-- Operator-facing index: "show me the last N events handled by
+-- subscriber X". Not needed by the hot path (the primary key already
+-- covers the dedupe lookup) but cheap to maintain and invaluable for
+-- post-incident inspection.
+CREATE INDEX inbox_handled_subscriber_idx
+    ON inbox_handled(subscriber, handled_at DESC);
+
+COMMIT;


### PR DESCRIPTION
Completes the Outbox/Inbox pair so at-least-once delivery becomes effectively exactly-once at the subscriber boundary.

- Migration: `inbox_handled(subscriber, event_id, handled_at)` with composite PK + operator index.
- `eventbus.Bus` gains `PublishWithID` / `SubscribeWithID` (using a new `HandlerWithID` type). Legacy `Publish` / `Subscribe` keep working — `Publish(ctx, e)` is a shim that calls `PublishWithID(ctx, 0, e)`. eventID==0 is the documented "no dedupe id available" sentinel.
- Outbox dispatcher now publishes via `PublishWithID` with the outbox row's id.
- New `internal/inbox` package: `Postgres.MarkHandled` returns `(alreadyHandled bool, err)` via `INSERT ... ON CONFLICT DO NOTHING` + `RowsAffected()`. `inbox.Wrap(subscriber, store, handler)` skips the handler on duplicates and on storage errors leaves the row unmarked so the Outbox dispatcher retries next tick.
- The three OrderPaid subscribers (cart-clear, order-confirmation email, fulfillment.OnOrderPaid) are now wrapped via the inbox with stable names. The old in-memory dedupe `sync.Map` is gone.

## Test plan
- [x] build / build -tags integration / vet / tests / lint green
- [x] dedupe tests: first delivery passes, duplicate skipped, different ids re-fire, eventID==0 passes through, storage errors don't skip, per-subscriber scoping