### PR TITLE
feat(sharedkernel): Money value object

### DIFF
--- a/backend/checkout/domain/order.go
+++ b/backend/checkout/domain/order.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"fmt"
 	"time"
+
+	"github.com/bkielbasa/go-ecommerce/backend/internal/sharedkernel"
 )
 
 type Status string
@@ -160,6 +162,42 @@ func (o Order) DiscountAmount() int64 { return o.discountAmt }
 // DiscountDisplay renders the discount amount for the totals row in the
 // templates (negative sign included).
 func (o Order) DiscountDisplay() string { return money(o.discountAmt) }
+
+// --- Shared-kernel Money accessors (additive) ---
+//
+// These getters return the same numbers as the int64 accessors above, wrapped
+// in the shared-kernel Money value object. They live ALONGSIDE the existing
+// accessors so callers that already speak Money (or want to) can pick them
+// up without breaking the int64-shaped reader paths (storage, templates,
+// CQRS projections) that still pair amount+currency at the boundary. See
+// internal/sharedkernel/README.md for the migration plan.
+
+// TotalMoney returns the order's grand total as a Money value.
+func (o Order) TotalMoney() sharedkernel.Money {
+	return sharedkernel.MustNewMoney(o.totalAmt, sharedkernel.Currency(o.totalCcy))
+}
+
+// SubtotalMoney returns the pre-discount, pre-tax, pre-shipping subtotal.
+func (o Order) SubtotalMoney() sharedkernel.Money {
+	return sharedkernel.MustNewMoney(o.subtotalAmt, sharedkernel.Currency(o.totalCcy))
+}
+
+// TaxMoney returns the tax charged on the discounted subtotal.
+func (o Order) TaxMoney() sharedkernel.Money {
+	return sharedkernel.MustNewMoney(o.taxAmt, sharedkernel.Currency(o.totalCcy))
+}
+
+// ShippingCostMoney returns the effective shipping cost (0 when free
+// shipping applied).
+func (o Order) ShippingCostMoney() sharedkernel.Money {
+	return sharedkernel.MustNewMoney(o.shipCostAmt, sharedkernel.Currency(o.totalCcy))
+}
+
+// DiscountMoney returns the resolved discount subtracted from the subtotal
+// before tax (zero when no code, or when the code only zeroed shipping).
+func (o Order) DiscountMoney() sharedkernel.Money {
+	return sharedkernel.MustNewMoney(o.discountAmt, sharedkernel.Currency(o.totalCcy))
+}
 
 // --- event-sourced write side ---
 

--- a/backend/checkout/domain/pricing.go
+++ b/backend/checkout/domain/pricing.go
@@ -45,7 +45,11 @@
 //     strategy only needs to cover its own math.
 package domain
 
-import "math"
+import (
+	"math"
+
+	"github.com/bkielbasa/go-ecommerce/backend/internal/sharedkernel"
+)
 
 // Quote is the value object returned by PriceQuote: every line a checkout
 // summary or order confirmation can render. Currency is implicit — the
@@ -215,4 +219,39 @@ func PriceQuote(lines []Line, shipMethod ShippingMethod, discount DiscountInput,
 		Total:          discountedSubtotal + taxAmount + shippingCost,
 		FreeShipping:   freeShipping,
 	}
