### PR TITLE
feat(fulfillment): Event-Carried State Transfer (OrderShippedECST)

### DIFF
--- a/backend/cmd/web/main.go
+++ b/backend/cmd/web/main.go
@@ -17,6 +17,8 @@ import (
 	checkoutquery "github.com/bkielbasa/go-ecommerce/backend/checkout/query"
 	"github.com/bkielbasa/go-ecommerce/backend/checkout/sweeper"
 	"github.com/bkielbasa/go-ecommerce/backend/fulfillment"
+	fulfillmentapp "github.com/bkielbasa/go-ecommerce/backend/fulfillment/app"
+	fulfillmentintegration "github.com/bkielbasa/go-ecommerce/backend/fulfillment/integration"
 	"github.com/bkielbasa/go-ecommerce/backend/internal"
 	"github.com/bkielbasa/go-ecommerce/backend/internal/application"
 	"github.com/bkielbasa/go-ecommerce/backend/internal/dependency"
@@ -156,10 +158,18 @@ func main() {
 	// (ship/deliver/refund). Stock release on refund goes through the
 	// productcatalog port wired below — same seam checkout used to
 	// call directly before that flow moved.
-	fulfillmentBD, fulfillmentSrv := fulfillment.New(db, bus)
+	//
+	// orderDetailReaderAdapter is the ACL onto checkout's read side
+	// the Ship command pulls through when it publishes the
+	// OrderShippedECST integration event (event-carried state
+	// transfer, alongside the notification-style OrderShipped). The
+	// translation lives in this composition root so fulfillment
+	// itself stays unaware of checkout's internal types.
+	fulfillmentBD, fulfillmentSrv := fulfillment.New(db, bus, orderDetailReaderAdapter{q: checkoutQry})
 	fulfillmentSrv = fulfillmentSrv.
 		WithStockReleaser(catalogService).
-		WithOrderLines(orderLinesAdapter{q: checkoutQry})
+		WithOrderLines(orderLinesAdapter{q: checkoutQry}).
+		WithLogger(logger)
 	// Promo bounded context: owns promo_code + promo_redemption. The
 	// checkout service redeems through its narrow PromoRedeemer seam so
 	// the math stays inside checkout while the ledger lives here.
@@ -273,6 +283,41 @@ func main() {
 		),
 	)
 
+	// 4. email.order-shipped — the ECST subscriber. This is the
+	//    counterpart to email.order-confirmation: it renders a "your
+	//    order has shipped" email and dispatches it via the same
+	//    Mailer. The subscriber is wired to fulfillment.OrderShippedECST
+	//    rather than the notification-style fulfillment.OrderShipped
+	//    — the whole point of the ECST pattern is to make this
+	//    subscriber operationally independent of checkout. Compare
+	//    with the order-confirmation subscriber above which has to
+	//    call back into checkoutQry.Find to materialise its render
+	//    data; here the event itself is sufficient.
+	//
+	//    The inbox.Wrap key matches the cross-context naming
+	//    convention used by the other subscribers — it is the
+	//    natural key in inbox_handled so renaming it is a migration
+	//    concern.
+	bus.SubscribeWithID(
+		fulfillmentintegration.OrderShippedECST{}.EventName(),
+		inbox.Wrap("email.order-shipped", inboxStore,
+			func(ctx context.Context, _ int64, e eventbus.Event) error {
+				shipped := e.(fulfillmentintegration.OrderShippedECST)
+				if shipped.Email == "" {
+					return nil
+				}
+				msg, err := layout.RenderOrderShipped(shipped)
+				if err != nil {
+					return fmt.Errorf("order shipped: render: %w", err)
+				}
+				if err := mailerSrv.Send(ctx, msg); err != nil {
+					return fmt.Errorf("order shipped: send: %w", err)
+				}
+				return nil
+			},
+		),
+	)
+
 	app.AddBoundedContext(cartBD)
 
 	imgStore := imagestore.NewDisk(cfg.UploadsDir, "/uploads")
@@ -373,6 +418,63 @@ func (a orderLinesAdapter) OrderQuantities(ctx context.Context, orderID string) 
 		out[ln.ProductID()] += ln.Quantity()
 	}
 	return out, nil
