### PR TITLE
refactor(checkout): extract pricing math into a Domain Service

### DIFF
--- a/backend/checkout/app/checkout.go
+++ b/backend/checkout/app/checkout.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math"
 	"time"
 
 	cartDomain "github.com/bkielbasa/go-ecommerce/backend/cart/domain"
@@ -93,34 +92,13 @@ type nopStockMovements struct{}
 
 func (nopStockMovements) Record(context.Context, string, int, string, string) error { return nil }
 
-// PricingPolicy tells the checkout service how to derive tax and the
-// effective shipping cost from the order's subtotal and chosen shipping
-// method. Both fields default to zero/disabled so existing wiring stays
-// arithmetic-identical to before the change.
-type PricingPolicy struct {
-	// TaxRatePercent is the flat tax rate applied to the subtotal, e.g.
-	// 8.875 for 8.875%. 0 disables tax.
-	TaxRatePercent float64
-	// FreeShippingThreshold is the minimum subtotal (in minor units) at or
-	// above which the chosen method's shipping cost is overridden to 0.
-	// 0 disables the override.
-	FreeShippingThreshold int64
-}
-
-// computeTaxAndShipping applies the policy to a given subtotal + method,
-// returning the tax amount and the effective shipping cost (both in minor
-// units).
-func (p PricingPolicy) computeTaxAndShipping(subtotal int64, method domain.ShippingMethod) (int64, int64) {
-	var tax int64
-	if p.TaxRatePercent > 0 && subtotal > 0 {
-		tax = int64(math.Round(float64(subtotal) * p.TaxRatePercent / 100.0))
-	}
-	shipping := method.Cost()
-	if p.FreeShippingThreshold > 0 && subtotal >= p.FreeShippingThreshold {
-		shipping = 0
-	}
-	return tax, shipping
-}
+// PricingPolicy is an alias for the domain-level policy so the
+// composition root (cmd/web) can continue to construct one through the
+// checkout/app package while the actual math lives in the Pricing
+// domain service (checkout/domain.PriceQuote). The field set —
+// TaxRatePercent + FreeShippingThreshold — is unchanged, which keeps
+// the historical wiring arithmetic-identical to before the lift.
+type PricingPolicy = domain.PricingPolicy
 
 // IDGenerator returns a fresh order ID. Injected so tests can substitute a
 // deterministic generator.
