### PR TITLE
feat(http): Idempotency-Key middleware

### DIFF
--- a/backend/internal/idempotency/postgres.go
+++ b/backend/internal/idempotency/postgres.go
@@ -1,0 +1,166 @@
+// Package idempotency implements the HTTP-boundary Idempotency-Key
+// pattern: clients send `Idempotency-Key: <opaque>` on a state-changing
+// request (POST/PUT/PATCH/DELETE) and a retry carrying the SAME key
+// gets the recorded response replayed verbatim, without re-running the
+// handler.
+//
+// WHY. CSRF protects against cross-origin abuse; retries are a
+// different failure mode. A network blip after the server commits but
+// before the client receives the response leaves the client uncertain
+// whether the action took effect. Without a key the client either
+// retries (and risks a duplicate write) or gives up (and risks lost
+// work). The Idempotency-Key contract makes "retry" the safe choice.
+//
+// WHERE IT FITS. The Outbox upgrades publisher→bus delivery to
+// at-least-once; the Inbox (internal/inbox) gives subscribers per-event
+// dedupe so their side effects run effectively once. The two together
+// give exactly-once SERVER-side semantics for asynchronous events.
+// This package is the matching boundary control for CLIENT-driven
+// requests: it makes "the same HTTP retry" cheap and safe in exactly
+// the same way the Inbox makes "the same outbox redelivery" cheap and
+// safe.
+//
+// CONTRACT.
+//   - The first request with a given key runs the handler; the
+//     middleware records (status, headers, body) and writes them under
+//     that key with a 24h TTL.
+//   - A retry with the SAME key returns the stored tuple without
+//     invoking the handler.
+//   - Save uses INSERT ... ON CONFLICT (key) DO NOTHING so a true race
+//     between two simultaneous first-time submissions still records
+//     exactly one response (whichever transaction commits first wins;
+//     the loser's recording is silently dropped — the loser's HTTP
+//     response has already been sent over the wire, that is fine).
+//   - TTL is 24h. The table is a retry-safety cache, not an audit log;
+//     a longer window grows the surface without unlocking real use
+//     cases.
+//
+// LIMITATIONS. Stored response sizes are bounded only by the table
+// (bytea, jsonb) — operators MUST avoid opting in handlers that stream
+// large responses. The middleware buffers the entire body in memory
+// before recording it.
+package idempotency
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+// StoredResponse is the recorded snapshot of a successfully processed
+// request. The middleware writes the captured ResponseWriter state
+// here on first execution and replays the same StoredResponse on every
+// subsequent retry that arrives with the same Idempotency-Key.
+//
+// Headers is a defensive copy of http.Header (which is itself a
+// map[string][]string) — storing it through the StoredResponse value
+// keeps the package storage-only with no net/http dependency.
+type StoredResponse struct {
+	StatusCode int
+	Body       []byte
+	Headers    map[string][]string
+}
+
+// Postgres is the durable Idempotency-Key store backed by the
+// idempotency_key table. The struct is intentionally a value type so
+// the composition root passes it around by copy (it is just a thin
+// wrapper over the pool handle; no per-store state to share).
+type Postgres struct {
+	db *sql.DB
+}
+
+// NewPostgres builds a Postgres idempotency store from an *sql.DB.
+//
+// Wiring note (the constraint that main.go is off-limits to this
+// agent): the composition root MUST call
+//
+//	app.Use(layout.IdempotencyMiddleware(idempotency.NewPostgres(db)))
+//
+// after layout.New so the middleware runs for every route on the
+// shared gorilla/mux pipeline. The middleware is content-agnostic and
+// only honors the header when it is present, so opting in a handler is
+// purely a client-side decision to include `Idempotency-Key`.
+func NewPostgres(db *sql.DB) Postgres {
+	return Postgres{db: db}
+}
+
+// Find looks up a recorded response by key.
+//
+// Return contract:
+//   - ok == true,  err == nil -> a fresh (not-yet-expired) row was
+//     found; the middleware MUST replay it instead of calling the
+//     handler.
+//   - ok == false, err == nil -> no row, or the row has expired; the
+//     middleware MUST run the handler and then Save the result.
+//   - err != nil              -> storage failure; the middleware MUST
+//     fall through to the handler. The point of the table is retry
+//     safety, not availability — a DB blip should not block real
+//     traffic, and the retry-on-network-blip case is itself rare
+//     enough that an occasional double-execution under DB stress is
+//     an acceptable degradation.
+//
+// The expires_at filter is applied in SQL so an expired-but-not-yet-
+// reaped row is invisible to the hot path without the middleware
+// having to know the TTL.
+func (p Postgres) Find(ctx context.Context, key string) (StoredResponse, bool, error) {
+	var (
+		status     int
+		body       []byte
+		headersRaw []byte
+	)
+	err := p.db.QueryRowContext(ctx, `
+		SELECT status_code, response_body, response_headers
+		FROM idempotency_key
+		WHERE key = $1 AND expires_at > now()
+	`, key).Scan(&status, &body, &headersRaw)
+	if err == sql.ErrNoRows {
+		return StoredResponse{}, false, nil
+	}
+	if err != nil {
+		return StoredResponse{}, false, fmt.Errorf("idempotency: find %q: %w", key, err)
+	}
+	headers := map[string][]string{}
+	if len(headersRaw) > 0 {
+		if jerr := json.Unmarshal(headersRaw, &headers); jerr != nil {
+			return StoredResponse{}, false, fmt.Errorf("idempotency: decode headers for %q: %w", key, jerr)
+		}
+	}
+	return StoredResponse{StatusCode: status, Body: body, Headers: headers}, true, nil
+}
+
+// Save records the response captured by the middleware under key.
+//
+// The INSERT uses ON CONFLICT (key) DO NOTHING so two simultaneous
+// first-time requests with the same key race safely: whichever
+// transaction commits first owns the recorded tuple, and the loser's
+// Save is silently a no-op. The loser's response has already been sent
+// to its caller — that response just doesn't get cached for a future
+// retry. The next retry will replay the winner's tuple, which is the
+// outcome the contract promises.
+//
+// ttl drives expires_at; the middleware passes 24h. The default in the
+// table is also 24h, but the column is set explicitly here so a future
+// caller experimenting with a different TTL doesn't need a schema
+// change.
+func (p Postgres) Save(ctx context.Context, key, method, path string, resp StoredResponse, ttl time.Duration) error {
+	headers := resp.Headers
+	if headers == nil {
+		headers = map[string][]string{}
+	}
+	headersRaw, err := json.Marshal(headers)
+	if err != nil {
+		return fmt.Errorf("idempotency: encode headers for %q: %w", key, err)
+	}
+	_, err = p.db.ExecContext(ctx, `
+		INSERT INTO idempotency_key (
+			key, method, path, status_code, response_body, response_headers, expires_at
+		) VALUES ($1, $2, $3, $4, $5, $6, now() + $7::interval)
+		ON CONFLICT (key) DO NOTHING
+	`, key, method, path, resp.StatusCode, resp.Body, headersRaw, fmt.Sprintf("%d milliseconds", ttl.Milliseconds()))
+	if err != nil {
+		return fmt.Errorf("idempotency: save %q: %w", key, err)
+	}
+	return nil
+}