+}
+
+// orderDetailReaderAdapter bridges the checkout query service to the
+// fulfillment service's OrderDetailReader port — the seam Ship's
+// ECST publication path pulls through to assemble an
+// OrderShippedECST event. The translation lives here, in the
+// composition root, so the fulfillment package never imports
+// checkout/query and downstream subscribers stay bound to
+// fulfillment's published-language DTOs (see
+// fulfillment/integration/events.go) rather than to checkout's
+// internal value objects.
+//
+// CustomerID on the OrderView is the customer's email today
+// (single-field identity); the adapter copies it into both
+// CustomerID and Email on the fulfillment-owned OrderDetail. If the
+// two ever diverge — e.g. a future change splits the columns — the
+// fix is local to this adapter.
+type orderDetailReaderAdapter struct {
+	q interface {
+		Find(ctx context.Context, id string) (checkoutquery.OrderView, error)
+	}
+}
+
+func (a orderDetailReaderAdapter) OrderDetail(ctx context.Context, orderID string) (fulfillmentapp.OrderDetail, error) {
+	view, err := a.q.Find(ctx, orderID)
+	if err != nil {
+		return fulfillmentapp.OrderDetail{}, err
+	}
+	items := make([]fulfillmentapp.OrderDetailLine, 0, len(view.Items()))
+	for _, ln := range view.Items() {
+		items = append(items, fulfillmentapp.OrderDetailLine{
+			ProductID:     ln.ProductID(),
+			ProductName:   ln.ProductName(),
+			Quantity:      ln.Quantity(),
+			PriceAmount:   ln.PriceAmount(),
+			PriceCurrency: ln.PriceCurrency(),
+		})
+	}
+	ship := view.ShipTo()
+	return fulfillmentapp.OrderDetail{
+		CustomerID: view.CustomerID(),
+		Email:      view.CustomerID(),
+		ShipTo: fulfillmentapp.OrderDetailAddress{
+			Name:    ship.Name(),
+			Street1: ship.Street1(),
+			Street2: ship.Street2(),
+			City:    ship.City(),
+			Zip:     ship.Zip(),
+			Country: ship.Country(),
+		},
+		Items:        items,
+		Subtotal:     view.Subtotal(),
+		Tax:          view.TaxAmount(),
+		ShippingCost: view.ShippingCost(),
+		Total:        view.TotalAmount(),
+		Currency:     view.TotalCurrency(),
+	}, nil
 }
 
 // newLogger builds the process-wide structured logger.

--- a/backend/fulfillment/app/service.go
+++ b/backend/fulfillment/app/service.go
@@ -93,6 +93,62 @@ type OrderLineSource interface {
 	OrderQuantities(ctx context.Context, orderID string) (map[string]int, error)
 }
 
+// OrderDetailLine is the fulfillment-owned shape of a single order
+// line. It mirrors what an ECST consumer cares about and is
+// deliberately decoupled from checkout/domain.Line: the composition
+// root's adapter translates the checkout view into these.
+type OrderDetailLine struct {
+	ProductID     string
+	ProductName   string
+	Quantity      int
+	PriceAmount   int64
+	PriceCurrency string
+}
+
+// OrderDetailAddress is the fulfillment-owned shape of a shipping
+// destination. Like OrderDetailLine, it is decoupled from
+// checkout/domain.Address — fulfillment owns its own value objects so
+// it does not import checkout's internal model.
+type OrderDetailAddress struct {
+	Name    string
+	Street1 string
+	Street2 string
+	City    string
+	Zip     string
+	Country string
+}
+
+// OrderDetail is the fulfillment-owned aggregate view of everything
+// the ECST publication path needs to build an OrderShippedECST event:
+// who the customer is, where the parcel is going, what is in it, and
+// the totals. The composition root supplies an adapter that maps
+// checkout's OrderView onto this type so fulfillment never imports
+// checkout/query.
+type OrderDetail struct {
+	CustomerID   string
+	Email        string
+	ShipTo       OrderDetailAddress
+	Items        []OrderDetailLine
+	Subtotal     int64
+	Tax          int64
+	ShippingCost int64
+	Total        int64
+	Currency     string
+}
+
+// OrderDetailReader is the seam onto which the Ship command pulls the
+// rich snapshot it needs to publish an ECST event. The composition
+// root wires it to a thin adapter over checkout's query side; the
+// adapter — not fulfillment — knows how checkout's read model is
+// shaped. A nil reader (or one returning an error) disables the ECST
+// publication path: the durable notification-style OrderShipped
+// event is still published, so the Ship transition stays committed
+// and any downstream consumer wired to the notification name still
+// fires.
+type OrderDetailReader interface {
+	OrderDetail(ctx context.Context, orderID string) (OrderDetail, error)
+}
+
 // Service is the application facade. Methods follow the same shape:
 //
 //  1. load the record (or no-op if missing for OnOrderPaid)