+}
+
+// --- Shared-kernel Money helpers on Quote (additive) ---
+//
+// Quote keeps its int64 fields so the existing pricing-math and persistence
+// paths stay untouched. These helpers wrap each amount in a Money value
+// using the currency the caller supplies (typically the order's stored
+// currency, since Quote intentionally does not carry one). See
+// internal/sharedkernel/README.md for the migration plan.
+
+// SubtotalMoney returns the subtotal as Money in the supplied currency.
+func (q Quote) SubtotalMoney(currency sharedkernel.Currency) sharedkernel.Money {
+	return sharedkernel.MustNewMoney(q.Subtotal, currency)
+}
+
+// DiscountMoney returns the (clamped) discount as Money in the supplied
+// currency.
+func (q Quote) DiscountMoney(currency sharedkernel.Currency) sharedkernel.Money {
+	return sharedkernel.MustNewMoney(q.DiscountAmount, currency)
+}
+
+// TaxMoney returns the tax amount as Money in the supplied currency.
+func (q Quote) TaxMoney(currency sharedkernel.Currency) sharedkernel.Money {
+	return sharedkernel.MustNewMoney(q.Tax, currency)
+}
+
+// ShippingCostMoney returns the effective shipping cost as Money in the
+// supplied currency (zero when free shipping applied).
+func (q Quote) ShippingCostMoney(currency sharedkernel.Currency) sharedkernel.Money {
+	return sharedkernel.MustNewMoney(q.ShippingCost, currency)
+}
+
+// TotalMoney returns the grand total as Money in the supplied currency.
+func (q Quote) TotalMoney(currency sharedkernel.Currency) sharedkernel.Money {
+	return sharedkernel.MustNewMoney(q.Total, currency)
 }