--- a/backend/layout/http_admin_orders.go
+++ b/backend/layout/http_admin_orders.go
@@ -211,6 +211,14 @@ func (handler httpHandler) AdminInventory(w http.ResponseWriter, r *http.Request
 // AdminRefundOrder refunds the fulfillment for an order; the
 // fulfillment service also releases the reserved stock back to the
 // catalogue via the wired StockReleaser port.
+//
+// Idempotency. This endpoint participates in the HTTP-boundary
+// Idempotency-Key contract (see internal/idempotency): a client may
+// send the same `Idempotency-Key` header on a retry and the
+// originally-recorded response will be replayed instead of issuing a
+// second refund attempt. Refunds are the highest-stakes admin POST in
+// the system — a network blip after the refund commits is exactly the
+// situation the contract exists to neutralise.
 func (handler httpHandler) AdminRefundOrder(w http.ResponseWriter, r *http.Request) {
 	if _, ok := handler.requireAdmin(w, r); !ok {
 		return

--- a/backend/layout/http_admin_products.go
+++ b/backend/layout/http_admin_products.go
@@ -103,6 +103,13 @@ func (handler httpHandler) AdminNewProductForm(w http.ResponseWriter, r *http.Re
 
 // AdminCreateProduct handles the create-product form (a simple product with a
 // single default variant). Price is entered in major units (e.g. "9.00").
+//
+// Idempotency. This endpoint participates in the HTTP-boundary
+// Idempotency-Key contract (see internal/idempotency): a client may
+// send the same `Idempotency-Key` header on a retry and the
+// originally-recorded response will be replayed instead of creating a
+// second product. No per-handler code is needed — the middleware
+// installed via layout.IdempotencyMiddleware is content-agnostic.
 func (handler httpHandler) AdminCreateProduct(w http.ResponseWriter, r *http.Request) {
 	if _, ok := handler.requireAdmin(w, r); !ok {
 		return

--- a/backend/layout/http_admin_promo.go
+++ b/backend/layout/http_admin_promo.go
@@ -33,6 +33,14 @@ func (handler httpHandler) AdminPromoCodes(w http.ResponseWriter, r *http.Reques
 }
 
 // AdminCreatePromoCode handles the create-promo-code form submission.
+//
+// Idempotency. This endpoint participates in the HTTP-boundary
+// Idempotency-Key contract (see internal/idempotency): a client may
+// send the same `Idempotency-Key` header on a retry and the
+// originally-recorded response will be replayed instead of attempting
+// to create a duplicate promo code (which the domain would reject with
+// ErrCodeAlreadyExists anyway — the contract just makes the retry
+// path return the original "created" response cleanly).
 func (handler httpHandler) AdminCreatePromoCode(w http.ResponseWriter, r *http.Request) {
 	if _, ok := handler.requireAdmin(w, r); !ok {
 		return

--- a/backend/layout/idempotency_middleware.go
+++ b/backend/layout/idempotency_middleware.go
@@ -1,0 +1,195 @@
+package layout
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/bkielbasa/go-ecommerce/backend/internal/idempotency"
+	"github.com/bkielbasa/go-ecommerce/backend/internal/observability"
+	"github.com/gorilla/mux"
+)
+
+// idempotencyHeader is the standard request header clients use to
+// stamp a retry-safe key onto an unsafe HTTP request. Values are
+// opaque to the server — the middleware only cares that the same
+// string arrives on the retry.
+const idempotencyHeader = "Idempotency-Key"
+
+// idempotencyTTL bounds how long a recorded response is replayable.
+// 24h matches the column default and is documented in the package
+// doc on internal/idempotency: long enough to cover a realistic
+// human-driven retry window, short enough to keep the cache surface
+// modest.
+const idempotencyTTL = 24 * time.Hour
+
+// IdempotencyStore is the storage seam the middleware depends on.
+// Defined as an interface (rather than the concrete *idempotency.Postgres)
+// so the middleware test can drive an in-memory fake without standing
+// up a database.
+type IdempotencyStore interface {
+	Find(ctx context.Context, key string) (idempotency.StoredResponse, bool, error)
+	Save(ctx context.Context, key, method, path string, resp idempotency.StoredResponse, ttl time.Duration) error
+}
+
+// IdempotencyMiddleware returns a gorilla/mux MiddlewareFunc that
+// implements the HTTP-boundary Idempotency-Key pattern.
+//
+// Wiring. The composition root in cmd/web/main.go must install it on
+// the same App.Use pipeline that already registers CSRFMiddleware:
+//
+//	app.Use(layout.IdempotencyMiddleware(idempotency.NewPostgres(db)))
+//
+// (cmd/web/main.go is off-limits to the agent that wrote this code; a
+// follow-up commit lands the one-line wiring change.)
+//
+// Behaviour, per request:
+//   - Safe methods (GET/HEAD/OPTIONS) are forwarded unchanged. Safe
+//     methods MUST NOT mutate state, so a "retry" of a GET is by
+//     definition idempotent already; spending a DB hit per render to
+//     prove that adds latency for zero correctness gain.
+//   - Unsafe methods (POST/PUT/PATCH/DELETE) are inspected for the
+//     `Idempotency-Key` header. Empty header => pass-through (the
+//     middleware is opt-IN at the client, not the route — see the
+//     opt-in handlers' Go doc comments). Non-empty header =>
+//     Find first; replay on hit; otherwise wrap the ResponseWriter
+//     with a recorder, call next, and Save what the handler emitted.
+//   - Find / Save errors are logged but never block the request. The
+//     point of the table is retry safety, not availability.
+//
+// Why scope by method, not by route. The middleware is content-
+// agnostic: it captures status + headers + body and replays them
+// faithfully. Route-scoped opt-in would require either a registry of
+// "idempotent" routes (drifts out of sync with the router) or a per-
+// handler call (defeats the middleware shape). The header-presence
+// gate keeps every route eligible without ever recording a response
+// the client did not opt-in to.
+func IdempotencyMiddleware(store IdempotencyStore) mux.MiddlewareFunc {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if isSafeMethod(r.Method) {
+				next.ServeHTTP(w, r)
+				return
+			}
+			key := r.Header.Get(idempotencyHeader)
+			if key == "" {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			log := observability.Logger(r.Context())
+
+			if existing, ok, err := store.Find(r.Context(), key); err != nil {
+				log.WithError(err).WithField("idempotency.key", key).
+					Warn("idempotency: find failed; falling through to handler")
+			} else if ok {
+				replayStoredResponse(w, existing)
+				return
+			}
+
+			rec := newIdempotencyRecorder(w)
+			next.ServeHTTP(rec, r)
+
+			resp := idempotency.StoredResponse{
+				StatusCode: rec.statusCode,
+				Body:       rec.body.Bytes(),
+				Headers:    cloneHeader(rec.capturedHeaders),
+			}
+			if err := store.Save(r.Context(), key, r.Method, r.URL.Path, resp, idempotencyTTL); err != nil {
+				log.WithError(err).WithField("idempotency.key", key).
+					Warn("idempotency: save failed; retries will re-execute the handler")
+			}
+		})
+	}
+}
+
+// replayStoredResponse writes a previously recorded response back to
+// the wire. Headers go first (Write* will commit them on the first
+// body byte), then the status, then the body. Empty Body is fine —
+// http.ResponseWriter happily accepts a zero-length Write.
+func replayStoredResponse(w http.ResponseWriter, resp idempotency.StoredResponse) {
+	dst := w.Header()
+	for k, vs := range resp.Headers {
+		dst[k] = append(dst[k][:0], vs...)
+	}
+	status := resp.StatusCode
+	if status == 0 {
+		status = http.StatusOK
+	}
+	w.WriteHeader(status)
+	if len(resp.Body) > 0 {
+		_, _ = w.Write(resp.Body)
+	}
+}
+
+// idempotencyRecorder is the ResponseWriter wrapper that captures
+// what the downstream handler emits so the middleware can both
+// (a) forward it to the real wire and (b) snapshot it for Save.
+//
+// It deliberately mirrors net/http's contract: WriteHeader is called
+// at most once by the handler (subsequent calls are dropped by the
+// underlying ResponseWriter), Header() returns a live map the
+// handler may mutate until the first WriteHeader/Write, and Write
+// implicitly defaults the status to 200 if no WriteHeader call has
+// happened yet.
+type idempotencyRecorder struct {
+	http.ResponseWriter
+	statusCode      int
+	wroteHeader     bool
+	capturedHeaders http.Header
+	body            bytes.Buffer
+}
+
+func newIdempotencyRecorder(w http.ResponseWriter) *idempotencyRecorder {
+	return &idempotencyRecorder{
+		ResponseWriter:  w,
+		statusCode:      http.StatusOK,
+		capturedHeaders: http.Header{},
+	}
+}
+
+func (r *idempotencyRecorder) WriteHeader(status int) {
+	if r.wroteHeader {
+		// net/http drops duplicate WriteHeader calls; mirror that so
+		// the snapshot matches what the client actually receives.
+		return
+	}
+	r.statusCode = status
+	// Snapshot the headers the handler set BEFORE WriteHeader. After
+	// WriteHeader the underlying response has committed them; capturing
+	// here ensures the replayed response has the same header set the
+	// original client saw.
+	for k, v := range r.Header() {
+		// http.Header is map[string][]string; copy the slice so a
+		// later handler mutation doesn't poison the snapshot.
+		dup := make([]string, len(v))
+		copy(dup, v)
+		r.capturedHeaders[k] = dup
+	}
+	r.wroteHeader = true
+	r.ResponseWriter.WriteHeader(status)
+}
+
+func (r *idempotencyRecorder) Write(p []byte) (int, error) {
+	if !r.wroteHeader {
+		// net/http auto-calls WriteHeader(200) on the first Write;
+		// route that through our wrapper so the snapshot is consistent.
+		r.WriteHeader(http.StatusOK)
+	}
+	r.body.Write(p)
+	return r.ResponseWriter.Write(p)
+}
+
+// cloneHeader is a small defensive copy used when constructing the
+// StoredResponse so the captured map cannot be mutated by anything
+// holding a reference to the recorder after the handler returns.
+func cloneHeader(h http.Header) map[string][]string {
+	out := make(map[string][]string, len(h))
+	for k, v := range h {
+		dup := make([]string, len(v))
+		copy(dup, v)
+		out[k] = dup
+	}
+	return out
+}

--- a/backend/layout/idempotency_middleware_test.go
+++ b/backend/layout/idempotency_middleware_test.go
@@ -1,0 +1,229 @@
+package layout
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/bkielbasa/go-ecommerce/backend/internal/idempotency"
+	"github.com/matryer/is"
+)
+
+// fakeStore is an in-memory IdempotencyStore. It stays in the layout
+// package so the test does not have to widen any interface — the
+// middleware depends on the IdempotencyStore seam exactly so this
+// fake exists.
+type fakeStore struct {
+	mu       sync.Mutex
+	rows     map[string]idempotency.StoredResponse
+	findErr  error
+	saveErr  error
+	calls    struct{ find, save int }
+}
+
+func newFakeStore() *fakeStore { return &fakeStore{rows: map[string]idempotency.StoredResponse{}} }
+
+func (s *fakeStore) Find(_ context.Context, key string) (idempotency.StoredResponse, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.calls.find++
+	if s.findErr != nil {
+		return idempotency.StoredResponse{}, false, s.findErr
+	}
+	r, ok := s.rows[key]
+	return r, ok, nil
+}
+
+func (s *fakeStore) Save(_ context.Context, key, _, _ string, resp idempotency.StoredResponse, _ time.Duration) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.calls.save++
+	if s.saveErr != nil {
+		return s.saveErr
+	}
+	if _, exists := s.rows[key]; exists {
+		// Mirror ON CONFLICT (key) DO NOTHING: first writer wins.
+		return nil
+	}
+	s.rows[key] = resp
+	return nil
+}
+
+func TestIdempotencyMiddleware_NoHeader_PassesThrough(t *testing.T) {
+	is := is.New(t)
+	store := newFakeStore()
+	var calls int
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls++
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte("ok"))
+	})
+
+	mw := IdempotencyMiddleware(store)(handler)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/admin/products", nil)
+	mw.ServeHTTP(rec, req)
+
+	is.Equal(calls, 1)
+	is.Equal(rec.Code, http.StatusCreated)
+	is.Equal(rec.Body.String(), "ok")
+	is.Equal(store.calls.find, 0) // no key, no lookup
+	is.Equal(store.calls.save, 0) // no key, no record
+}
+
+func TestIdempotencyMiddleware_SafeMethod_NeverConsultsStore(t *testing.T) {
+	is := is.New(t)
+	store := newFakeStore()
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("page"))
+	})
+
+	mw := IdempotencyMiddleware(store)(handler)
+	rec := httptest.NewRecorder()
+	// Safe method + an Idempotency-Key: the middleware MUST ignore it.
+	req := httptest.NewRequest(http.MethodGet, "/admin/products", nil)
+	req.Header.Set("Idempotency-Key", "k-safe")
+	mw.ServeHTTP(rec, req)
+
+	is.Equal(rec.Code, http.StatusOK)
+	is.Equal(store.calls.find, 0)
+	is.Equal(store.calls.save, 0)
+}
+
+func TestIdempotencyMiddleware_FirstCallRecordsResponse(t *testing.T) {
+	is := is.New(t)
+	store := newFakeStore()
+	var calls int
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls++
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusAccepted)
+		_, _ = w.Write([]byte(`{"id":42}`))
+	})
+
+	mw := IdempotencyMiddleware(store)(handler)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/admin/orders/o-1/refund", nil)
+	req.Header.Set("Idempotency-Key", "k-first")
+	mw.ServeHTTP(rec, req)
+
+	is.Equal(calls, 1)
+	is.Equal(rec.Code, http.StatusAccepted)
+	is.Equal(rec.Body.String(), `{"id":42}`)
+	is.Equal(store.calls.find, 1)
+	is.Equal(store.calls.save, 1)
+
+	// The recorded tuple matches the response that went out on the wire.
+	saved := store.rows["k-first"]
+	is.Equal(saved.StatusCode, http.StatusAccepted)
+	is.Equal(string(saved.Body), `{"id":42}`)
+	is.Equal(saved.Headers["Content-Type"], []string{"application/json"})
+}
+
+func TestIdempotencyMiddleware_SameKey_ReplaysWithoutCallingHandler(t *testing.T) {
+	is := is.New(t)
+	store := newFakeStore()
+	store.rows["k-replay"] = idempotency.StoredResponse{
+		StatusCode: http.StatusCreated,
+		Body:       []byte("replayed"),
+		Headers:    map[string][]string{"Content-Type": {"text/plain"}, "X-Demo": {"yes"}},
+	}
+	var calls int
+	handler := http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		calls++
+	})
+
+	mw := IdempotencyMiddleware(store)(handler)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/admin/promo-codes", nil)
+	req.Header.Set("Idempotency-Key", "k-replay")
+	mw.ServeHTTP(rec, req)
+
+	is.Equal(calls, 0) // handler MUST NOT run on replay
+	is.Equal(rec.Code, http.StatusCreated)
+	is.Equal(rec.Body.String(), "replayed")
+	is.Equal(rec.Header().Get("Content-Type"), "text/plain")
+	is.Equal(rec.Header().Get("X-Demo"), "yes")
+	is.Equal(store.calls.find, 1)
+	is.Equal(store.calls.save, 0) // nothing new to record on a replay
+}
+
+func TestIdempotencyMiddleware_DifferentKeys_DoNotCollide(t *testing.T) {
+	is := is.New(t)
+	store := newFakeStore()
+	var calls int
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		w.WriteHeader(http.StatusOK)
+		// Echo the key so we can prove the per-key response is distinct.
+		_, _ = w.Write([]byte("body-for-" + r.Header.Get("Idempotency-Key")))
+	})
+
+	mw := IdempotencyMiddleware(store)(handler)
+
+	for _, key := range []string{"k-a", "k-b"} {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPost, "/admin/products", nil)
+		req.Header.Set("Idempotency-Key", key)
+		mw.ServeHTTP(rec, req)
+		is.Equal(rec.Code, http.StatusOK)
+		is.Equal(rec.Body.String(), "body-for-"+key)
+	}
+
+	// Both keys reached the handler — dedupe is per-key, exactly the
+	// table shape says.
+	is.Equal(calls, 2)
+	is.Equal(string(store.rows["k-a"].Body), "body-for-k-a")
+	is.Equal(string(store.rows["k-b"].Body), "body-for-k-b")
+}
+
+func TestIdempotencyMiddleware_FindError_FallsThroughToHandler(t *testing.T) {
+	is := is.New(t)
+	store := newFakeStore()
+	store.findErr = errors.New("transient db")
+	var calls int
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls++
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("served"))
+	})
+
+	mw := IdempotencyMiddleware(store)(handler)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/admin/products", nil)
+	req.Header.Set("Idempotency-Key", "k-error")
+	mw.ServeHTTP(rec, req)
+
+	// Storage error is observable in logs but MUST NOT block the request.
+	is.Equal(calls, 1)
+	is.Equal(rec.Code, http.StatusOK)
+	is.Equal(rec.Body.String(), "served")
+}
+
+func TestIdempotencyMiddleware_HandlerWritesWithoutExplicitWriteHeader(t *testing.T) {
+	is := is.New(t)
+	store := newFakeStore()
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		// No WriteHeader call — net/http defaults to 200 on the first
+		// Write. The recorder must capture that default so a replay
+		// produces an identical response.
+		_, _ = w.Write([]byte("implicit-200"))
+	})
+
+	mw := IdempotencyMiddleware(store)(handler)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/admin/products", nil)
+	req.Header.Set("Idempotency-Key", "k-implicit")
+	mw.ServeHTTP(rec, req)
+
+	is.Equal(rec.Code, http.StatusOK)
+	saved := store.rows["k-implicit"]
+	is.Equal(saved.StatusCode, http.StatusOK)
+	is.Equal(string(saved.Body), "implicit-200")
+}