@@ -100,13 +156,30 @@ type OrderLineSource interface {
 //  3. save (Create / Update)
 //  4. publish pending events
 type Service struct {
-	storage   Storage
-	publisher EventPublisher
-	stock     StockReleaser
-	lines     OrderLineSource
-	now       func() time.Time
-	newID     func() string
+	storage     Storage
+	publisher   EventPublisher
+	stock       StockReleaser
+	lines       OrderLineSource
+	orderDetail OrderDetailReader
+	logger      Logger
+	now         func() time.Time
+	newID       func() string
 }
+
+// Logger is the minimal log seam the service uses for non-fatal
+// warnings (e.g. ECST publication failed but the Ship transition has
+// already committed). Implemented by *logrus.Entry; tests can pass a
+// no-op.
+type Logger interface {
+	Warnf(format string, args ...any)
+}
+
+// nopLogger is the default when no logger is supplied — keeps the
+// service constructible in tests that don't care about non-fatal
+// warnings.
+type nopLogger struct{}
+
+func (nopLogger) Warnf(string, ...any) {}
 
 // NewService wires the service against its storage adapter. Optional
 // dependencies (publisher, stock releaser, line source, clock, id
@@ -116,6 +189,7 @@ func NewService(storage Storage) *Service {
 		storage:   storage,
 		publisher: nopPublisher{},
 		stock:     nopReleaser{},
+		logger:    nopLogger{},
 		now:       func() time.Time { return time.Now().UTC() },
 		newID:     newRandomID,
 	}
@@ -146,6 +220,26 @@ func (s *Service) WithStockReleaser(r StockReleaser) *Service {
 // best-effort no-op.
 func (s *Service) WithOrderLines(src OrderLineSource) *Service {
 	s.lines = src
+	return s
+}
+
+// WithOrderDetailReader wires the seam onto which Ship pulls the
+// rich order snapshot for the ECST publication. Without it the Ship
+// transition still commits and the notification-style OrderShipped
+// event is still published; only the ECST publication is suppressed.
+func (s *Service) WithOrderDetailReader(r OrderDetailReader) *Service {
+	s.orderDetail = r
+	return s
+}
+
+// WithLogger wires the warn-level log seam. Used by Ship to record
+// when the ECST publication path could not run (e.g. checkout's read
+// side could not be queried) without aborting the transition.
+func (s *Service) WithLogger(l Logger) *Service {
+	if l == nil {
+		l = nopLogger{}
+	}
+	s.logger = l
 	return s
 }
 
@@ -212,12 +306,96 @@ func (s *Service) Label(ctx context.Context, orderID, carrier, trackingCode stri
 	})
 }
 
-// Ship marks a labeled fulfillment shipped. Emits the
-// fulfillment.OrderShipped integration event.
+// Ship marks a labeled fulfillment shipped. Emits the notification-
+// style fulfillment.OrderShipped integration event from the
+// transition's pending-events drain (the durable signal) and then
+// additionally publishes the ECST-style fulfillment.OrderShippedECST
+// event carrying the full snapshot a downstream consumer needs to
+// render a "your order has shipped" notification without calling
+// back into checkout.
+//
+// The ECST publication is best-effort: a failure to load the order
+// detail or to publish the event is logged at Warn but does NOT
+// abort the Ship transition. The notification event is the durable
+// signal — a subscriber wired to OrderShipped still fires; only the
+// ECST consumer misses this one delivery. This mirrors the bus's
+// overall fire-and-forget contract for cross-context publishes.
 func (s *Service) Ship(ctx context.Context, orderID string) error {
-	return s.transition(ctx, orderID, func(f *domain.Fulfillment) error {
+	if err := s.transition(ctx, orderID, func(f *domain.Fulfillment) error {
 		return f.Ship(s.now())
-	})
+	}); err != nil {
+		return err
+	}
+	s.publishOrderShippedECST(ctx, orderID)
+	return nil
+}
+
+// publishOrderShippedECST builds and publishes the ECST companion to
+// the notification-style OrderShipped event. All failure paths are
+// logged at Warn and swallowed — the Ship transition has already
+// committed by the time we get here, and the durable notification
+// event has already been published.
+func (s *Service) publishOrderShippedECST(ctx context.Context, orderID string) {
+	if s.orderDetail == nil {
+		// Nothing wired — ECST publication is opt-in at the
+		// composition root. Stay silent (the absence is intentional
+		// in tests that don't exercise the ECST path).
+		return
+	}
+	f, err := s.storage.FindByOrder(ctx, orderID)
+	if err != nil {
+		s.logger.Warnf("fulfillment: ECST publish: reload after ship: %v", err)
+		return
+	}
+	detail, err := s.orderDetail.OrderDetail(ctx, orderID)
+	if err != nil {
+		s.logger.Warnf("fulfillment: ECST publish: order detail: %v", err)
+		return
+	}
+	ev := integration.OrderShippedECST{
+		OrderID:      orderID,
+		CustomerID:   detail.CustomerID,
+		Email:        detail.Email,
+		Carrier:      f.Carrier(),
+		TrackingCode: f.TrackingCode(),
+		ShipTo: integration.ShippingAddressDTO{
+			Name:    detail.ShipTo.Name,
+			Street1: detail.ShipTo.Street1,
+			Street2: detail.ShipTo.Street2,
+			City:    detail.ShipTo.City,
+			Zip:     detail.ShipTo.Zip,
+			Country: detail.ShipTo.Country,
+		},
+		Items:        toLineDTOs(detail.Items),
+		Subtotal:     detail.Subtotal,
+		Tax:          detail.Tax,
+		ShippingCost: detail.ShippingCost,
+		Total:        detail.Total,
+		Currency:     detail.Currency,
+		At:           f.ShippedAt(),
+	}
+	s.publisher.Publish(ctx, ev)
+}
+
+// toLineDTOs maps the fulfillment-owned line snapshots onto the
+// published-language LineDTOs that travel on the wire. Keeping the
+// mapping next to the publish path means the DTO contract stays in
+// one place.
+func toLineDTOs(lines []OrderDetailLine) []integration.LineDTO {
+	if len(lines) == 0 {
+		return nil
+	}
+	out := make([]integration.LineDTO, 0, len(lines))
+	for _, ln := range lines {
+		out = append(out, integration.LineDTO{
+			ProductID:     ln.ProductID,
+			ProductName:   ln.ProductName,
+			Quantity:      ln.Quantity,
+			PriceAmount:   ln.PriceAmount,
+			PriceCurrency: ln.PriceCurrency,
+		})
+	}
+	return out
 }
 
 // Deliver marks a shipped fulfillment delivered. Emits