--- a/backend/checkout/query/views.go
+++ b/backend/checkout/query/views.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/bkielbasa/go-ecommerce/backend/checkout/domain"
+	"github.com/bkielbasa/go-ecommerce/backend/internal/sharedkernel"
 )
 
 func money(amount int64) string {
@@ -44,6 +45,15 @@ func (s OrderSummary) ItemCount() int        { return s.itemCount }
 func (s OrderSummary) TotalAmount() int64    { return s.total }
 func (s OrderSummary) TotalDisplay() string  { return money(s.total) }
 func (s OrderSummary) TotalCurrency() string { return s.currency }
+
+// TotalMoney returns the row's grand total as a shared-kernel Money value.
+// It mirrors TotalAmount+TotalCurrency and is the preferred read for new
+// callers; the int64 accessors remain so the templates' currency-aware
+// `money` helper keeps working unchanged. See
+// internal/sharedkernel/README.md for the migration plan.
+func (s OrderSummary) TotalMoney() sharedkernel.Money {
+	return sharedkernel.MustNewMoney(s.total, sharedkernel.Currency(s.currency))
+}
 
 // OrderView is the read model for the order detail page.
 type OrderView struct {
@@ -136,6 +146,40 @@ func (v OrderView) DiscountDisplay() string { return money(v.discountAmount) }
 // row as "free shipping (CODE)" instead of a money amount.
 func (v OrderView) FreeShipping() bool {
 	return v.discountCode != "" && v.shipCost == 0 && v.discountAmount == 0
+}
+
+// --- Shared-kernel Money accessors (additive) ---
+//
+// These return the same numbers as the int64 accessors above, paired with
+// the view's stored currency. They sit alongside the existing accessors so
+// the storefront templates' `money` FuncMap helper keeps working unchanged
+// while new readers can speak Money directly.
+
+// SubtotalMoney returns the view's subtotal as a Money value.
+func (v OrderView) SubtotalMoney() sharedkernel.Money {
+	return sharedkernel.MustNewMoney(v.subtotal, sharedkernel.Currency(v.currency))
+}
+
+// TaxMoney returns the view's tax amount as a Money value.
+func (v OrderView) TaxMoney() sharedkernel.Money {
+	return sharedkernel.MustNewMoney(v.tax, sharedkernel.Currency(v.currency))
+}
+
+// ShippingCostMoney returns the view's effective shipping cost as a Money
+// value (zero when free shipping applied).
+func (v OrderView) ShippingCostMoney() sharedkernel.Money {
+	return sharedkernel.MustNewMoney(v.shipCost, sharedkernel.Currency(v.currency))
+}
+
+// TotalMoney returns the view's grand total as a Money value.
+func (v OrderView) TotalMoney() sharedkernel.Money {
+	return sharedkernel.MustNewMoney(v.total, sharedkernel.Currency(v.currency))
+}
+
+// DiscountMoney returns the view's discount as a Money value (zero when no
+// code was used).
+func (v OrderView) DiscountMoney() sharedkernel.Money {
+	return sharedkernel.MustNewMoney(v.discountAmount, sharedkernel.Currency(v.currency))
 }
 
 // DailySalesRow is one row of the analytics_daily_sales projection — a

--- a/backend/internal/sharedkernel/README.md
+++ b/backend/internal/sharedkernel/README.md
@@ -1,0 +1,42 @@
+# Shared Kernel
+
+This package is the project's **Shared Kernel** in the DDD sense: a small,
+deliberately stable common language that multiple bounded contexts depend on.
+The kernel is *published*: changing it costs coordination across every
+consuming context, so the bar for adding types here is high and the bar for
+changing existing ones is higher.
+
+## Contents
+
+Today the kernel ships a single type:
+
+- **`Money`** — an `(int64 minor units, ISO 4217 currency)` value object with
+  currency-aware arithmetic. The pair was previously threaded around as two
+  parameters (`amount int64`, `currency string`), which let cross-currency
+  bugs slip through type checks. `Money.Add`, `Sub` and `Compare` return
+  `ErrCurrencyMismatch` when the operands disagree; `Mul` and `MulFloat`
+  preserve the currency. `MulFloat` rounds via `math.Round` and is the
+  designated hook for percent math (tax, discount).
+
+The full contract is documented on the type itself in `money.go`.
+
+## Migration plan
+
+Adoption is **gradual**. The shared kernel exists from day one, but it does
+not need to land in every context at the same time:
+
+- **Today (this PR):** the `checkout` context exposes Money-returning getters
+  *alongside* its existing `(int64, string)` accessors on `Order`, `OrderView`
+  and `OrderSummary`. The pricing domain service (`PriceQuote`) still computes
+  in `int64`; the `Quote` value object gains Money-returning helpers but keeps
+  its int64 fields. Storage and events stay `int64`-based.
+- **Next:** `cart` and `productcatalog` adopt Money on their read sides, then
+  expose Money on commands.
+- **Later:** events and persistence rows migrate to store Money. Until that
+  ships, contexts that have not yet adopted Money exchange `(int64, string)`
+  at their boundaries and convert at the edge — typically a single
+  `sharedkernel.NewMoney(amt, sharedkernel.Currency(ccy))` call.
+
+The kernel deliberately does NOT include FX conversion: that is an
+infrastructure concern (rates, providers, caching) and belongs in its own
+service when the business needs it.

--- a/backend/internal/sharedkernel/money.go
+++ b/backend/internal/sharedkernel/money.go
@@ -1,0 +1,200 @@
+// Package sharedkernel hosts the small DDD Shared Kernel: a published common
+// language shared by multiple bounded contexts in this codebase. Types here
+// are intentionally tiny, dependency-free, and stable — every owning context
+// pays a coordination cost when they change, so changes must stay rare and
+// backwards-compatible.
+//
+// Money is the kernel's first inhabitant. It replaces the
+// (int64 minor units, string currency) pairs that callers were forced to
+// thread through hand-in-hand. Wrapping the pair in a value object gives us
+// three things the loose pair could not:
+//
+//  1. compile-time prevention of cross-currency arithmetic (Add/Sub/Compare
+//     return an error when currencies disagree),
+//  2. a single place to enforce ISO 4217 currency validation, and
+//  3. a single rounding policy for percent math (MulFloat uses math.Round).
+//
+// Adoption is intentionally gradual. The checkout bounded context exposes
+// Money-returning getters ALONGSIDE the existing int64+currency accessors
+// in this PR; other contexts continue to use the loose pairs at their
+// boundaries and convert at the edge. See the package README for the
+// migration plan and the rationale for keeping the storage layer on int64
+// for now.
+package sharedkernel
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"strings"
+)
+
+// ErrInvalidMoney is returned when constructing a Money with an invalid
+// currency (anything other than three uppercase ASCII letters per the
+// ISO 4217 alphabetic code shape).
+var ErrInvalidMoney = errors.New("invalid money")
+
+// ErrCurrencyMismatch is returned by every binary operation when the two
+// operands carry different currencies. Cross-currency arithmetic requires
+// an explicit FX conversion that this kernel deliberately does not provide.
+var ErrCurrencyMismatch = errors.New("currency mismatch")
+
+// Currency is an ISO 4217 three-letter alphabetic code (e.g. "EUR", "USD").
+// The string is treated as opaque — Money never reasons about the code's
+// minor-unit exponent or symbol. Display formatting (currency placement,
+// thousands separator, locale) lives in the presentation layer; this
+// package's Display() returns only "X.YY".
+type Currency string
+
+// String returns the underlying ISO code so a Currency interpolates as the
+// raw three-letter symbol in log lines and error messages.
+func (c Currency) String() string { return string(c) }
+
+// Validate enforces the ISO 4217 alphabetic shape: exactly three uppercase
+// ASCII letters. It does NOT check the code against the live ISO register —
+// callers stay free to use test currencies in unit tests.
+func (c Currency) Validate() error {
+	s := string(c)
+	if len(s) != 3 {
+		return fmt.Errorf("%w: currency %q must be 3 letters", ErrInvalidMoney, s)
+	}
+	for i := 0; i < len(s); i++ {
+		ch := s[i]
+		if ch < 'A' || ch > 'Z' {
+			return fmt.Errorf("%w: currency %q must be uppercase ASCII letters", ErrInvalidMoney, s)
+		}
+	}
+	return nil
+}
+
+// Money is an immutable value object: an amount in minor units (e.g. cents)
+// paired with the currency it is denominated in. Fields are unexported so the
+// only way to obtain a Money is via the constructors below, which guarantees
+// every Money in the system carries a validated currency.
+//
+// All operations are value-receiver: they never mutate the receiver and
+// always return a new Money.
+type Money struct {
+	amount   int64
+	currency Currency
+}
+
+// NewMoney constructs a Money after validating the currency. It is the
+// preferred constructor at boundaries where the currency originated from
+// untrusted input (HTTP form, database row, external event).
+func NewMoney(amount int64, currency Currency) (Money, error) {
+	if err := currency.Validate(); err != nil {
+		return Money{}, err
+	}
+	return Money{amount: amount, currency: currency}, nil
+}
+
+// MustNewMoney is the panicking counterpart of NewMoney. Use it only when
+// the currency is a compile-time constant or has already been validated
+// upstream — e.g. inside aggregate getters that know the stored currency
+// passed validation when the aggregate was constructed.
+func MustNewMoney(amount int64, currency Currency) Money {
+	m, err := NewMoney(amount, currency)
+	if err != nil {
+		panic(err)
+	}
+	return m
+}
+
+// Zero returns a Money worth nothing in the supplied currency. Useful as
+// an additive identity in summation loops and as the default value when a
+// field is optional (e.g. an order with no discount).
+func Zero(currency Currency) Money {
+	return MustNewMoney(0, currency)
+}
+
+// Amount returns the value in minor units (e.g. cents). Persistence layers
+// pair this with Currency() to round-trip Money through int64 columns
+// without a custom SQL type.
+func (m Money) Amount() int64 { return m.amount }
+
+// Currency returns the ISO 4217 code Money is denominated in.
+func (m Money) Currency() Currency { return m.currency }
+
+// IsZero reports whether the amount is exactly 0 (independent of currency).
+// A zero-EUR and a zero-USD both report true.
+func (m Money) IsZero() bool { return m.amount == 0 }
+
+// Add returns m + other. It rejects cross-currency operands with
+// ErrCurrencyMismatch — adding 10 EUR to 5 USD is meaningless without an
+// FX rate.
+func (m Money) Add(other Money) (Money, error) {
+	if m.currency != other.currency {
+		return Money{}, fmt.Errorf("%w: %s vs %s", ErrCurrencyMismatch, m.currency, other.currency)
+	}
+	return Money{amount: m.amount + other.amount, currency: m.currency}, nil
+}
+
+// Sub returns m - other. It rejects cross-currency operands, same as Add.
+func (m Money) Sub(other Money) (Money, error) {
+	if m.currency != other.currency {
+		return Money{}, fmt.Errorf("%w: %s vs %s", ErrCurrencyMismatch, m.currency, other.currency)
+	}
+	return Money{amount: m.amount - other.amount, currency: m.currency}, nil
+}
+
+// Mul scales the amount by an integer factor. The currency is preserved, so
+// there is no error path. Negative factors flip the sign — same as Negate
+// when factor is -1.
+func (m Money) Mul(factor int64) Money {
+	return Money{amount: m.amount * factor, currency: m.currency}
+}
+
+// MulFloat scales the amount by a float factor and rounds the result via
+// math.Round (banker's rounding is NOT used — see the README for the
+// rounding-policy rationale). This is the percent-math hook used for tax
+// and discount lines.
+func (m Money) MulFloat(factor float64) Money {
+	return Money{
+		amount:   int64(math.Round(float64(m.amount) * factor)),
+		currency: m.currency,
+	}
+}
+
+// Compare returns -1, 0 or 1 when m is less than, equal to or greater than
+// other respectively. It rejects cross-currency operands — there is no
+// total order across currencies without an FX rate.
+func (m Money) Compare(other Money) (int, error) {
+	if m.currency != other.currency {
+		return 0, fmt.Errorf("%w: %s vs %s", ErrCurrencyMismatch, m.currency, other.currency)
+	}
+	switch {
+	case m.amount < other.amount:
+		return -1, nil
+	case m.amount > other.amount:
+		return 1, nil
+	default:
+		return 0, nil
+	}
+}
+
+// Negate returns -m, preserving the currency.
+func (m Money) Negate() Money {
+	return Money{amount: -m.amount, currency: m.currency}
+}
+
+// Display renders the amount as a "X.YY" minor-units string with no
+// currency suffix. Templates pair this with the currency code so the
+// presentation layer keeps full control over symbol placement and locale.
+// Negative amounts render with a leading "-" (e.g. "-1.50").
+func (m Money) Display() string {
+	a := m.amount
+	sign := ""
+	if a < 0 {
+		sign = "-"
+		a = -a
+	}
+	return fmt.Sprintf("%s%d.%02d", sign, a/100, a%100)
+}
+
+// String renders Money as "X.YY CCY" for logs and error messages. It is
+// distinct from Display() on purpose: log lines want the currency, the
+// storefront templates do not.
+func (m Money) String() string {
+	return strings.TrimSpace(m.Display() + " " + string(m.currency))
+}

--- a/backend/internal/sharedkernel/money_test.go
+++ b/backend/internal/sharedkernel/money_test.go
@@ -1,0 +1,477 @@
+package sharedkernel_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/bkielbasa/go-ecommerce/backend/internal/sharedkernel"
+)
+
+func TestCurrencyValidate(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		c       sharedkernel.Currency
+		wantErr bool
+	}{
+		{"valid EUR", "EUR", false},
+		{"valid USD", "USD", false},
+		{"valid PLN", "PLN", false},
+		{"empty", "", true},
+		{"too short", "EU", true},
+		{"too long", "EURO", true},
+		{"lowercase", "eur", true},
+		{"mixed case", "Eur", true},
+		{"digits", "123", true},
+		{"symbol", "EU$", true},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := tc.c.Validate()
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				if !errors.Is(err, sharedkernel.ErrInvalidMoney) {
+					t.Fatalf("expected ErrInvalidMoney, got %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestNewMoney(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		amount   int64
+		currency sharedkernel.Currency
+		wantErr  bool
+	}{
+		{"positive EUR", 1000, "EUR", false},
+		{"zero", 0, "USD", false},
+		{"negative", -500, "GBP", false},
+		{"large", 9_999_999_999, "JPY", false},
+		{"min int64", -9_223_372_036_854_775_808, "EUR", false},
+		{"max int64", 9_223_372_036_854_775_807, "EUR", false},
+		{"bad currency lowercase", 100, "eur", true},
+		{"bad currency length", 100, "EU", true},
+		{"bad currency empty", 100, "", true},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			m, err := sharedkernel.NewMoney(tc.amount, tc.currency)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if m.Amount() != tc.amount {
+				t.Fatalf("amount = %d, want %d", m.Amount(), tc.amount)
+			}
+			if m.Currency() != tc.currency {
+				t.Fatalf("currency = %q, want %q", m.Currency(), tc.currency)
+			}
+		})
+	}
+}
+
+func TestMustNewMoney(t *testing.T) {
+	t.Parallel()
+
+	t.Run("valid", func(t *testing.T) {
+		t.Parallel()
+		m := sharedkernel.MustNewMoney(500, "EUR")
+		if m.Amount() != 500 || m.Currency() != "EUR" {
+			t.Fatalf("unexpected money: %v", m)
+		}
+	})
+
+	t.Run("panics on invalid", func(t *testing.T) {
+		t.Parallel()
+		defer func() {
+			if r := recover(); r == nil {
+				t.Fatalf("expected panic, got none")
+			}
+		}()
+		_ = sharedkernel.MustNewMoney(500, "bad")
+	})
+}
+
+func TestZero(t *testing.T) {
+	t.Parallel()
+
+	z := sharedkernel.Zero("EUR")
+	if !z.IsZero() {
+		t.Fatalf("Zero(EUR).IsZero() = false")
+	}
+	if z.Amount() != 0 {
+		t.Fatalf("amount = %d, want 0", z.Amount())
+	}
+	if z.Currency() != "EUR" {
+		t.Fatalf("currency = %q, want EUR", z.Currency())
+	}
+}
+
+func TestIsZero(t *testing.T) {
+	t.Parallel()
+
+	if !sharedkernel.MustNewMoney(0, "USD").IsZero() {
+		t.Fatalf("0 USD should be zero")
+	}
+	if sharedkernel.MustNewMoney(1, "USD").IsZero() {
+		t.Fatalf("1 USD should not be zero")
+	}
+	if sharedkernel.MustNewMoney(-1, "USD").IsZero() {
+		t.Fatalf("-1 USD should not be zero")
+	}
+}
+
+func TestAdd(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		a, b    sharedkernel.Money
+		want    int64
+		wantErr bool
+	}{
+		{
+			"same currency positive",
+			sharedkernel.MustNewMoney(100, "EUR"),
+			sharedkernel.MustNewMoney(250, "EUR"),
+			350, false,
+		},
+		{
+			"same currency mixed signs",
+			sharedkernel.MustNewMoney(100, "EUR"),
+			sharedkernel.MustNewMoney(-30, "EUR"),
+			70, false,
+		},
+		{
+			"adding zero",
+			sharedkernel.MustNewMoney(100, "EUR"),
+			sharedkernel.Zero("EUR"),
+			100, false,
+		},
+		{
+			"large values",
+			sharedkernel.MustNewMoney(1_000_000_000, "USD"),
+			sharedkernel.MustNewMoney(2_000_000_000, "USD"),
+			3_000_000_000, false,
+		},
+		{
+			"cross currency rejected",
+			sharedkernel.MustNewMoney(100, "EUR"),
+			sharedkernel.MustNewMoney(100, "USD"),
+			0, true,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := tc.a.Add(tc.b)
+			if tc.wantErr {
+				if !errors.Is(err, sharedkernel.ErrCurrencyMismatch) {
+					t.Fatalf("expected ErrCurrencyMismatch, got %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got.Amount() != tc.want {
+				t.Fatalf("amount = %d, want %d", got.Amount(), tc.want)
+			}
+			if got.Currency() != tc.a.Currency() {
+				t.Fatalf("currency = %q, want %q", got.Currency(), tc.a.Currency())
+			}
+		})
+	}
+}
+
+func TestSub(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		a, b    sharedkernel.Money
+		want    int64
+		wantErr bool
+	}{
+		{
+			"same currency",
+			sharedkernel.MustNewMoney(500, "EUR"),
+			sharedkernel.MustNewMoney(200, "EUR"),
+			300, false,
+		},
+		{
+			"going negative",
+			sharedkernel.MustNewMoney(100, "EUR"),
+			sharedkernel.MustNewMoney(250, "EUR"),
+			-150, false,
+		},
+		{
+			"subtract zero",
+			sharedkernel.MustNewMoney(100, "EUR"),
+			sharedkernel.Zero("EUR"),
+			100, false,
+		},
+		{
+			"cross currency rejected",
+			sharedkernel.MustNewMoney(100, "EUR"),
+			sharedkernel.MustNewMoney(50, "USD"),
+			0, true,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := tc.a.Sub(tc.b)
+			if tc.wantErr {
+				if !errors.Is(err, sharedkernel.ErrCurrencyMismatch) {
+					t.Fatalf("expected ErrCurrencyMismatch, got %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got.Amount() != tc.want {
+				t.Fatalf("amount = %d, want %d", got.Amount(), tc.want)
+			}
+		})
+	}
+}
+
+func TestMul(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		m      sharedkernel.Money
+		factor int64
+		want   int64
+	}{
+		{"by zero", sharedkernel.MustNewMoney(100, "EUR"), 0, 0},
+		{"by one", sharedkernel.MustNewMoney(100, "EUR"), 1, 100},
+		{"by three", sharedkernel.MustNewMoney(100, "EUR"), 3, 300},
+		{"by negative", sharedkernel.MustNewMoney(100, "EUR"), -2, -200},
+		{"negative amount", sharedkernel.MustNewMoney(-50, "EUR"), 4, -200},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := tc.m.Mul(tc.factor)
+			if got.Amount() != tc.want {
+				t.Fatalf("amount = %d, want %d", got.Amount(), tc.want)
+			}
+			if got.Currency() != tc.m.Currency() {
+				t.Fatalf("currency = %q, want %q", got.Currency(), tc.m.Currency())
+			}
+		})
+	}
+}
+
+func TestMulFloat(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		m      sharedkernel.Money
+		factor float64
+		want   int64
+	}{
+		{"tax 8.875% on 12345 cents", sharedkernel.MustNewMoney(12345, "USD"), 0.08875, 1096},
+		{"half off", sharedkernel.MustNewMoney(2000, "EUR"), 0.5, 1000},
+		{"rounds up", sharedkernel.MustNewMoney(100, "EUR"), 0.005, 1}, // 0.5 rounds up via math.Round
+		{"rounds down", sharedkernel.MustNewMoney(100, "EUR"), 0.004, 0},
+		{"rounds .5 away from zero (positive)", sharedkernel.MustNewMoney(1, "EUR"), 0.5, 1},
+		{"rounds .5 away from zero (negative)", sharedkernel.MustNewMoney(-1, "EUR"), 0.5, -1},
+		{"zero amount", sharedkernel.Zero("EUR"), 0.5, 0},
+		{"zero factor", sharedkernel.MustNewMoney(1234, "EUR"), 0, 0},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := tc.m.MulFloat(tc.factor)
+			if got.Amount() != tc.want {
+				t.Fatalf("amount = %d, want %d", got.Amount(), tc.want)
+			}
+			if got.Currency() != tc.m.Currency() {
+				t.Fatalf("currency mismatch")
+			}
+		})
+	}
+}
+
+func TestCompare(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		a, b    sharedkernel.Money
+		want    int
+		wantErr bool
+	}{
+		{"less", sharedkernel.MustNewMoney(100, "EUR"), sharedkernel.MustNewMoney(200, "EUR"), -1, false},
+		{"equal", sharedkernel.MustNewMoney(200, "EUR"), sharedkernel.MustNewMoney(200, "EUR"), 0, false},
+		{"greater", sharedkernel.MustNewMoney(300, "EUR"), sharedkernel.MustNewMoney(200, "EUR"), 1, false},
+		{"negative less than positive", sharedkernel.MustNewMoney(-1, "EUR"), sharedkernel.MustNewMoney(0, "EUR"), -1, false},
+		{"cross currency rejected", sharedkernel.MustNewMoney(100, "EUR"), sharedkernel.MustNewMoney(100, "USD"), 0, true},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := tc.a.Compare(tc.b)
+			if tc.wantErr {
+				if !errors.Is(err, sharedkernel.ErrCurrencyMismatch) {
+					t.Fatalf("expected ErrCurrencyMismatch, got %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("got %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestNegate(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		in   int64
+		want int64
+	}{
+		{"positive", 100, -100},
+		{"negative", -100, 100},
+		{"zero", 0, 0},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			m := sharedkernel.MustNewMoney(tc.in, "EUR")
+			got := m.Negate()
+			if got.Amount() != tc.want {
+				t.Fatalf("amount = %d, want %d", got.Amount(), tc.want)
+			}
+			if got.Currency() != "EUR" {
+				t.Fatalf("currency lost: %q", got.Currency())
+			}
+		})
+	}
+}
+
+func TestDisplay(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		amount int64
+		want   string
+	}{
+		{"zero", 0, "0.00"},
+		{"one cent", 1, "0.01"},
+		{"one dollar", 100, "1.00"},
+		{"with cents", 1234, "12.34"},
+		{"big", 1_234_567, "12345.67"},
+		{"negative", -150, "-1.50"},
+		{"negative single cent", -1, "-0.01"},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := sharedkernel.MustNewMoney(tc.amount, "EUR").Display()
+			if got != tc.want {
+				t.Fatalf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestString(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		amount   int64
+		currency sharedkernel.Currency
+		want     string
+	}{
+		{"positive", 1234, "EUR", "12.34 EUR"},
+		{"negative", -150, "USD", "-1.50 USD"},
+		{"zero", 0, "GBP", "0.00 GBP"},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := sharedkernel.MustNewMoney(tc.amount, tc.currency).String()
+			if got != tc.want {
+				t.Fatalf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCurrencyString(t *testing.T) {
+	t.Parallel()
+
+	if got := sharedkernel.Currency("EUR").String(); got != "EUR" {
+		t.Fatalf("got %q, want EUR", got)
+	}
+}
+
+func TestImmutability(t *testing.T) {
+	t.Parallel()
+
+	// Operations must never mutate the receiver — Money is a value object.
+	m := sharedkernel.MustNewMoney(100, "EUR")
+	_, _ = m.Add(sharedkernel.MustNewMoney(50, "EUR"))
+	_, _ = m.Sub(sharedkernel.MustNewMoney(10, "EUR"))
+	_ = m.Mul(3)
+	_ = m.MulFloat(0.5)
+	_ = m.Negate()
+	if m.Amount() != 100 {
+		t.Fatalf("original amount mutated: %d", m.Amount())
+	}
+	if m.Currency() != "EUR" {
+		t.Fatalf("original currency mutated: %q", m.Currency())
+	}
+}


### PR DESCRIPTION
Introduces a `Money` value object as a **Shared Kernel** — a small, deliberately-shared common-language for cross-context use. Demonstrates one more DDD strategic pattern this codebase didn't yet exhibit.

- New `internal/sharedkernel/money.go`: `Money{amount, currency}` with currency-aware arithmetic. `Add`/`Sub`/`Compare` reject cross-currency operations with `ErrCurrencyMismatch`; `Mul`/`MulFloat` (rounding via math.Round); `Negate`, `IsZero`, `Display`, `String`. Constructors validate ISO 4217 three-letter currencies.
- `internal/sharedkernel/README.md` documents the pattern + a gradual-adoption plan.
- Adoption is intentionally scoped to **checkout** for this PR: `Order`, `OrderView`, `OrderSummary`, and `Quote` gain Money-returning getters ALONGSIDE the existing int64+currency accessors. Pricing/Save/Load paths stay int64-based.
- Comprehensive table-driven `money_test.go` covering every operation, cross-currency rejection, edge cases (negative amounts, zero, large values, rounding).

Other contexts (cart, productcatalog, promo, etc.) keep their existing int64+currency style; subsequent PRs can migrate them.

## Test plan
- [x] build / build -tags integration / vet / tests / lint green