### PR TITLE
docs: annotate context map with DDD relationship types

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,26 +46,71 @@ graph TD
     auth["auth<br/><i>customers, sessions, admin role</i>"]
     shippinginfo["shippinginfo<br/><i>saved addresses</i>"]
 
-    layout --> productcatalog
-    layout --> cart
-    layout --> checkout
-    layout --> auth
-    layout --> shippinginfo
+    layout -->|Conformist| productcatalog
+    layout -->|Conformist| cart
+    layout -->|Conformist| checkout
+    layout -->|Conformist| auth
+    layout -->|Conformist| shippinginfo
 
-    cart -- "ACL: variant → cart product" --> productcatalog
-    checkout -- "reads cart at order time" --> cart
-    checkout -- "reserves / releases stock" --> productcatalog
-    checkout -. "OrderPaid event (bus)" .-> cart
+    cart -->|ACL: variant → cart product| productcatalog
+    checkout -->|Customer-Supplier: cart read port| cart
+    checkout -->|Customer-Supplier: stock ports| productcatalog
+    checkout -. "Published Language: OrderPaid (bus)" .-> cart
 ```
+
+### Relationship types
+
+Each edge above is labelled with one of the standard DDD strategic-design
+relationships. The patterns realised in the code are:
+
+- **Anti-Corruption Layer (ACL)** — a translation layer that protects one
+  context from another's vocabulary. Here: `cart` translates a
+  `productcatalog.Variant` into its own `domain.Product` (re-checking stock
+  and currency) in
+  [`transformProductCatalog`](./backend/cart/bounded_context.go) — cart
+  never imports productcatalog types beyond that seam.
+- **Customer-Supplier** — two contexts collaborate on a port the customer
+  needs; the supplier agrees to honour it. Here: `checkout` defines
+  `CartReader` and the stock ports (`StockReserver`, `StockMovements`) in
+  [`backend/checkout/bounded_context.go`](./backend/checkout/bounded_context.go);
+  `cart` and `productcatalog` implement them. The contract is checkout-shaped,
+  not a generic catalogue API.
+- **Published Language** — a documented, stable interchange schema. Here:
+  the integration event `checkout.OrderPaid`
+  ([`backend/checkout/integration/events.go`](./backend/checkout/integration/events.go))
+  is checkout's outward-facing shape — subscribers (cart, fulfillment, the
+  email subscriber) consume it through the in-process bus + Outbox without
+  checkout knowing they exist.
+- **Conformist** — the consumer accepts the producer's vocabulary with no
+  translation. Here: `layout` declares narrow per-context interfaces but
+  refers to each producer's domain types directly (e.g. `pcdomain.Product`,
+  `checkoutDomain.Order`, `fulfillmentDomain.Fulfillment`); see the imports
+  at the top of
+  [`backend/layout/bounded_context.go`](./backend/layout/bounded_context.go).
+  A presentation layer that just renders is a natural conformist.
+- **Open Host Service (OHS)** — a context exposes a deliberately stable,
+  public API any other context can integrate with. Here: `search` publishes
+  the `Document` value object plus the `Indexer` / `Querier` ports in
+  [`backend/search/app/service.go`](./backend/search/app/service.go).
+  Productcatalog is the in-repo producer today (via the
+  `SearchIndexer` port), but the surface is intentionally generic — a blog
+  or FAQ producer could light it up with no changes to search. (Not drawn
+  in the diagram above because the search context is omitted for
+  readability; see the table below.)
+
+The other patterns from Evans' catalogue — **Partnership** (joint
+co-evolution) and **Shared Kernel** (a small set of shared types) — are
+not realised in master today, so no edge above carries those labels.
 
 | Context | Responsibility | Talks to |
 | --- | --- | --- |
-| **productcatalog** | Products, variants, option types, filterable attributes, categories, and stock reservation. No dependencies on other contexts. | — |
-| **cart** | Session-scoped shopping carts. Resolves a variant id into its own product notion through an anti-corruption layer over productcatalog. | productcatalog (sync, ACL) |
-| **checkout** | Orders as an event-sourced aggregate with a separate CQRS read side. Snapshots the cart, reserves stock, records payment, and publishes an `OrderPaid` integration event. | cart, productcatalog (sync); cart (async, via event bus) |
+| **productcatalog** | Products, variants, option types, filterable attributes, categories, and stock reservation. No dependencies on other contexts. | search (OHS producer side: publishes Documents via `SearchIndexer`) |
+| **cart** | Session-scoped shopping carts. Resolves a variant id into its own product notion through an anti-corruption layer over productcatalog. | productcatalog (sync, ACL); checkout (async, subscribes to `OrderPaid` to clear the basket) |
+| **checkout** | Orders as an event-sourced aggregate with a separate CQRS read side. Snapshots the cart, reserves stock, records payment, and publishes an `OrderPaid` integration event. | cart (sync, Customer-Supplier on `CartReader`); productcatalog (sync, Customer-Supplier on stock ports); downstream subscribers via Published Language `OrderPaid` |
 | **auth** | Customers, sessions, password policy, and the admin role. Standalone. | — |
 | **shippinginfo** | Customers' saved shipping addresses. Standalone. | — |
-| **layout** | HTTP presentation: the HTMX storefront and the admin panel. Orchestrates every context through narrow interfaces. | all contexts |
+| **search** | Free-text + filtered search over an open set of `Document` kinds. Two ports: `Indexer` (write) and `Querier` (read). | productcatalog (OHS consumer side) |
+| **layout** | HTTP presentation: the HTMX storefront and the admin panel. Orchestrates every context through narrow interfaces, conforming to each producer's domain types. | all contexts (Conformist) |
 
 Cross-context integration is mostly synchronous through anti-corruption interfaces
 defined at the composition root (`backend/cmd/web/main.go`). The one decoupled
@@ -73,7 +118,10 @@ path is an in-process event bus (`backend/internal/eventbus`): checkout publishe
 `OrderPaid` after a successful payment and the cart context subscribes to empty
 the basket, so checkout never calls the cart directly for that side effect.
 
-The shared vocabulary used across these contexts is collected in the [ubiquitous-language glossary](./docs/glossary.md).
+The shared vocabulary used across these contexts is collected in the
+[ubiquitous-language glossary](./docs/glossary.md). See
+[docs/glossary.md](./docs/glossary.md) for the full DDD vocabulary used
+by this project — including the relationship-type definitions above.
 
 
 ## Quick start

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -117,11 +117,36 @@ the codec (see [Upcaster](#upcaster)). Today every producer passes "web",
 but the parameter is wired through so a future iOS / API entry point
 needs no schema change.
 
+### Conformist [cross-context]
+A strategic-design relationship where the downstream context accepts the
+upstream's model and vocabulary as-is, without a translation layer. Cheap
+but tightly coupled: any upstream change ripples through. Here: `layout`
+declares narrow per-context interfaces but those interfaces refer to each
+producer's domain types directly (e.g. `pcdomain.Product`,
+`checkoutDomain.Order`, `fulfillmentDomain.Fulfillment`); see the imports
+at the top of
+[backend/layout/bounded_context.go](../backend/layout/bounded_context.go).
+A presentation layer that only renders is a natural conformist. Contrast
+with [Anti-Corruption Layer](#anti-corruption-layer-acl-cross-context).
+
 ### Customer [auth]
 An authenticated end user, identified by email address. The aggregate is
 `Customer` in [backend/auth/domain/customer.go](../backend/auth/domain/customer.go).
 Sessions reference a customer through `Session.CustomerID()`. The
 cart's `User` is **not** a customer — see [User vs Customer](#user-vs-customer-disambiguation).
+
+### Customer-Supplier [cross-context]
+A strategic-design relationship where two contexts collaborate on the
+shape of their seam: the downstream "customer" tells the upstream
+"supplier" what it needs, and the supplier honours that contract. Here:
+`checkout` (customer) defines `CartReader` and the stock ports
+(`StockReserver`, `StockMovements`) in
+[backend/checkout/bounded_context.go](../backend/checkout/bounded_context.go);
+`cart` and `productcatalog` (suppliers) implement them. The contract is
+checkout-shaped, not a generic catalogue API. Distinct from
+[Conformist](#conformist-cross-context) (no negotiation) and from
+[Anti-Corruption Layer](#anti-corruption-layer-acl-cross-context) (one-way
+translation against an unchangeable upstream).
 
 ### Discount [promo]
 The *resolved* effect of a promo [Code](#code) on one specific order:
@@ -253,6 +278,18 @@ in action.
 Read models are projected from the event stream and are never used to
 issue commands.
 
+### Partnership [cross-context]
+A strategic-design relationship where two contexts jointly evolve their
+shared interface, succeeding or failing together. The strongest form of
+coupling between two otherwise distinct contexts, and rare in practice.
+Not realised in this codebase today — no two contexts here co-own a
+contract; every cross-context seam is either
+[Customer-Supplier](#customer-supplier-cross-context),
+[ACL](#anti-corruption-layer-acl-cross-context),
+[OHS](#open-host-service-ohs) /
+[Published Language](#published-language-cross-context), or
+[Conformist](#conformist-cross-context).
+
 ### Process Manager [fulfillment]
 A long-running coordinator that reacts to events from other aggregates
 and emits commands of its own. The `fulfillment` context is the example
@@ -285,6 +322,19 @@ with values `["Red","Blue"]`. Defined in
 [backend/productcatalog/domain/variant.go](../backend/productcatalog/domain/variant.go)
 as `OptionType`. A `Product` has zero or more option types; each
 `Variant` is one combination of option-type values.
+
+### Published Language [cross-context]
+A documented, stable interchange schema that one or more contexts agree
+to read or produce — the "language" of the conversation between them,
+deliberately decoupled from any one context's internal model. Here:
+[`checkout.OrderPaid`](../backend/checkout/integration/events.go) is the
+checkout context's outward shape; the cart, fulfillment and email
+subscribers consume it through the [event bus](#event-bus) +
+[Transactional Outbox](#transactional-outbox) without checkout knowing
+they exist. The search [Document](#document) value object is a second
+example, paired with the search [OHS](#open-host-service-ohs). Closely
+related to [Integration event](#integration-event), which is the
+specific carrier here.
 
 ### Projection / Read model [checkout]
 The CQRS read side: a flat representation of an aggregate, derived from
@@ -326,6 +376,15 @@ with a moderation lifecycle `pending → approved | rejected` and a
 soft-delete escape hatch (the unique index is partial so a buyer can
 re-review after a removal). Only verified buyers can submit — see
 [Verified buyer](#verified-buyer).
+
+### Shared Kernel [cross-context]
+A strategic-design relationship where two contexts deliberately share a
+small, jointly-owned set of types — typically primitives like `Money` or
+`Currency`. Any change to the kernel is a coordinated change across both
+sides, so the kernel is kept intentionally tiny. Not realised in master
+today: each context defines its own currency / money types and the cart's
+ACL re-validates them on the way through. Listed here so a future `Money`
+value object lifted into `backend/internal/` lands with a name.
 
 ### Snapshot [checkout]
 A serialised point-in-time copy of an event-sourced aggregate's state,


### PR DESCRIPTION
The README's context-map diagram showed contexts and arrows but no relationship-type labels. Add them.

- Mermaid edges now labelled: `cart -|ACL|- productcatalog`; `checkout -|Customer-Supplier|- cart` and `-|Customer-Supplier|- productcatalog`; `layout -|Conformist|- *`; `checkout -.|Published Language|.- cart` (via the event bus + Outbox); `search` exposed as OHS.
- New legend below the diagram explaining each type with a one-line concrete file reference.
- Existing Talks-to table rewritten to use canonical relationship names.
- `docs/glossary.md` gains entries for Conformist, Customer-Supplier, Partnership, Published Language, Shared Kernel.

Partnership and Shared Kernel are explicitly called out as **not realised in master** — no edge carries those labels.

Docs only.