--- a/backend/fulfillment/bounded_context.go
+++ b/backend/fulfillment/bounded_context.go
@@ -22,9 +22,21 @@ import (
 // .Service is intentionally exposed so the composition root can call
 // the optional With… seams (stock releaser, order line source)
 // without re-importing storage types.
-func New(db *sql.DB, bus *eventbus.Bus) (application.BoundedContext, *app.Service) {
+//
+// orderDetail is the seam onto which Ship's ECST publication path
+// pulls the rich order snapshot it puts on the wire. The composition
+// root supplies an adapter over checkout's query side so this
+// package never imports checkout/query — fulfillment owns the port
+// shape, the composition root owns the translation. A nil reader is
+// permitted: the ECST publication path is best-effort and silently
+// disabled when no reader is wired (mirroring how StockReleaser /
+// OrderLineSource are optional). The notification-style
+// OrderShipped event is published unconditionally either way.
+func New(db *sql.DB, bus *eventbus.Bus, orderDetail app.OrderDetailReader) (application.BoundedContext, *app.Service) {
 	storage := adapter.NewPostgres(db)
-	srv := app.NewService(storage).WithPublisher(busPublisher{bus: bus})
+	srv := app.NewService(storage).
+		WithPublisher(busPublisher{bus: bus}).
+		WithOrderDetailReader(orderDetail)
 	return &boundedContext{}, srv
 }
 

--- a/backend/fulfillment/integration/events.go
+++ b/backend/fulfillment/integration/events.go
@@ -10,12 +10,64 @@
 //
 // Other contexts (e.g. a future email-on-shipment subscriber) wire
 // onto these names without depending on checkout.
+//
+// NOTIFICATION vs EVENT-CARRIED STATE TRANSFER (ECST)
+//
+// This codebase deliberately demonstrates BOTH integration-event
+// styles side-by-side so the trade-off is visible at a glance:
+//
+//   - NOTIFICATION events carry only identifiers (and a timestamp).
+//     Subscribers learn that "something happened" and call back into
+//     the publishing context's read side for the data they need.
+//     OrderShipped (below) is the example: it carries OrderID +
+//     Carrier + TrackingCode + At. A subscriber that wants the
+//     line-items or the shipping address has to query checkout's
+//     OrderView itself. Pros: tiny payload, the publisher's schema
+//     stays small, no risk of stale denormalised state on the
+//     consumer. Cons: every consumer takes a runtime dependency on
+//     the publisher's read side (a coupling the bus was supposed to
+//     remove), and back-pressure / outage on the publisher cascades
+//     into the consumer.
+//
+//   - EVENT-CARRIED STATE TRANSFER (ECST) events carry the full
+//     snapshot the consumer needs to do its job. OrderShippedECST
+//     (below) is the example: it carries the customer's email, the
+//     shipping address, the line items, and the totals — everything
+//     a "your order has shipped" email needs to render without ever
+//     calling back into checkout. Pros: consumers stay live even
+//     when the publisher is down; the consumer never holds a stale
+//     join against the publisher's read model. Cons: the published
+//     payload is larger and the schema is a real contract (renaming
+//     a field is now a breaking change for every subscriber).
+//
+// When to use each:
+//
+//   - Use a NOTIFICATION event when the subscriber's reaction is
+//     small ("clear the cart") or when the subscriber always wants
+//     the freshest data ("admin dashboard re-render").
+//   - Use an ECST event when the subscriber wants to be operationally
+//     independent from the publisher (e.g. a "ship notification"
+//     email service that must not fail because checkout is hot) and
+//     the snapshot the consumer needs is well-bounded.
+//
+// The published-language DTOs below (ShippingAddressDTO, LineDTO) are
+// the CONTRACT for ECST consumers. Downstream consumers MUST bind to
+// these DTOs and MUST NOT import checkout's internal value objects
+// (checkout/domain.Address, checkout/domain.Line) — those are
+// checkout's internal model and can change without notice; the DTOs
+// in this file are the stable interchange shape.
 package integration
 
 import "time"
 
 // OrderShipped is published when a fulfillment transitions to
 // shipped. Carrier + TrackingCode mirror what was recorded by Label.
+//
+// NOTIFICATION-STYLE EVENT (see package doc). The payload carries the
+// identifiers and the operational metadata recorded by the shipping
+// transition; subscribers wanting more (line items, totals, the
+// customer's address) must query the checkout read side themselves.
+// Pair this with OrderShippedECST below for the contrast.
 type OrderShipped struct {
 	OrderID      string
 	Carrier      string
@@ -46,3 +98,62 @@ type OrderRefunded struct {
 }
 
 func (OrderRefunded) EventName() string { return "fulfillment.OrderRefunded" }
+
+// ShippingAddressDTO is the published-language shape of a shipping
+// address as it appears on the wire of ECST events. It deliberately
+// duplicates the field shape of checkout/domain.Address rather than
+// re-exporting it: downstream consumers bind to this DTO and never
+// import checkout's internal types.
+type ShippingAddressDTO struct {
+	Name    string
+	Street1 string
+	Street2 string
+	City    string
+	Zip     string
+	Country string
+}
+
+// LineDTO is the published-language shape of a single order line as
+// it appears on the wire of ECST events. PriceAmount is in minor
+// units of PriceCurrency (the same convention used everywhere else in
+// the codebase).
+type LineDTO struct {
+	ProductID     string
+	ProductName   string
+	Quantity      int
+	PriceAmount   int64
+	PriceCurrency string
+}
+
+// OrderShippedECST is published when a fulfillment transitions to
+// shipped, alongside the notification-style OrderShipped above.
+//
+// EVENT-CARRIED STATE TRANSFER (see package doc). The payload carries
+// the full state a downstream consumer needs to render a "your order
+// has shipped" notification — customer email, shipping destination,
+// line items, totals — without calling back into checkout's read
+// side. The notification-style OrderShipped above remains the durable
+// signal recorded on the bus; this ECST event is published alongside
+// it for consumers who want to be operationally independent of
+// checkout.
+type OrderShippedECST struct {
+	OrderID      string
+	CustomerID   string
+	Email        string
+	Carrier      string
+	TrackingCode string
+	ShipTo       ShippingAddressDTO
+	Items        []LineDTO
+	Subtotal     int64
+	Tax          int64
+	ShippingCost int64
+	Total        int64
+	Currency     string
+	At           time.Time
+}
+
+// EventName returns the wire name used by the outbox decoder / bus
+// subscribers. The "ECST" suffix in the name makes the style explicit
+// at the subscription site so it is impossible to mistake for the
+// notification-style OrderShipped.
+func (OrderShippedECST) EventName() string { return "fulfillment.OrderShippedECST" }

--- a/backend/internal/mailer/mailer.go
+++ b/backend/internal/mailer/mailer.go
@@ -41,6 +41,7 @@ type MessageKind = string
 const (
 	KindUnknown           MessageKind = "unknown"
 	KindOrderConfirmation MessageKind = "order_confirmation"
+	KindOrderShipped      MessageKind = "order_shipped"
 	KindPasswordReset     MessageKind = "password_reset"
 )
 

--- a/backend/layout/emails.go
+++ b/backend/layout/emails.go
@@ -9,6 +9,7 @@ import (
 	texttmpl "text/template"
 
 	checkoutQuery "github.com/bkielbasa/go-ecommerce/backend/checkout/query"
+	fulfillmentIntegration "github.com/bkielbasa/go-ecommerce/backend/fulfillment/integration"
 	"github.com/bkielbasa/go-ecommerce/backend/internal/mailer"
 )
 
@@ -45,6 +46,14 @@ var (
 	resetTextOnce sync.Once
 	resetText     *texttmpl.Template
 	resetTextErr  error
+
+	orderShippedHTMLOnce sync.Once
+	orderShippedHTML     *htmltmpl.Template
+	orderShippedHTMLErr  error
+
+	orderShippedTextOnce sync.Once
+	orderShippedText     *texttmpl.Template
+	orderShippedTextErr  error
 )
 
 func loadOrderConfHTML() (*htmltmpl.Template, error) {
@@ -73,6 +82,20 @@ func loadResetText() (*texttmpl.Template, error) {
 		resetText, resetTextErr = texttmpl.ParseFS(emailTemplates, "tmpl/emails/password_reset.txt.tmpl")
 	})
 	return resetText, resetTextErr
+}
+
+func loadOrderShippedHTML() (*htmltmpl.Template, error) {
+	orderShippedHTMLOnce.Do(func() {
+		orderShippedHTML, orderShippedHTMLErr = htmltmpl.ParseFS(emailTemplates, "tmpl/emails/order_shipped.html.tmpl")
+	})
+	return orderShippedHTML, orderShippedHTMLErr
+}
+
+func loadOrderShippedText() (*texttmpl.Template, error) {
+	orderShippedTextOnce.Do(func() {
+		orderShippedText, orderShippedTextErr = texttmpl.ParseFS(emailTemplates, "tmpl/emails/order_shipped.txt.tmpl")
+	})
+	return orderShippedText, orderShippedTextErr
 }
 
 // RenderOrderConfirmation builds a Message for the order-paid email. The
@@ -110,6 +133,46 @@ func RenderOrderConfirmation(view checkoutQuery.OrderView, baseURL string) (mail
 		HTMLBody: htmlBuf.String(),
 		TextBody: textBuf.String(),
 		Kind:     mailer.KindOrderConfirmation,
+	}, nil
+}
+
+// RenderOrderShipped builds a Message for the fulfillment.OrderShippedECST
+// integration event. It is the ECST companion to
+// RenderOrderConfirmation: every byte the templates execute against
+// comes from the event itself — there is NO callback into checkout's
+// read side. The subscriber that drives this helper can therefore
+// stay live even when the checkout context is unavailable, which is
+// the whole point of the Event-Carried State Transfer pattern (see
+// the fulfillment/integration package doc for the trade-off).
+func RenderOrderShipped(event fulfillmentIntegration.OrderShippedECST) (mailer.Message, error) {
+	htmlT, err := loadOrderShippedHTML()
+	if err != nil {
+		return mailer.Message{}, err
+	}
+	textT, err := loadOrderShippedText()
+	if err != nil {
+		return mailer.Message{}, err
+	}
+
+	data := map[string]any{
+		"Event":    event,
+		"SiteName": emailSiteName,
+	}
+
+	var htmlBuf, textBuf bytes.Buffer
+	if err := htmlT.Execute(&htmlBuf, data); err != nil {
+		return mailer.Message{}, err
+	}
+	if err := textT.Execute(&textBuf, data); err != nil {
+		return mailer.Message{}, err
+	}
+
+	return mailer.Message{
+		To:       event.Email,
+		Subject:  "Your order " + event.OrderID + " has shipped",
+		HTMLBody: htmlBuf.String(),
+		TextBody: textBuf.String(),
+		Kind:     mailer.KindOrderShipped,
 	}, nil
 }
 

--- a/backend/layout/emails_test.go
+++ b/backend/layout/emails_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/bkielbasa/go-ecommerce/backend/checkout/domain"
 	checkoutQuery "github.com/bkielbasa/go-ecommerce/backend/checkout/query"
+	fulfillmentIntegration "github.com/bkielbasa/go-ecommerce/backend/fulfillment/integration"
 )
 
 // TestRenderOrderConfirmation locks in that the embedded templates parse
