### PR TITLE
refactor(checkout): pricing as TaxStrategy + ShippingStrategy

### DIFF
--- a/backend/checkout/app/checkout.go
+++ b/backend/checkout/app/checkout.go
@@ -92,14 +92,6 @@ type nopStockMovements struct{}
 
 func (nopStockMovements) Record(context.Context, string, int, string, string) error { return nil }
 
-// PricingPolicy is an alias for the domain-level policy so the
-// composition root (cmd/web) can continue to construct one through the
-// checkout/app package while the actual math lives in the Pricing
-// domain service (checkout/domain.PriceQuote). The field set —
-// TaxRatePercent + FreeShippingThreshold — is unchanged, which keeps
-// the historical wiring arithmetic-identical to before the lift.
-type PricingPolicy = domain.PricingPolicy
-
 // IDGenerator returns a fresh order ID. Injected so tests can substitute a
 // deterministic generator.
 type IDGenerator func() string
@@ -121,18 +113,25 @@ func (nopPromoRedeemer) Redeem(context.Context, string, string, string, promodom
 }
 
 type CheckoutService struct {
-	cart      CartReader
-	storage   OrderStorage
-	payment   PaymentProcessor
-	stock     StockReserver
-	movements StockMovements
-	promo     PromoRedeemer
-	newID     IDGenerator
-	now       func() time.Time
-	pricing   PricingPolicy
+	cart             CartReader
+	storage          OrderStorage
+	payment          PaymentProcessor
+	stock            StockReserver
+	movements        StockMovements
+	promo            PromoRedeemer
+	newID            IDGenerator
+	now              func() time.Time
+	taxStrategy      domain.TaxStrategy
+	shippingStrategy domain.ShippingStrategy
 }
 
 // NewCheckoutService constructs the checkout command service.
+//
+// taxStrategy / shippingStrategy are the pluggable pricing policies the
+// service hands to domain.PriceQuote. Passing nil for either falls back
+// to the historical zero-config behaviour (no tax / catalogue shipping
+// cost) — both defaults are constructable as the zero value of the
+// matching default strategy (FlatTaxStrategy{} / ThresholdShippingStrategy{}).
 //
 // Note: there is no EventPublisher dependency. Integration events
 // (e.g. OrderPaid) are staged into the Transactional Outbox by the
@@ -146,21 +145,29 @@ func NewCheckoutService(
 	stock StockReserver,
 	movements StockMovements,
 	newID IDGenerator,
-	pricing PricingPolicy,
+	taxStrategy domain.TaxStrategy,
+	shippingStrategy domain.ShippingStrategy,
 ) CheckoutService {
 	if movements == nil {
 		movements = nopStockMovements{}
 	}
+	if taxStrategy == nil {
+		taxStrategy = domain.FlatTaxStrategy{}
+	}
+	if shippingStrategy == nil {
+		shippingStrategy = domain.ThresholdShippingStrategy{}
+	}
 	return CheckoutService{
-		cart:      cart,
-		storage:   storage,
-		payment:   payment,
-		stock:     stock,
-		movements: movements,
-		promo:     nopPromoRedeemer{},
-		newID:     newID,
-		now:       func() time.Time { return time.Now().UTC() },
-		pricing:   pricing,
+		cart:             cart,
+		storage:          storage,
+		payment:          payment,
+		stock:            stock,
+		movements:        movements,
+		promo:            nopPromoRedeemer{},
+		newID:            newID,
+		now:              func() time.Time { return time.Now().UTC() },
+		taxStrategy:      taxStrategy,
+		shippingStrategy: shippingStrategy,
 	}
 }
 