@@ -207,13 +185,9 @@ func (s CheckoutService) WithPromoRedeemer(p PromoRedeemer) CheckoutService {
 // recorded but will not appear in any customer's order history.
 //
 // discount carries an already-resolved promo code (see promo/app.Service.
-// Resolve). Pricing math applies it BEFORE tax:
-//
-//	discountedSubtotal = subtotal - discount.AmountMinor
-//	tax                = round(discountedSubtotal * cfg.TaxRate / 100)
-//	effectiveShipping  = 0 if discount.FreeShipping
-//	                     else (free-shipping-threshold logic on discountedSubtotal)
-//	total              = discountedSubtotal + tax + effectiveShipping
+// Resolve). The pricing math — discount-before-tax, free-shipping
+// override, total — lives in the domain.PriceQuote service; this
+// orchestrator just hands it the inputs and reads the quote back.
 //
 // An empty Discount value (no code applied) is the same arithmetic as
 // before promo codes existed.
@@ -289,37 +263,20 @@ func (s CheckoutService) Place(ctx context.Context, sessID, customerID, cardNumb
 		_ = s.movements.Record(ctx, vid, -qty, "reserve", orderID)
 	}
 
-	// Pricing math, in order:
-	//   1. sum line totals → subtotal
-	//   2. subtract discount.AmountMinor (capped to 0) → discountedSubtotal
-	//   3. compute tax on discountedSubtotal so the saving carries through
-	//      the tax line (avoids charging tax on a discount the customer
-	//      never paid)
-	//   4. compute shipping from discountedSubtotal via the free-shipping
-	//      threshold; a free-shipping promo overrides that to 0 outright
-	//   5. total = discountedSubtotal + tax + effectiveShipping
-	var subtotal int64
-	for _, ln := range lines {
-		subtotal += ln.LineTotal()
-	}
-	discountAmount := discount.AmountMinor()
-	if discountAmount < 0 {
-		discountAmount = 0
-	}
-	if discountAmount > subtotal {
-		discountAmount = subtotal
-	}
-	discountedSubtotal := subtotal - discountAmount
-	tax, effectiveShipping := s.pricing.computeTaxAndShipping(discountedSubtotal, shipMethod)
-	if discount.FreeShipping() {
-		effectiveShipping = 0
-	}
+	// Pricing math is delegated to the Pricing domain service so this
+	// orchestrator stays focused on the workflow. The aggregate's
+	// constructor still takes the resolved tax / shipping / discount
+	// values — we just no longer compute them here.
+	quote := domain.PriceQuote(lines, shipMethod, domain.DiscountInput{
+		AmountMinor:  discount.AmountMinor(),
+		FreeShipping: discount.FreeShipping(),
+	}, s.pricing)
 	span.SetAttributes(
-		attribute.Int64("order.subtotal", subtotal),
-		attribute.Int64("order.discount", discountAmount),
+		attribute.Int64("order.subtotal", quote.Subtotal),
+		attribute.Int64("order.discount", quote.DiscountAmount),
 		attribute.String("order.discount_code", discount.Code()),
-		attribute.Int64("order.tax", tax),
-		attribute.Int64("order.shipping", effectiveShipping),
+		attribute.Int64("order.tax", quote.Tax),
+		attribute.Int64("order.shipping", quote.ShippingCost),
 	)
 
 	// channel records the sales channel the order was placed through; the
@@ -327,7 +284,7 @@ func (s CheckoutService) Place(ctx context.Context, sessID, customerID, cardNumb
 	// "web". Pluggable when iOS / API channels arrive — the signature is
 	// already wired through PlaceOrder and the OrderPlaced v2 schema.
 	const channel = "web"
-	order, err := domain.PlaceOrder(orderID, sessID, customerID, shipTo, shipMethod, payMethod, lines, tax, effectiveShipping, discount.Code(), discountAmount, channel, s.now())
+	order, err := domain.PlaceOrder(orderID, sessID, customerID, shipTo, shipMethod, payMethod, lines, quote.Tax, quote.ShippingCost, discount.Code(), quote.DiscountAmount, channel, s.now())
 	if err != nil {
 		_ = s.stock.Release(ctx, quantities)
 		for vid, qty := range quantities {

--- a/backend/checkout/domain/pricing.go
+++ b/backend/checkout/domain/pricing.go
@@ -1,0 +1,123 @@
+// Pricing is a domain service: pure math that doesn't belong to any
+// aggregate. It lives in the domain package because it speaks the domain's
+// vocabulary (Line, ShippingMethod) and has no infrastructure dependencies.
+//
+// The split keeps the Order aggregate focused on its lifecycle (place,
+// pay, cancel, ship, ...) and the application service (checkout/app)
+// focused on orchestration (load cart, reserve stock, charge, save).
+// The maths — subtotal, discount clamp, tax on the discounted subtotal,
+// free-shipping override, total — lives here so it is independently
+// testable and easy to reason about.
+package domain
+
+import "math"
+
+// Quote is the value object returned by PriceQuote: every line a checkout
+// summary or order confirmation can render. Currency is implicit — the
+// caller derives it from the order's lines and pairs it with these
+// numeric amounts. All fields are in minor units (e.g. cents).
+type Quote struct {
+	// Subtotal is the sum of every Line.LineTotal() before any discount,
+	// tax or shipping is applied.
+	Subtotal int64
+	// DiscountAmount is the resolved promo discount actually subtracted
+	// from the subtotal, clamped so the discounted subtotal never goes
+	// negative.
+	DiscountAmount int64
+	// Tax is computed on the discounted subtotal so the customer is not
+	// charged tax on a discount they never paid.
+	Tax int64
+	// ShippingCost is the effective shipping price: 0 when free shipping
+	// applies (either the promo flag or the configured threshold),
+	// otherwise the chosen ShippingMethod's Cost().
+	ShippingCost int64
+	// Total is discountedSubtotal + Tax + ShippingCost.
+	Total int64
+	// FreeShipping records whether the shipping cost was zeroed by the
+	// pricing rules — useful for the summary line ("Free shipping
+	// applied"). Set when either the promo's FreeShipping flag is true
+	// or the configured FreeShippingThreshold was reached.
+	FreeShipping bool
+}
+
+// PricingPolicy carries the configurable inputs to the pricing math:
+// the flat tax rate and the free-shipping threshold. Both default to
+// zero, which disables the corresponding rule (no tax, no automatic
+// free-shipping override) — matching the historical behaviour before
+// either was wired.
+type PricingPolicy struct {
+	// TaxRatePercent is the flat tax rate applied to the discounted
+	// subtotal, e.g. 8.875 for 8.875%. 0 disables tax.
+	TaxRatePercent float64
+	// FreeShippingThreshold is the minimum (discounted) subtotal at or
+	// above which the chosen method's shipping cost is overridden to 0.
+	// 0 disables the override.
+	FreeShippingThreshold int64
+}
+
+// DiscountInput is what the pricing service needs from a resolved
+// discount. It is deliberately a small, local value type so the pricing
+// math does not depend on the promo bounded context's types — the
+// application service translates from promo.Discount into DiscountInput.
+type DiscountInput struct {
+	// AmountMinor is the discount in minor units. Negative values are
+	// treated as zero; values larger than the subtotal are clamped to
+	// the subtotal so the discounted subtotal cannot go negative.
+	AmountMinor int64
+	// FreeShipping zeroes the effective shipping cost regardless of the
+	// configured threshold.
+	FreeShipping bool
+}
+
+// PriceQuote is the domain service entry point. It is a pure function:
+// given the line snapshots, the chosen shipping method, the resolved
+// discount and the configured policy, it returns the complete Quote.
+// The math, in order:
+//
+//  1. subtotal = sum of Line.LineTotal() over every line.
+//  2. discount = min(max(DiscountInput.AmountMinor, 0), subtotal) — clamp
+//     so the discounted subtotal cannot go negative.
+//  3. discountedSubtotal = subtotal - discount.
+//  4. tax = round(discountedSubtotal * policy.TaxRatePercent / 100).
+//  5. freeShipping = DiscountInput.FreeShipping OR
+//     (policy.FreeShippingThreshold > 0 AND
+//     discountedSubtotal >= policy.FreeShippingThreshold).
+//  6. shippingCost = 0 when freeShipping, else shipMethod.Cost().
+//  7. total = discountedSubtotal + tax + shippingCost.
+func PriceQuote(lines []Line, shipMethod ShippingMethod, discount DiscountInput, policy PricingPolicy) Quote {
+	var subtotal int64
+	for _, ln := range lines {
+		subtotal += ln.LineTotal()
+	}
+
+	discountAmount := discount.AmountMinor
+	if discountAmount < 0 {
+		discountAmount = 0
+	}
+	if discountAmount > subtotal {
+		discountAmount = subtotal
+	}
+	discountedSubtotal := subtotal - discountAmount
+
+	var tax int64
+	if policy.TaxRatePercent > 0 && discountedSubtotal > 0 {
+		tax = int64(math.Round(float64(discountedSubtotal) * policy.TaxRatePercent / 100.0))
+	}
+
+	freeShipping := discount.FreeShipping ||
+		(policy.FreeShippingThreshold > 0 && discountedSubtotal >= policy.FreeShippingThreshold)
+
+	var shippingCost int64
+	if !freeShipping {
+		shippingCost = shipMethod.Cost()
+	}
+
+	return Quote{
+		Subtotal:       subtotal,
+		DiscountAmount: discountAmount,
+		Tax:            tax,
+		ShippingCost:   shippingCost,
+		Total:          discountedSubtotal + tax + shippingCost,
+		FreeShipping:   freeShipping,
+	}
+}

--- a/backend/checkout/domain/pricing_test.go
+++ b/backend/checkout/domain/pricing_test.go
@@ -1,0 +1,154 @@
+package domain_test
+
+import (
+	"testing"
+
+	"github.com/bkielbasa/go-ecommerce/backend/checkout/domain"
+)
+
+// TestPriceQuote covers the pricing domain service's interesting cases.
+// The math order is documented on PriceQuote itself; this table exercises
+// each branch in isolation plus the clamp invariant.
+func TestPriceQuote(t *testing.T) {
+	lines := func() []domain.Line {
+		// 2 * 1500 + 1 * 2000 = 5000 subtotal.
+		return []domain.Line{
+			domain.NewLine("v1", "Mug", 2, 1500, "USD"),
+			domain.NewLine("v2", "Plate", 1, 2000, "USD"),
+		}
+	}
+	courier := domain.RebuildShippingMethod("courier", "Courier", 1500)
+	pickup := domain.RebuildShippingMethod("pickup", "Personal pickup", 0)
+
+	tests := []struct {
+		name     string
+		lines    []domain.Line
+		method   domain.ShippingMethod
+		discount domain.DiscountInput
+		policy   domain.PricingPolicy
+		want     domain.Quote
+	}{
+		{
+			name:     "no discount no tax no free-shipping",
+			lines:    lines(),
+			method:   courier,
+			discount: domain.DiscountInput{},
+			policy:   domain.PricingPolicy{},
+			want: domain.Quote{
+				Subtotal:       5000,
+				DiscountAmount: 0,
+				Tax:            0,
+				ShippingCost:   1500,
+				Total:          6500,
+				FreeShipping:   false,
+			},
+		},
+		{
+			// 10% of 5000 = 500.
+			name:     "percent tax only",
+			lines:    lines(),
+			method:   courier,
+			discount: domain.DiscountInput{},
+			policy:   domain.PricingPolicy{TaxRatePercent: 10},
+			want: domain.Quote{
+				Subtotal:       5000,
+				DiscountAmount: 0,
+				Tax:            500,
+				ShippingCost:   1500,
+				Total:          7000,
+				FreeShipping:   false,
+			},
+		},
+		{
+			// 1000 off, 10% tax of remaining 4000 = 400.
+			name:     "fixed discount applied before tax",
+			lines:    lines(),
+			method:   courier,
+			discount: domain.DiscountInput{AmountMinor: 1000},
+			policy:   domain.PricingPolicy{TaxRatePercent: 10},
+			want: domain.Quote{
+				Subtotal:       5000,
+				DiscountAmount: 1000,
+				Tax:            400,
+				ShippingCost:   1500,
+				Total:          5900,
+				FreeShipping:   false,
+			},
+		},
+		{
+			// Threshold 4000 — discounted subtotal 5000 clears it, shipping is zeroed.
+			name:     "free shipping via threshold",
+			lines:    lines(),
+			method:   courier,
+			discount: domain.DiscountInput{},
+			policy:   domain.PricingPolicy{FreeShippingThreshold: 4000},
+			want: domain.Quote{
+				Subtotal:       5000,
+				DiscountAmount: 0,
+				Tax:            0,
+				ShippingCost:   0,
+				Total:          5000,
+				FreeShipping:   true,
+			},
+		},
+		{
+			// Promo flag wins regardless of the threshold being unset.
+			name:     "free shipping via discount flag",
+			lines:    lines(),
+			method:   courier,
+			discount: domain.DiscountInput{FreeShipping: true},
+			policy:   domain.PricingPolicy{},
+			want: domain.Quote{
+				Subtotal:       5000,
+				DiscountAmount: 0,
+				Tax:            0,
+				ShippingCost:   0,
+				Total:          5000,
+				FreeShipping:   true,
+			},
+		},
+		{
+			// Discount larger than subtotal must clamp; total can't go negative
+			// and tax on a zero discounted subtotal is zero too.
+			name:     "discount greater than subtotal clamps to subtotal",
+			lines:    lines(),
+			method:   courier,
+			discount: domain.DiscountInput{AmountMinor: 9_999_999},
+			policy:   domain.PricingPolicy{TaxRatePercent: 10},
+			want: domain.Quote{
+				Subtotal:       5000,
+				DiscountAmount: 5000,
+				Tax:            0,
+				ShippingCost:   1500,
+				Total:          1500,
+				FreeShipping:   false,
+			},
+		},
+		{
+			// Pickup is free shipping by virtue of Cost()==0 — assert the
+			// "no override needed" path stays internally consistent.
+			name:     "pickup method costs nothing without free-shipping flag",
+			lines:    lines(),
+			method:   pickup,
+			discount: domain.DiscountInput{},
+			policy:   domain.PricingPolicy{},
+			want: domain.Quote{
+				Subtotal:       5000,
+				DiscountAmount: 0,
+				Tax:            0,
+				ShippingCost:   0,
+				Total:          5000,
+				FreeShipping:   false,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := domain.PriceQuote(tc.lines, tc.method, tc.discount, tc.policy)
+			if got != tc.want {
+				t.Errorf("PriceQuote = %+v\n want %+v", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Lifts the subtotal + discount + tax + shipping math out of the orchestrator and into a pure domain service. The aggregate stays focused on lifecycle; the orchestrator stays focused on orchestration; the math lives in its own testable place.

- New `backend/checkout/domain/pricing.go`: a pure function `PriceQuote(lines, shipMethod, discount, policy) Quote` returning a `Quote{Subtotal, DiscountAmount, Tax, ShippingCost, Total, FreeShipping}`. No I/O, no context, no logger.
- Math order (documented in code): subtotal → clamp discount → tax on the discounted subtotal → free-shipping if discount-flag or threshold met → total.
- `checkout/app.Place` becomes thin orchestration: cart.Get → build lines → resolve discount → `PriceQuote` → reserve stock → PlaceOrder → charge → save → publish. The aggregate's `PlaceOrder` signature is unchanged.
- `app.PricingPolicy` becomes a type alias of `domain.PricingPolicy` so the composition root keeps compiling unchanged.

## Test plan
- [x] build / build -tags integration / vet / tests / lint green
- [x] Table-driven `TestPriceQuote`: no-discount/no-tax/no-free-shipping, percent tax only, fixed discount before tax, free-shipping via threshold, free-shipping via discount flag, discount > subtotal (clamps), pickup method with zero cost