@@ -54,6 +55,81 @@ func TestRenderOrderConfirmation(t *testing.T) {
 	}
 	if !strings.Contains(msg.TextBody, "Widget") {
 		t.Fatalf("TextBody missing item name: %q", msg.TextBody)
+	}
+}
+
+// TestRenderOrderShipped locks in the ECST property of the
+// order-shipped email: every byte of the rendered bodies must come
+// from the OrderShippedECST event payload supplied to the helper.
+// The fixture is constructed inline (not loaded from any store), so a
+// passing render proves the subscriber NEVER needs to call back into
+// checkout's read side. A regression that re-introduces a checkout
+// lookup would manifest as a missing field below.
+func TestRenderOrderShipped(t *testing.T) {
+	event := fulfillmentIntegration.OrderShippedECST{
+		OrderID:      "ord-789",
+		CustomerID:   "carol@example.com",
+		Email:        "carol@example.com",
+		Carrier:      "UPS",
+		TrackingCode: "1Z-ABC-999",
+		ShipTo: fulfillmentIntegration.ShippingAddressDTO{
+			Name:    "Carol Example",
+			Street1: "12 Test Lane",
+			Street2: "Apt 4B",
+			City:    "Krakow",
+			Zip:     "30-000",
+			Country: "PL",
+		},
+		Items: []fulfillmentIntegration.LineDTO{
+			{ProductID: "p-1", ProductName: "Widget", Quantity: 2, PriceAmount: 999, PriceCurrency: "USD"},
+			{ProductID: "p-2", ProductName: "Sprocket", Quantity: 1, PriceAmount: 2599, PriceCurrency: "USD"},
+		},
+		Subtotal:     4597,
+		Tax:          0,
+		ShippingCost: 500,
+		Total:        5097,
+		Currency:     "USD",
+		At:           time.Date(2026, 5, 27, 12, 0, 0, 0, time.UTC),
+	}
+
+	msg, err := RenderOrderShipped(event)
+	if err != nil {
+		t.Fatalf("RenderOrderShipped: %v", err)
+	}
+	if msg.To != "carol@example.com" {
+		t.Fatalf("To = %q, want carol@example.com", msg.To)
+	}
+	if !strings.Contains(msg.Subject, "ord-789") {
+		t.Fatalf("Subject does not include order id: %q", msg.Subject)
+	}
+	if !strings.Contains(msg.Subject, "shipped") {
+		t.Fatalf("Subject does not include 'shipped': %q", msg.Subject)
+	}
+
+	// Every load-bearing field MUST show up in BOTH bodies. The
+	// loop names the field being asserted so a failure points
+	// straight at the missing piece in the template.
+	wants := []struct {
+		label string
+		want  string
+	}{
+		{"OrderID", "ord-789"},
+		{"Carrier", "UPS"},
+		{"TrackingCode", "1Z-ABC-999"},
+		{"ShipTo.Name", "Carol Example"},
+		{"ShipTo.Street1", "12 Test Lane"},
+		{"ShipTo.City", "Krakow"},
+		{"ShipTo.Country", "PL"},
+		{"item 1 name", "Widget"},
+		{"item 2 name", "Sprocket"},
+	}
+	for _, w := range wants {
+		if !strings.Contains(msg.HTMLBody, w.want) {
+			t.Errorf("HTMLBody missing %s (%q)", w.label, w.want)
+		}
+		if !strings.Contains(msg.TextBody, w.want) {
+			t.Errorf("TextBody missing %s (%q)", w.label, w.want)
+		}
 	}
 }
 