@@ -270,7 +277,7 @@ func (s CheckoutService) Place(ctx context.Context, sessID, customerID, cardNumb
 	quote := domain.PriceQuote(lines, shipMethod, domain.DiscountInput{
 		AmountMinor:  discount.AmountMinor(),
 		FreeShipping: discount.FreeShipping(),
-	}, s.pricing)
+	}, s.taxStrategy, s.shippingStrategy)
 	span.SetAttributes(
 		attribute.Int64("order.subtotal", quote.Subtotal),
 		attribute.Int64("order.discount", quote.DiscountAmount),

--- a/backend/checkout/bounded_context.go
+++ b/backend/checkout/bounded_context.go
@@ -9,6 +9,7 @@ import (
 	cartDomain "github.com/bkielbasa/go-ecommerce/backend/cart/domain"
 	"github.com/bkielbasa/go-ecommerce/backend/checkout/adapter"
 	"github.com/bkielbasa/go-ecommerce/backend/checkout/app"
+	"github.com/bkielbasa/go-ecommerce/backend/checkout/domain"
 	"github.com/bkielbasa/go-ecommerce/backend/checkout/query"
 	"github.com/bkielbasa/go-ecommerce/backend/internal/application"
 )
@@ -49,13 +50,15 @@ type StockMovements interface {
 // what older tests expect).
 //
 // movements may be nil — checkout then runs without writing audit rows, which
-// is the historical behaviour. pricing carries tax + free-shipping config; a
-// zero-value PricingPolicy disables both, again matching the historical
-// behaviour.
-func New(db *sql.DB, cart CartReader, outbox adapter.OutboxAppender, stock StockReserver, movements StockMovements, pricing app.PricingPolicy) (application.BoundedContext, app.CheckoutService, query.Service) {
+// is the historical behaviour. taxStrategy and shippingStrategy are the
+// pluggable pricing policies the service hands to domain.PriceQuote; passing
+// nil for either falls back to the zero-config defaults (FlatTaxStrategy{} /
+// ThresholdShippingStrategy{}), matching the historical "no tax, no
+// automatic free-shipping override" behaviour.
+func New(db *sql.DB, cart CartReader, outbox adapter.OutboxAppender, stock StockReserver, movements StockMovements, taxStrategy domain.TaxStrategy, shippingStrategy domain.ShippingStrategy) (application.BoundedContext, app.CheckoutService, query.Service) {
 	storage := adapter.NewPostgres(db, outbox)
 	payment := adapter.NewFakePayment()
-	cmd := app.NewCheckoutService(cart, storage, payment, stock, movements, newOrderID, pricing)
+	cmd := app.NewCheckoutService(cart, storage, payment, stock, movements, newOrderID, taxStrategy, shippingStrategy)
 	queries := query.NewService(storage)
 	return &boundedContext{}, cmd, queries
 }

--- a/backend/checkout/domain/order_test.go
+++ b/backend/checkout/domain/order_test.go
@@ -113,8 +113,9 @@ func TestPlaceOrder_AppliesDiscount(t *testing.T) {
 }
 
 // TestPlaceOrder_AppliesTaxAndEffectiveShipping locks in the tax/shipping
-// math driven by the new PricingPolicy: the OrderPlaced event carries the
-// derived numbers and the rehydrated order's total reflects them.
+// math driven by the pluggable pricing strategies: the OrderPlaced event
+// carries the derived numbers and the rehydrated order's total reflects
+// them.
 func TestPlaceOrder_AppliesTaxAndEffectiveShipping(t *testing.T) {
 	at := time.Date(2026, 5, 27, 9, 0, 0, 0, time.UTC)
 	lines := []domain.Line{domain.NewLine("v1", "Mug", 4, 1000, "USD")}

--- a/backend/checkout/domain/pricing.go
+++ b/backend/checkout/domain/pricing.go
@@ -8,6 +8,41 @@
 // The maths — subtotal, discount clamp, tax on the discounted subtotal,
 // free-shipping override, total — lives here so it is independently
 // testable and easy to reason about.
+//
+// # The Strategy pattern
+//
+// The two policy-driven steps of the math — computing tax and computing
+// the effective shipping cost — used to be baked into PriceQuote as
+// "flat percent on the discounted subtotal" and "flat method cost,
+// zeroed above a configurable free-shipping threshold". Both are fine
+// defaults but they are also only two points in a much larger space:
+//
+//   - Tax: VAT-inclusive jurisdictions (price already contains the tax),
+//     per-line categories (food vs alcohol vs digital goods), destination-
+//     based US sales tax, B2B reverse-charge, etc.
+//   - Shipping: weight-based couriers, per-jurisdiction surcharges,
+//     promotional free-shipping windows ("free shipping on Wednesdays"),
+//     free pickup at a store, dimensional weight, etc.
+//
+// Rather than grow the PricingPolicy struct with one more boolean every
+// quarter, the two policies are lifted behind small Strategy interfaces
+// (TaxStrategy, ShippingStrategy). PriceQuote orchestrates the order of
+// operations and delegates the two policy-dependent calculations to the
+// injected strategies; the composition root (cmd/web) decides which
+// concrete strategy gets wired.
+//
+// Adding a new strategy is a three-step change with no edits to
+// PriceQuote, the Order aggregate, or the application service:
+//
+//  1. Implement the relevant interface in a new type (anywhere — inside
+//     this package for shared defaults, or in an adapter package for a
+//     vendor-specific calculator).
+//  2. Add the configuration the new strategy needs to the composition
+//     root (cmd/web reads cfg, builds the strategy value, passes it to
+//     NewCheckoutService).
+//  3. Optionally add a dedicated test exercising the new behaviour —
+//     PriceQuote's tests already lock down the orchestration; the new
+//     strategy only needs to cover its own math.
 package domain
 
 import "math"
@@ -40,21 +75,6 @@ type Quote struct {
 	FreeShipping bool
 }
 
-// PricingPolicy carries the configurable inputs to the pricing math:
-// the flat tax rate and the free-shipping threshold. Both default to
-// zero, which disables the corresponding rule (no tax, no automatic
-// free-shipping override) — matching the historical behaviour before
-// either was wired.
-type PricingPolicy struct {
-	// TaxRatePercent is the flat tax rate applied to the discounted
-	// subtotal, e.g. 8.875 for 8.875%. 0 disables tax.
-	TaxRatePercent float64
-	// FreeShippingThreshold is the minimum (discounted) subtotal at or
-	// above which the chosen method's shipping cost is overridden to 0.
-	// 0 disables the override.
-	FreeShippingThreshold int64
-}
-
 // DiscountInput is what the pricing service needs from a resolved
 // discount. It is deliberately a small, local value type so the pricing
 // math does not depend on the promo bounded context's types — the
@@ -69,22 +89,91 @@ type DiscountInput struct {
 	FreeShipping bool
 }
 
+// TaxStrategy computes the tax due on a discounted subtotal.
+// Implementations may inspect the lines (e.g. per-line VAT categories
+// such as food vs alcohol) or apply a single flat rate. Returning 0
+// means "no tax" — that is also the historical zero-value behaviour the
+// composition root falls back to when no rate is configured.
+type TaxStrategy interface {
+	Tax(lines []Line, discountedSubtotal int64) int64
+}
+
+// ShippingStrategy computes the effective shipping cost for an order.
+// It receives the chosen ShippingMethod (with its catalogue cost), the
+// discounted subtotal, the per-line basket, and a flag indicating
+// whether the resolved discount itself includes free shipping (the
+// promo's FreeShipping flag). Returning 0 means "free shipping",
+// whatever the reason — the FreeShipping field on the resulting Quote
+// is set accordingly.
+type ShippingStrategy interface {
+	Cost(lines []Line, shipMethod ShippingMethod, discountedSubtotal int64, freeShippingFromDiscount bool) int64
+}
+
+// FlatTaxStrategy applies a single rate (percent) to the discounted
+// subtotal. It is the historical default that the composition root
+// builds from cfg.TaxRatePercent — a zero rate yields zero tax, matching
+// the pre-strategy behaviour.
+type FlatTaxStrategy struct {
+	// RatePercent is the flat tax rate applied to the discounted
+	// subtotal, e.g. 8.875 for 8.875%. 0 disables tax.
+	RatePercent float64
+}
+
+// Tax returns round(discountedSubtotal * RatePercent / 100). A
+// non-positive subtotal yields 0 so a fully-discounted basket is
+// charged no tax. The result rounds to the nearest minor unit.
+func (s FlatTaxStrategy) Tax(_ []Line, discountedSubtotal int64) int64 {
+	if s.RatePercent <= 0 || discountedSubtotal <= 0 {
+		return 0
+	}
+	return int64(math.Round(float64(discountedSubtotal) * s.RatePercent / 100.0))
+}
+
+// ThresholdShippingStrategy is the historical shipping behaviour: a
+// flat cost taken from the chosen method, zeroed when the discounted
+// subtotal exceeds a configurable free-shipping threshold or when the
+// discount itself includes free shipping. The composition root builds
+// it from cfg.FreeShippingThreshold — a zero threshold disables the
+// override entirely, matching the pre-strategy behaviour.
+type ThresholdShippingStrategy struct {
+	// FreeShippingThreshold is the minimum (discounted) subtotal at or
+	// above which the chosen method's shipping cost is overridden to 0.
+	// 0 disables the override.
+	FreeShippingThreshold int64
+}
+
+// Cost returns 0 when free shipping applies (either the discount flag
+// or the configured threshold being reached), otherwise the chosen
+// method's catalogue Cost().
+func (s ThresholdShippingStrategy) Cost(_ []Line, sm ShippingMethod, discountedSubtotal int64, freeShippingFromDiscount bool) int64 {
+	if freeShippingFromDiscount {
+		return 0
+	}
+	if s.FreeShippingThreshold > 0 && discountedSubtotal >= s.FreeShippingThreshold {
+		return 0
+	}
+	return sm.Cost()
+}
+
 // PriceQuote is the domain service entry point. It is a pure function:
 // given the line snapshots, the chosen shipping method, the resolved
-// discount and the configured policy, it returns the complete Quote.
-// The math, in order:
+// discount and the two pluggable strategies, it returns the complete
+// Quote. The math, in order:
 //
 //  1. subtotal = sum of Line.LineTotal() over every line.
 //  2. discount = min(max(DiscountInput.AmountMinor, 0), subtotal) — clamp
 //     so the discounted subtotal cannot go negative.
 //  3. discountedSubtotal = subtotal - discount.
-//  4. tax = round(discountedSubtotal * policy.TaxRatePercent / 100).
-//  5. freeShipping = DiscountInput.FreeShipping OR
-//     (policy.FreeShippingThreshold > 0 AND
-//     discountedSubtotal >= policy.FreeShippingThreshold).
-//  6. shippingCost = 0 when freeShipping, else shipMethod.Cost().
+//  4. tax = tax.Tax(lines, discountedSubtotal).
+//  5. shippingCost = ship.Cost(lines, shipMethod, discountedSubtotal,
+//     discount.FreeShipping).
+//  6. freeShipping = (shippingCost == 0 AND shipMethod.Cost() > 0) OR
+//     discount.FreeShipping. Pickup-style methods whose catalogue cost
+//     is already 0 are not flagged as "free shipping applied" — that
+//     summary line is reserved for the cases where the pricing rules
+//     actively zeroed a chargeable method.
 //  7. total = discountedSubtotal + tax + shippingCost.
-func PriceQuote(lines []Line, shipMethod ShippingMethod, discount DiscountInput, policy PricingPolicy) Quote {
+func PriceQuote(lines []Line, shipMethod ShippingMethod, discount DiscountInput, tax TaxStrategy, ship ShippingStrategy) Quote {
 	var subtotal int64
 	for _, ln := range lines {
 		subtotal += ln.LineTotal()
@@ -99,25 +188,31 @@ func PriceQuote(lines []Line, shipMethod ShippingMethod, discount DiscountInput,
 	}
 	discountedSubtotal := subtotal - discountAmount
 
-	var tax int64
-	if policy.TaxRatePercent > 0 && discountedSubtotal > 0 {
-		tax = int64(math.Round(float64(discountedSubtotal) * policy.TaxRatePercent / 100.0))
+	var taxAmount int64
+	if tax != nil {
+		taxAmount = tax.Tax(lines, discountedSubtotal)
 	}
-
-	freeShipping := discount.FreeShipping ||
-		(policy.FreeShippingThreshold > 0 && discountedSubtotal >= policy.FreeShippingThreshold)
 
 	var shippingCost int64
-	if !freeShipping {
+	if ship != nil {
+		shippingCost = ship.Cost(lines, shipMethod, discountedSubtotal, discount.FreeShipping)
+	} else {
 		shippingCost = shipMethod.Cost()
 	}
+
+	// freeShipping reports whether the pricing rules actively zeroed a
+	// chargeable method. A pickup-style method whose catalogue Cost()
+	// is already 0 is NOT flagged here — the summary line "Free
+	// shipping applied" would be misleading.
+	freeShipping := discount.FreeShipping ||
+		(shippingCost == 0 && shipMethod.Cost() > 0)
 
 	return Quote{
 		Subtotal:       subtotal,
 		DiscountAmount: discountAmount,
-		Tax:            tax,
+		Tax:            taxAmount,
 		ShippingCost:   shippingCost,
-		Total:          discountedSubtotal + tax + shippingCost,
+		Total:          discountedSubtotal + taxAmount + shippingCost,
 		FreeShipping:   freeShipping,
 	}
 }

--- a/backend/checkout/domain/pricing_test.go
+++ b/backend/checkout/domain/pricing_test.go
@@ -1,14 +1,44 @@
 package domain_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/bkielbasa/go-ecommerce/backend/checkout/domain"
 )
 
+// perLineTaxStrategy is a test-local TaxStrategy that demonstrates the
+// pluggability of the interface: it taxes only the lines whose product
+// name starts with "Tax:" at a flat rate, ignoring the rest of the
+// basket. Real-world per-line strategies follow the same shape
+// (jurisdictional categories, VAT rates per product class, etc.).
+type perLineTaxStrategy struct {
+	ratePercent float64
+}
+
+func (s perLineTaxStrategy) Tax(lines []domain.Line, _ int64) int64 {
+	if s.ratePercent <= 0 {
+		return 0
+	}
+	var taxable int64
+	for _, ln := range lines {
+		if strings.HasPrefix(ln.ProductName(), "Tax:") {
+			taxable += ln.LineTotal()
+		}
+	}
+	if taxable <= 0 {
+		return 0
+	}
+	// Truncating division keeps the test arithmetic predictable; the
+	// production strategy in domain rounds to the nearest minor unit.
+	return taxable * int64(s.ratePercent) / 100
+}
+
 // TestPriceQuote covers the pricing domain service's interesting cases.
 // The math order is documented on PriceQuote itself; this table exercises
-// each branch in isolation plus the clamp invariant.
+// each branch in isolation plus the clamp invariant, with the default
+// FlatTaxStrategy + ThresholdShippingStrategy that the composition root
+// wires in production.
 func TestPriceQuote(t *testing.T) {
 	lines := func() []domain.Line {
 		// 2 * 1500 + 1 * 2000 = 5000 subtotal.
@@ -25,7 +55,8 @@ func TestPriceQuote(t *testing.T) {
 		lines    []domain.Line
 		method   domain.ShippingMethod
 		discount domain.DiscountInput
-		policy   domain.PricingPolicy
+		tax      domain.TaxStrategy
+		ship     domain.ShippingStrategy
 		want     domain.Quote
 	}{
 		{
@@ -33,7 +64,8 @@ func TestPriceQuote(t *testing.T) {
 			lines:    lines(),
 			method:   courier,
 			discount: domain.DiscountInput{},
-			policy:   domain.PricingPolicy{},
+			tax:      domain.FlatTaxStrategy{},
+			ship:     domain.ThresholdShippingStrategy{},
 			want: domain.Quote{
 				Subtotal:       5000,
 				DiscountAmount: 0,
@@ -49,7 +81,8 @@ func TestPriceQuote(t *testing.T) {
 			lines:    lines(),
 			method:   courier,
 			discount: domain.DiscountInput{},
-			policy:   domain.PricingPolicy{TaxRatePercent: 10},
+			tax:      domain.FlatTaxStrategy{RatePercent: 10},
+			ship:     domain.ThresholdShippingStrategy{},
 			want: domain.Quote{
 				Subtotal:       5000,
 				DiscountAmount: 0,
@@ -65,7 +98,8 @@ func TestPriceQuote(t *testing.T) {
 			lines:    lines(),
 			method:   courier,
 			discount: domain.DiscountInput{AmountMinor: 1000},
-			policy:   domain.PricingPolicy{TaxRatePercent: 10},
+			tax:      domain.FlatTaxStrategy{RatePercent: 10},
+			ship:     domain.ThresholdShippingStrategy{},
 			want: domain.Quote{
 				Subtotal:       5000,
 				DiscountAmount: 1000,
@@ -81,7 +115,8 @@ func TestPriceQuote(t *testing.T) {
 			lines:    lines(),
 			method:   courier,
 			discount: domain.DiscountInput{},
-			policy:   domain.PricingPolicy{FreeShippingThreshold: 4000},
+			tax:      domain.FlatTaxStrategy{},
+			ship:     domain.ThresholdShippingStrategy{FreeShippingThreshold: 4000},
 			want: domain.Quote{
 				Subtotal:       5000,
 				DiscountAmount: 0,
@@ -97,7 +132,8 @@ func TestPriceQuote(t *testing.T) {
 			lines:    lines(),
 			method:   courier,
 			discount: domain.DiscountInput{FreeShipping: true},
-			policy:   domain.PricingPolicy{},
+			tax:      domain.FlatTaxStrategy{},
+			ship:     domain.ThresholdShippingStrategy{},
 			want: domain.Quote{
 				Subtotal:       5000,
 				DiscountAmount: 0,
@@ -114,7 +150,8 @@ func TestPriceQuote(t *testing.T) {
 			lines:    lines(),
 			method:   courier,
 			discount: domain.DiscountInput{AmountMinor: 9_999_999},
-			policy:   domain.PricingPolicy{TaxRatePercent: 10},
+			tax:      domain.FlatTaxStrategy{RatePercent: 10},
+			ship:     domain.ThresholdShippingStrategy{},
 			want: domain.Quote{
 				Subtotal:       5000,
 				DiscountAmount: 5000,
@@ -126,12 +163,15 @@ func TestPriceQuote(t *testing.T) {
 		},
 		{
 			// Pickup is free shipping by virtue of Cost()==0 — assert the
-			// "no override needed" path stays internally consistent.
+			// "no override needed" path stays internally consistent. The
+			// quote's FreeShipping flag stays false because the rule
+			// didn't fire; the method just costs nothing.
 			name:     "pickup method costs nothing without free-shipping flag",
 			lines:    lines(),
 			method:   pickup,
 			discount: domain.DiscountInput{},
-			policy:   domain.PricingPolicy{},
+			tax:      domain.FlatTaxStrategy{},
+			ship:     domain.ThresholdShippingStrategy{},
 			want: domain.Quote{
 				Subtotal:       5000,
 				DiscountAmount: 0,
@@ -141,11 +181,37 @@ func TestPriceQuote(t *testing.T) {
 				FreeShipping:   false,
 			},
 		},
+		{
+			// Per-line tax demo: only lines whose name starts with "Tax:"
+			// are taxed, at 20%. The "Mug" + "Plate" basket above has no
+			// such lines, so we build a bespoke basket here.
+			//   Tax:Wine (1 * 1000) is taxed at 20% = 200.
+			//   Bread (2 * 500 = 1000) is not.
+			// Total taxable = 1000, tax = 200. Subtotal = 2000.
+			// Shipping = courier 1500. Total = 2000 + 200 + 1500 = 3700.
+			name:   "per-line tax strategy taxes only matching lines",
+			method: courier,
+			lines: []domain.Line{
+				domain.NewLine("v3", "Tax:Wine", 1, 1000, "USD"),
+				domain.NewLine("v4", "Bread", 2, 500, "USD"),
+			},
+			discount: domain.DiscountInput{},
+			tax:      perLineTaxStrategy{ratePercent: 20},
+			ship:     domain.ThresholdShippingStrategy{},
+			want: domain.Quote{
+				Subtotal:       2000,
+				DiscountAmount: 0,
+				Tax:            200,
+				ShippingCost:   1500,
+				Total:          3700,
+				FreeShipping:   false,
+			},
+		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := domain.PriceQuote(tc.lines, tc.method, tc.discount, tc.policy)
+			got := domain.PriceQuote(tc.lines, tc.method, tc.discount, tc.tax, tc.ship)
 			if got != tc.want {
 				t.Errorf("PriceQuote = %+v\n want %+v", got, tc.want)
 			}

--- a/backend/cmd/web/main.go
+++ b/backend/cmd/web/main.go
@@ -12,7 +12,7 @@ import (
 	"github.com/bkielbasa/go-ecommerce/backend/auth"
 	"github.com/bkielbasa/go-ecommerce/backend/cart"
 	"github.com/bkielbasa/go-ecommerce/backend/checkout"
-	checkoutapp "github.com/bkielbasa/go-ecommerce/backend/checkout/app"
+	checkoutdomain "github.com/bkielbasa/go-ecommerce/backend/checkout/domain"
 	checkoutintegration "github.com/bkielbasa/go-ecommerce/backend/checkout/integration"
 	checkoutquery "github.com/bkielbasa/go-ecommerce/backend/checkout/query"
 	"github.com/bkielbasa/go-ecommerce/backend/checkout/sweeper"
@@ -148,11 +148,16 @@ func main() {
 	pcBD, catalogService := productcatalog.New(db, searchSrv)
 	cartBD, cartSrv := cart.New(db, logger, catalogService)
 	authBD, authService := auth.New(db)
-	pricing := checkoutapp.PricingPolicy{
-		TaxRatePercent:        cfg.TaxRatePercent,
-		FreeShippingThreshold: cfg.FreeShippingThreshold,
-	}
-	checkoutBD, checkoutSrv, checkoutQry := checkout.New(db, cartSrv, outboxStore, catalogService, catalogService, pricing)
+	// Pricing policies are pluggable Strategies — the composition root
+	// chooses concrete implementations and the checkout service stays
+	// agnostic. The defaults (FlatTaxStrategy / ThresholdShippingStrategy)
+	// preserve the historical "flat percent tax, free shipping above a
+	// configurable threshold" behaviour while leaving the door open for
+	// per-jurisdiction tax, weight-based shipping etc. by swapping in a
+	// different strategy here.
+	taxStrategy := checkoutdomain.FlatTaxStrategy{RatePercent: cfg.TaxRatePercent}
+	shippingStrategy := checkoutdomain.ThresholdShippingStrategy{FreeShippingThreshold: cfg.FreeShippingThreshold}
+	checkoutBD, checkoutSrv, checkoutQry := checkout.New(db, cartSrv, outboxStore, catalogService, catalogService, taxStrategy, shippingStrategy)
 	// Fulfillment Process Manager: subscribes to OrderPaid, spawns a
 	// state-stored Fulfillment, and owns the operational lifecycle
 	// (ship/deliver/refund). Stock release on refund goes through the


### PR DESCRIPTION
Now that pricing is a domain service (#115), pull the policies behind Strategy interfaces. Future implementations (VAT-inclusive, per-jurisdiction, weight-based shipping, etc.) snap in without touching the aggregate or orchestrator.

- New `TaxStrategy` + `ShippingStrategy` interfaces in `checkout/domain/pricing.go`.
- Default impls: `FlatTaxStrategy{RatePercent}` and `ThresholdShippingStrategy{FreeShippingThreshold}`.
- `PriceQuote` signature changes to take the two strategies. `PricingPolicy` and its type-alias in `app` are deleted.
- `CheckoutService` gains two strategy fields; `NewCheckoutService` takes them. Composition root constructs them from env config.
- pricing tests rewritten to construct strategies; ONE new case demonstrates a test-local `perLineTaxStrategy` that taxes only lines whose name starts with "Tax:" — proves cross-package pluggability.