### PR TITLE
feat(cli): event catalog command

### DIFF
--- a/backend/cmd/cli/events.go
+++ b/backend/cmd/cli/events.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/bkielbasa/go-ecommerce/backend/internal/eventcatalog"
+	"github.com/spf13/cobra"
+)
+
+// newEventsCmd is the `events` subcommand: it walks the hand-curated
+// event catalog and prints it to stdout as living architecture
+// documentation. The catalog itself lives in
+// internal/eventcatalog so this command stays a thin Cobra wrapper.
+//
+// Flags:
+//   --by-context  group the table by producing bounded context
+//                  (one H2 + sub-table per producer) instead of a
+//                  single flat sorted table.
+func newEventsCmd() *cobra.Command {
+	var byContext bool
+
+	cmd := &cobra.Command{
+		Use:   "events",
+		Short: "Print the catalog of domain and integration events as a Markdown table",
+		Long: `Walks the hand-curated event catalog (internal/eventcatalog)
+and prints it to stdout as a Markdown table. The default output is one
+table sorted by event name; --by-context groups by producing context
+instead. The artefact is intended as living architecture documentation
+that is regenerated from the source.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			events := eventcatalog.Catalog()
+			w := cmd.OutOrStdout()
+			if byContext {
+				if err := eventcatalog.RenderMarkdownByContext(w, events); err != nil {
+					return fmt.Errorf("render by-context: %w", err)
+				}
+				return nil
+			}
+			if err := eventcatalog.RenderMarkdown(w, events); err != nil {
+				return fmt.Errorf("render markdown: %w", err)
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVar(&byContext, "by-context", false,
+		"group the table into one section per producing bounded context")
+
+	return cmd
+}

--- a/backend/cmd/cli/rootcmd.go
+++ b/backend/cmd/cli/rootcmd.go
@@ -29,6 +29,7 @@ func Execute(db *sql.DB) {
 	rootCmd.AddCommand(newSeedsCmd(appServ, db))
 	rootCmd.AddCommand(newReindexCmd(db))
 	rootCmd.AddCommand(newRebuildReadModelsCmd(db))
+	rootCmd.AddCommand(newEventsCmd())
 
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, err)

--- a/backend/internal/eventcatalog/README.md
+++ b/backend/internal/eventcatalog/README.md
@@ -1,0 +1,69 @@
+# eventcatalog
+
+A hand-curated registry of every event the codebase emits, plus the
+small `ecommerce events` CLI subcommand that renders it as Markdown.
+
+## Why hand-curated?
+
+The codebase has two flavours of events:
+
+- internal **domain** events inside aggregates (event-sourced in
+  `checkout/domain`, or in-memory bridges in `fulfillment/domain`);
+- **integration** events published on the bus as the published
+  language of one bounded context to its subscribers
+  (`checkout/integration`, `fulfillment/integration`).
+
+A real AST walker could discover them, but it would have to track our
+conventions for declaring an event (the `EventType`/`EventName`
+methods, the marker interfaces, codec version switches) and stay
+correct as those conventions evolve. A flat slice of `Event` literals
+is cheap to read, trivial to review, and orders of magnitude easier
+to keep accurate. The discipline is the same one the
+`docs/glossary.md` follows: when you introduce a new event, add a row
+in the same commit.
+
+The unit test `TestCatalogIsConsistent` enforces the basic shape (no
+duplicate `Name`s, valid `Kind`, `Version >= 1`, no empty `Name` /
+`Kind` / `Package` / `Producer`) so accidental drift fails CI.
+
+## Adding a new event
+
+When you introduce a new event type:
+
+1. Add the Go type and its `EventType()` / `EventName()` method in
+   the producing context (e.g. `checkout/domain` or
+   `fulfillment/integration`).
+2. Append a row to `Catalog()` in `catalog.go` describing it. Pick
+   a `Kind` (`KindDomain` or `KindIntegration`), set `Package` to
+   the relative import slice (e.g. `"checkout/domain"`), set
+   `Producer` to the bounded context name, set `Version` to `1`,
+   and list known `Consumers` (may be empty).
+3. Write a one-line `Description`. Note whether the event is
+   notification-style (IDs only) or event-carried-state-transfer
+   (full snapshot) when it is non-obvious.
+4. Run the verification gate: `go test ./internal/eventcatalog/...`
+   plus `go run ./cmd/cli events` to eyeball the rendered table.
+
+## Changing an event's schema
+
+When you change an event's payload shape (add or remove a field, or
+re-interpret an existing one):
+
+1. Bump the `Version` in `Catalog()` to the new latest value the
+   writer emits.
+2. Wire the version into the codec's marshal / unmarshal switch in
+   the owning context's adapter (see
+   `checkout/adapter/events_codec.go` for the OrderPlaced v1 -> v2
+   upcaster as the worked example).
+3. Note the change in the `Description` so the rendered table tells
+   readers why the version bumped (one short sentence is plenty).
+
+## How to view the catalog
+
+```sh
+go run ./cmd/cli events             # default: one Markdown table, sorted by Name
+go run ./cmd/cli events --by-context  # one H2 per producing context
+```
+
+The output is plain stdout — pipe it into a file or into your
+favourite Markdown previewer.

--- a/backend/internal/eventcatalog/catalog.go
+++ b/backend/internal/eventcatalog/catalog.go
@@ -1,0 +1,232 @@
+// Package eventcatalog is a hand-maintained registry of every event type
+// the codebase emits — both the internal, event-sourced domain events
+// (checkout/domain, fulfillment/domain) and the published integration
+// events that cross context boundaries (checkout/integration,
+// fulfillment/integration).
+//
+// WHY HAND-CURATED, NOT AST-PARSED
+//
+// A real AST walker over the source tree would be more elegant but
+// brittle: it has to recognise the conventions used to declare an
+// event (EventType / EventName methods, marker interfaces), track
+// versioning through codec switches, and stay correct when the team
+// changes those conventions. A hand-maintained list is cheap, total,
+// and trivially reviewable. The discipline is the same one the
+// docs/glossary.md follows — when you introduce a new event type,
+// append a row to Catalog() in the same commit. The unit test in
+// catalog_test.go enforces basic consistency (no duplicates, valid
+// kinds, version ≥ 1) so accidental drift fails CI rather than the
+// docs.
+//
+// The Catalog feeds the `ecommerce events` CLI subcommand, which
+// renders a Markdown table that is regenerated from source — living
+// architecture documentation that cannot silently fall behind the
+// code.
+package eventcatalog
+
+// Kind is the qualitative category of an event. Two values only:
+// "domain" for internal events that live inside a single bounded
+// context (event-sourced into its own event log or used as an
+// in-memory bridge to the publisher), and "integration" for events
+// published across the bus as the published language of one context
+// to its subscribers.
+const (
+	KindDomain      = "domain"
+	KindIntegration = "integration"
+)
+
+// Event describes one event type for the catalog. Fields are kept
+// human-friendly because the immediate consumer is a Markdown table —
+// the value is documentation, not machine schema.
+type Event struct {
+	// Name is the wire / EventType identifier as used in storage or
+	// on the bus. For integration events this matches EventName()
+	// (e.g. "checkout.OrderPaid"); for domain events we prefix
+	// the package shortname so the table groups naturally (e.g.
+	// "checkout.OrderPlaced", "fulfillment.FulfillmentScheduled").
+	Name string
+
+	// Kind is one of KindDomain or KindIntegration. Enforced by
+	// the consistency test.
+	Kind string
+
+	// Package is the import path slice that owns the event type
+	// (e.g. "checkout/domain", "fulfillment/integration"). Kept as
+	// a short relative path so the table column stays narrow.
+	Package string
+
+	// Version is the latest payload version known to the codebase.
+	// Domain events that have never been re-shaped stay at 1;
+	// event-sourced events that have been migrated through an
+	// upcaster (e.g. checkout.OrderPlaced today) carry the latest
+	// version the writer emits.
+	Version int
+
+	// Producer is the bounded context that emits the event, in
+	// human-readable form (e.g. "checkout", "fulfillment").
+	Producer string
+
+	// Consumers lists the contexts / subscribers that react to the
+	// event, again in human-readable form. May be empty for purely
+	// internal domain events.
+	Consumers []string
+
+	// Description is a one-line summary written for readers of the
+	// generated table. Note whether the event is notification-style
+	// (IDs only) or event-carried-state-transfer (full snapshot)
+	// here when relevant.
+	Description string
+}
+
+// Catalog returns every event type in the codebase.
+//
+// HAND-MAINTAINED — when you introduce a new event, add it here in
+// the same commit. The CI catalog-drift test (see catalog_test.go)
+// guards basic shape; semantic accuracy is on the author.
+//
+// Ordering inside the slice is not load-bearing: the CLI sorts by
+// Name before rendering.
+func Catalog() []Event {
+	return []Event{
+		// --- checkout / domain (event-sourced) ---
+		{
+			Name:        "checkout.OrderPlaced",
+			Kind:        KindDomain,
+			Package:     "checkout/domain",
+			Version:     2,
+			Producer:    "checkout",
+			Description: "An order has been placed. Carries the full line snapshot, ship and pay choices, tax, shipping cost, discount, and originating sales channel. v2 added Channel; the codec upcasts v1 rows to 'unknown'.",
+		},
+		{
+			Name:        "checkout.PaymentSucceeded",
+			Kind:        KindDomain,
+			Package:     "checkout/domain",
+			Version:     1,
+			Producer:    "checkout",
+			Description: "The payment for an order has been captured.",
+		},
+		{
+			Name:        "checkout.PaymentFailed",
+			Kind:        KindDomain,
+			Package:     "checkout/domain",
+			Version:     1,
+			Producer:    "checkout",
+			Description: "The payment for an order was declined; carries the failure reason.",
+		},
+		{
+			Name:        "checkout.OrderCancelled",
+			Kind:        KindDomain,
+			Package:     "checkout/domain",
+			Version:     1,
+			Producer:    "checkout",
+			Description: "A placed order was cancelled by the customer; carries the cancellation reason.",
+		},
+		{
+			Name:        "checkout.OrderShipped",
+			Kind:        KindDomain,
+			Package:     "checkout/domain",
+			Version:     1,
+			Producer:    "checkout",
+			Description: "Legacy commercial-side shipment event written to the order's event log; carrier and tracking code are optional. The operational lifecycle now lives in fulfillment/domain.",
+		},
+		{
+			Name:        "checkout.OrderDelivered",
+			Kind:        KindDomain,
+			Package:     "checkout/domain",
+			Version:     1,
+			Producer:    "checkout",
+			Description: "Legacy commercial-side delivery event written to the order's event log. Retained for replay; operational deliveries now live in fulfillment/domain.",
+		},
+		{
+			Name:        "checkout.OrderRefunded",
+			Kind:        KindDomain,
+			Package:     "checkout/domain",
+			Version:     1,
+			Producer:    "checkout",
+			Description: "A paid/shipped/delivered order has been refunded; carries the refund reason. Refund returns goods so reserved/sold stock is added back to the catalogue.",
+		},
+
+		// --- fulfillment / domain (state-stored, in-memory bridge) ---
+		{
+			Name:        "fulfillment.FulfillmentScheduled",
+			Kind:        KindDomain,
+			Package:     "fulfillment/domain",
+			Version:     1,
+			Producer:    "fulfillment",
+			Description: "A Fulfillment record has been spawned by OnOrderPaid in StatusScheduled. Not persisted: in-memory bridge drained by the service after a successful save.",
+		},
+		{
+			Name:        "fulfillment.FulfillmentLabeled",
+			Kind:        KindDomain,
+			Package:     "fulfillment/domain",
+			Version:     1,
+			Producer:    "fulfillment",
+			Description: "A shipping label was printed and the carrier + tracking code recorded; transitions Scheduled to Labeled.",
+		},
+		{
+			Name:        "fulfillment.FulfillmentShipped",
+			Kind:        KindDomain,
+			Package:     "fulfillment/domain",
+			Version:     1,
+			Producer:    "fulfillment",
+			Description: "The carrier has accepted the parcel; transitions Labeled to Shipped.",
+		},
+		{
+			Name:        "fulfillment.FulfillmentDelivered",
+			Kind:        KindDomain,
+			Package:     "fulfillment/domain",
+			Version:     1,
+			Producer:    "fulfillment",
+			Description: "The parcel was delivered; transitions Shipped to the happy-path terminal Delivered state.",
+		},
+		{
+			Name:        "fulfillment.FulfillmentRefunded",
+			Kind:        KindDomain,
+			Package:     "fulfillment/domain",
+			Version:     1,
+			Producer:    "fulfillment",
+			Description: "The fulfillment was refunded from any active state; carries the operator-supplied reason.",
+		},
+
+		// --- checkout / integration (published language) ---
+		{
+			Name:     "checkout.OrderPaid",
+			Kind:     KindIntegration,
+			Package:  "checkout/integration",
+			Version:  1,
+			Producer: "checkout",
+			Consumers: []string{
+				"cart (clear basket)",
+				"email (order confirmation)",
+				"fulfillment (schedule fulfillment)",
+			},
+			Description: "Published when an order's payment succeeds. Notification-style: carries OrderID / SessionID / CustomerID / At only, subscribers re-fetch state if they need details.",
+		},
+
+		// --- fulfillment / integration (published language) ---
+		{
+			Name:        "fulfillment.OrderShipped",
+			Kind:        KindIntegration,
+			Package:     "fulfillment/integration",
+			Version:     1,
+			Producer:    "fulfillment",
+			Description: "Published when a fulfillment reaches the Shipped state. Notification-style with the carrier + tracking code echoed for convenience; no external subscribers wired yet.",
+		},
+		{
+			Name:        "fulfillment.OrderDelivered",
+			Kind:        KindIntegration,
+			Package:     "fulfillment/integration",
+			Version:     1,
+			Producer:    "fulfillment",
+			Description: "Published when a fulfillment reaches the Delivered terminal state. Notification-style; no external subscribers wired yet.",
+		},
+		{
+			Name:        "fulfillment.OrderRefunded",
+			Kind:        KindIntegration,
+			Package:     "fulfillment/integration",
+			Version:     1,
+			Producer:    "fulfillment",
+			Description: "Published when a fulfillment is refunded; carries the operator-supplied reason. Notification-style; no external subscribers wired yet.",
+		},
+	}
+}

--- a/backend/internal/eventcatalog/catalog_test.go
+++ b/backend/internal/eventcatalog/catalog_test.go
@@ -1,0 +1,92 @@
+package eventcatalog
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// TestCatalogIsConsistent is the catalog-drift guard: every Event
+// must have non-empty Name / Kind / Package / Producer, Kind must be
+// one of the two allowed values, Version must be at least 1, and no
+// two events may share a Name. Adding a new event without satisfying
+// these invariants fails CI before the rendered doc can drift.
+func TestCatalogIsConsistent(t *testing.T) {
+	events := Catalog()
+	if len(events) == 0 {
+		t.Fatal("Catalog() returned no events")
+	}
+
+	allowedKinds := map[string]struct{}{
+		KindDomain:      {},
+		KindIntegration: {},
+	}
+
+	seen := make(map[string]struct{}, len(events))
+	for i, e := range events {
+		if e.Name == "" {
+			t.Errorf("events[%d]: Name is empty", i)
+		}
+		if e.Kind == "" {
+			t.Errorf("events[%d] (%s): Kind is empty", i, e.Name)
+		}
+		if _, ok := allowedKinds[e.Kind]; !ok {
+			t.Errorf("events[%d] (%s): Kind %q is not one of %q/%q",
+				i, e.Name, e.Kind, KindDomain, KindIntegration)
+		}
+		if e.Package == "" {
+			t.Errorf("events[%d] (%s): Package is empty", i, e.Name)
+		}
+		if e.Producer == "" {
+			t.Errorf("events[%d] (%s): Producer is empty", i, e.Name)
+		}
+		if e.Version < 1 {
+			t.Errorf("events[%d] (%s): Version %d is less than 1",
+				i, e.Name, e.Version)
+		}
+		if _, dup := seen[e.Name]; dup {
+			t.Errorf("events[%d]: duplicate Name %q", i, e.Name)
+		}
+		seen[e.Name] = struct{}{}
+	}
+}
+
+// TestRenderMarkdown sanity-checks that the rendered table contains
+// the header row, the separator row, and every event Name. It is a
+// smoke test, not a golden-file fixture — we want changes to the
+// catalog to land freely without touching the test.
+func TestRenderMarkdown(t *testing.T) {
+	var buf bytes.Buffer
+	if err := RenderMarkdown(&buf, Catalog()); err != nil {
+		t.Fatalf("RenderMarkdown returned error: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "| Name | Kind | Producer | Consumers | Version | Description |") {
+		t.Errorf("rendered output missing header row:\n%s", out)
+	}
+	for _, e := range Catalog() {
+		if !strings.Contains(out, e.Name) {
+			t.Errorf("rendered output missing event %q", e.Name)
+		}
+	}
+}
+
+// TestRenderMarkdownByContext checks that the by-context renderer
+// emits one H2 per distinct producer and includes every event under
+// some producer.
+func TestRenderMarkdownByContext(t *testing.T) {
+	var buf bytes.Buffer
+	if err := RenderMarkdownByContext(&buf, Catalog()); err != nil {
+		t.Fatalf("RenderMarkdownByContext returned error: %v", err)
+	}
+	out := buf.String()
+	producers := map[string]struct{}{}
+	for _, e := range Catalog() {
+		producers[e.Producer] = struct{}{}
+	}
+	for p := range producers {
+		if !strings.Contains(out, "## "+p) {
+			t.Errorf("by-context output missing section for producer %q", p)
+		}
+	}
+}

--- a/backend/internal/eventcatalog/render.go
+++ b/backend/internal/eventcatalog/render.go
@@ -1,0 +1,83 @@
+package eventcatalog
+
+import (
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+)
+
+// RenderMarkdown writes the catalog as a single Markdown table sorted
+// by Name. The columns are Name, Kind, Producer, Consumers, Version,
+// Description — the order chosen so the eye reads "what is it /
+// where does it come from / where does it go / what shape / why" in
+// one sweep.
+func RenderMarkdown(w io.Writer, events []Event) error {
+	sorted := append([]Event(nil), events...)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i].Name < sorted[j].Name })
+
+	if _, err := fmt.Fprintln(w, "| Name | Kind | Producer | Consumers | Version | Description |"); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintln(w, "| --- | --- | --- | --- | --- | --- |"); err != nil {
+		return err
+	}
+	for _, e := range sorted {
+		if _, err := fmt.Fprintf(w, "| %s | %s | %s | %s | %d | %s |\n",
+			e.Name, e.Kind, e.Producer, joinConsumers(e.Consumers), e.Version, escapePipes(e.Description),
+		); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// RenderMarkdownByContext groups the catalog into per-producer
+// sections (one H2 per producer) before rendering each section's
+// table. Useful for context-map style documentation where the
+// producing context is the anchor.
+func RenderMarkdownByContext(w io.Writer, events []Event) error {
+	byProducer := make(map[string][]Event)
+	for _, e := range events {
+		byProducer[e.Producer] = append(byProducer[e.Producer], e)
+	}
+
+	producers := make([]string, 0, len(byProducer))
+	for p := range byProducer {
+		producers = append(producers, p)
+	}
+	sort.Strings(producers)
+
+	for i, p := range producers {
+		if i > 0 {
+			if _, err := fmt.Fprintln(w); err != nil {
+				return err
+			}
+		}
+		if _, err := fmt.Fprintf(w, "## %s\n\n", p); err != nil {
+			return err
+		}
+		if err := RenderMarkdown(w, byProducer[p]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// joinConsumers renders the consumer slice for the Markdown column.
+// Empty slices become a single dash so the table column stays
+// non-empty (some Markdown renderers collapse empty cells).
+func joinConsumers(c []string) string {
+	if len(c) == 0 {
+		return "-"
+	}
+	return escapePipes(strings.Join(c, "; "))
+}
+
+// escapePipes escapes the pipe character so descriptions / consumer
+// strings can't break the Markdown table structure. We use the
+// HTML-ish escape rather than a backslash because GitHub-flavoured
+// Markdown is more reliable about rendering the entity.
+func escapePipes(s string) string {
+	return strings.ReplaceAll(s, "|", "&#124;")
+}


### PR DESCRIPTION
A new `cli events` subcommand prints a markdown table of every event type in the codebase (domain and integration), with producer, consumers, version, and a one-line description. Living architecture documentation that can't drift — regenerated from a hand-curated registry kept next to the events.

- New `internal/eventcatalog/` package with `Catalog() []Event` registry + `Markdown` / `MarkdownByContext` renderers.
- Hand-curated; doc explains the discipline (when you add an event, add an entry).
- `cli events` (default markdown table sorted by name); `cli events --by-context` (grouped).
- 3 unit tests: consistency (no duplicate names, valid kind, version ≥ 1) + both render shapes.
- 16 events catalogued today: 12 domain + 4 integration across checkout and fulfillment.