--- a/backend/layout/tmpl/emails/order_shipped.html.tmpl
+++ b/backend/layout/tmpl/emails/order_shipped.html.tmpl
@@ -1,0 +1,71 @@
+{{/*
+  Order shipped is rendered ENTIRELY from the OrderShippedECST event
+  payload — no callbacks into checkout's read side. The pattern is
+  Event-Carried State Transfer: the publisher hands us everything the
+  consumer needs to do its job. Compare with order_confirmation
+  above, which renders from a freshly-loaded checkout OrderView.
+*/ -}}
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Order {{.Event.OrderID}} has shipped</title>
+</head>
+<body style="font-family: -apple-system, Segoe UI, Roboto, sans-serif; color: #1d1d1f; line-height: 1.5; max-width: 560px; margin: 24px auto; padding: 0 16px;">
+  <h1 style="font-size: 22px; font-weight: 600;">Your order is on its way.</h1>
+  <p>Order <strong>{{.Event.OrderID}}</strong> shipped {{.Event.At.Format "Jan 2, 2006 15:04 MST"}}.</p>
+
+  <p style="margin-top: 16px;">
+    <strong>Carrier:</strong> {{.Event.Carrier}}<br>
+    <strong>Tracking code:</strong> {{.Event.TrackingCode}}
+  </p>
+
+  <table cellspacing="0" cellpadding="6" style="width: 100%; border-collapse: collapse; margin-top: 16px;">
+    <thead>
+      <tr style="text-align: left; border-bottom: 1px solid #d2d2d7;">
+        <th>Item</th>
+        <th style="text-align: right;">Qty</th>
+        <th style="text-align: right;">Unit</th>
+      </tr>
+    </thead>
+    <tbody>
+      {{range $line := .Event.Items}}
+        <tr style="border-bottom: 1px solid #f0f0f0;">
+          <td>{{$line.ProductName}}</td>
+          <td style="text-align: right;">{{$line.Quantity}}</td>
+          <td style="text-align: right;">{{$line.PriceAmount}} {{$line.PriceCurrency}}</td>
+        </tr>
+      {{end}}
+    </tbody>
+    <tfoot>
+      <tr>
+        <td colspan="2" style="text-align: right;">Subtotal</td>
+        <td style="text-align: right;">{{.Event.Subtotal}} {{.Event.Currency}}</td>
+      </tr>
+      <tr>
+        <td colspan="2" style="text-align: right;">Shipping</td>
+        <td style="text-align: right;">{{.Event.ShippingCost}} {{.Event.Currency}}</td>
+      </tr>
+      <tr>
+        <td colspan="2" style="text-align: right;">Tax</td>
+        <td style="text-align: right;">{{.Event.Tax}} {{.Event.Currency}}</td>
+      </tr>
+      <tr style="font-weight: 600; border-top: 1px solid #d2d2d7;">
+        <td colspan="2" style="text-align: right;">Total</td>
+        <td style="text-align: right;">{{.Event.Total}} {{.Event.Currency}}</td>
+      </tr>
+    </tfoot>
+  </table>
+
+  <p style="margin-top: 16px;"><strong>Shipping to</strong></p>
+  <p style="margin: 0;">
+    {{.Event.ShipTo.Name}}<br>
+    {{.Event.ShipTo.Street1}}<br>
+    {{with .Event.ShipTo.Street2}}{{.}}<br>{{end}}
+    {{.Event.ShipTo.City}}, {{.Event.ShipTo.Zip}}<br>
+    {{.Event.ShipTo.Country}}
+  </p>
+
+  <p style="color: #6e6e73; font-size: 12px; margin-top: 32px;">This email is a shipping notification from {{.SiteName}}. Track your parcel with the carrier code above.</p>
+</body>
+</html>