--- a/migrations/000037_idempotency_key.down.sql
+++ b/migrations/000037_idempotency_key.down.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+DROP INDEX IF EXISTS public.idempotency_key_expires_idx;
+DROP TABLE IF EXISTS public.idempotency_key;
+
+COMMIT;

--- a/migrations/000037_idempotency_key.up.sql
+++ b/migrations/000037_idempotency_key.up.sql
@@ -1,0 +1,44 @@
+BEGIN;
+
+-- idempotency_key is the HTTP-boundary record of (client-supplied key,
+-- recorded response) tuples that lets the application return the SAME
+-- response body+status for a retried POST/PUT/PATCH/DELETE without
+-- re-executing the handler. Pairs with the Outbox + Inbox: those give
+-- exactly-once semantics for server-to-server event propagation; this
+-- table closes the equivalent loop for client-driven actions where the
+-- client may legitimately retry on a flaky network.
+--
+-- key is opaque text supplied by the client via the Idempotency-Key
+-- request header; the column is the primary key so a retry collides
+-- with the original row and ON CONFLICT DO NOTHING preserves the first
+-- caller's recorded response.
+--
+-- response_body is bytea (not text) because handler output is allowed
+-- to be HTML, JSON, or any other byte sequence; response_headers is
+-- jsonb so the middleware can faithfully replay Content-Type and any
+-- HX-* headers a downstream HTMX swap depends on.
+--
+-- expires_at defaults to now()+24h: the table is purely a retry-safety
+-- cache, not a long-lived audit log, so a generous-but-bounded TTL
+-- keeps the surface small without sacrificing the operationally
+-- interesting "the same client retried within a reasonable window"
+-- case.
+CREATE TABLE idempotency_key (
+    key text PRIMARY KEY,
+    method text NOT NULL,
+    path text NOT NULL,
+    status_code int NOT NULL,
+    response_body bytea NOT NULL,
+    response_headers jsonb NOT NULL DEFAULT '{}'::jsonb,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    expires_at timestamptz NOT NULL DEFAULT (now() + interval '24 hours')
+);
+
+-- Plain B-tree on expires_at supports the routine maintenance sweep
+-- `DELETE FROM idempotency_key WHERE expires_at < now()`. We can't use
+-- a partial index with a now()-based predicate (Postgres rejects it
+-- because now() is STABLE, not IMMUTABLE). The hot path uses the PK
+-- anyway; the expires_at index is only for the sweeper.
+CREATE INDEX idempotency_key_expires_idx ON idempotency_key(expires_at);
+
+COMMIT;


### PR DESCRIPTION
Standard production pattern at the HTTP boundary. Admin POSTs may carry an `Idempotency-Key` header; the middleware records the (key, status, headers, body) tuple in a table with a 24h TTL; retries with the same key return the recorded response without re-executing the handler. Pairs with Outbox + Inbox to give end-to-end exactly-once semantics for client-driven actions.

- Migration 000037: `idempotency_key` table.
- New `internal/idempotency` package (Postgres adapter, no http dep).
- New `layout.IdempotencyMiddleware(store)` — pass-through on safe methods or empty header; otherwise look up, replay on hit, capture-and-store on miss.
- Three admin handlers documented as Idempotency-Key-aware: create product, refund order, create promo code (middleware is content-agnostic; opt-in is documentation only).
- 7 unit tests (no-header, safe-method, first-call records, replay, key-isolation, find-error fall-through, implicit-200 capture).

**Wiring note**: per the parallel-agent constraint the subagent couldn't touch `cmd/web/main.go`; install with `app.Use(layout.IdempotencyMiddleware(idempotency.NewPostgres(db)))` in a follow-up — or fold it into the merge commit.