--- a/backend/layout/tmpl/emails/order_shipped.txt.tmpl
+++ b/backend/layout/tmpl/emails/order_shipped.txt.tmpl
@@ -1,0 +1,28 @@
+{{/*
+  Order shipped is rendered ENTIRELY from the OrderShippedECST event
+  payload — no callbacks into checkout's read side. See the .html
+  template's comment for the pattern.
+*/ -}}
+Your order is on its way.
+
+Order {{.Event.OrderID}} shipped {{.Event.At.Format "Jan 2, 2006 15:04 MST"}}
+
+Carrier: {{.Event.Carrier}}
+Tracking code: {{.Event.TrackingCode}}
+
+Items:
+{{range $line := .Event.Items}}- {{$line.ProductName}} x {{$line.Quantity}} @ {{$line.PriceAmount}} {{$line.PriceCurrency}}
+{{end}}
+Subtotal: {{.Event.Subtotal}} {{.Event.Currency}}
+Shipping: {{.Event.ShippingCost}} {{.Event.Currency}}
+Tax: {{.Event.Tax}} {{.Event.Currency}}
+Total: {{.Event.Total}} {{.Event.Currency}}
+
+Shipping to:
+  {{.Event.ShipTo.Name}}
+  {{.Event.ShipTo.Street1}}{{with .Event.ShipTo.Street2}}
+  {{.}}{{end}}
+  {{.Event.ShipTo.City}}, {{.Event.ShipTo.Zip}}
+  {{.Event.ShipTo.Country}}
+
+This email is a shipping notification from {{.SiteName}}. Track your parcel with the carrier code above.


### PR DESCRIPTION
Demonstrates the **ECST** integration-event style alongside the existing notification style.

- Notification (today): `fulfillment.OrderShipped` carries IDs; consumers query checkout for details.
- **ECST (new)**: `fulfillment.OrderShippedECST` carries everything a downstream consumer needs — order id, customer email, ship-to address, line items, totals, carrier and tracking — with no callback required.

When the Process Manager transitions to Shipped, both events are published. A new email subscriber renders 'your order has shipped' using ONLY the data in the ECST event — proven by a template-render test with no checkout dependency.

- `fulfillment.app` gains an `OrderDetailReader` port + its own `OrderDetail` value object so the published-language stays decoupled from checkout's internals; the composition root adapts `checkoutQry.Find` into it.
- New email template `tmpl/emails/order_shipped.{html,txt}.tmpl` + `RenderOrderShipped` helper.
- ECST publish failures log Warn and DO NOT abort the Ship transition (the notification event is the durable signal).
- Subscriber wrapped via `inbox.Wrap` like the others.

## Test plan
- [x] build / build -tags integration / vet / tests / lint green
- [x] `TestRenderOrderShipped` asserts every required field is present in BOTH HTML and text bodies, rendering from the event alone