### PR TITLE
test(promo): storage conformance suite shared between adapters

### DIFF
--- a/backend/internal/storagetest/Readme.md
+++ b/backend/internal/storagetest/Readme.md
@@ -1,0 +1,94 @@
+# Storage conformance tests
+
+This codebase pairs every adapter: a postgres implementation backs
+production and an in-memory implementation backs fast unit tests. When the
+two drift the bug hides in plain sight — a fix lands in the in-memory store
+the integration tests never exercise, or vice-versa.
+
+A **storage conformance test** fixes that. One table-driven suite per
+`Storage` interface runs against BOTH adapters. One bug, one fix, one
+place; [Liskov substitution](https://en.wikipedia.org/wiki/Liskov_substitution_principle)
+as enforceable code.
+
+## Anatomy of a suite
+
+Next to the `Storage` interface (in the same `app` package so the suite
+can use the unexported sentinel errors) add a `conformance.go`:
+
+```go
+// RunStorageConformance exercises every contract guarantee of Storage.
+// Adapters call it from their own test files with a factory that hands
+// back a freshly initialised store.
+func RunStorageConformance(t *testing.T, newStorage func() Storage) {
+    t.Helper()
+
+    t.Run("Create_RoundTripsViaFind", func(t *testing.T) { ... })
+    t.Run("Update_OverwritesPersistedState", func(t *testing.T) { ... })
+    // ...one sub-test per contract clause...
+}
+```
+
+Each adapter then ships a thin test file that supplies the factory:
+
+```go
+// promo/adapter/inmemory_test.go         (default build tag)
+func TestInMemory_Conformance(t *testing.T) {
+    promoapp.RunStorageConformance(t, func() promoapp.Storage {
+        return NewInMemory()
+    })
+}
+
+// promo/adapter/postgres_test.go         (//go:build integration)
+func TestPostgres_Conformance(t *testing.T) {
+    db := openTestDB(t)
+    promoapp.RunStorageConformance(t, func() promoapp.Storage {
+        wipePromoTables(t, db)
+        return NewPostgres(db)
+    })
+}
+```
+
+Both files invoke the SAME suite. New contract tests added to the suite
+apply to both adapters automatically — that is the entire point.
+
+## Where the suite lives
+
+In the `app` package, not the `adapter` package, because:
+
+- it needs `Storage` and the sentinel errors (`ErrCodeNotFound`, …);
+- both adapter test files import it, so it must not depend on either
+  adapter;
+- placing it in `app` (rather than `app_test`) makes it importable
+  from `package adapter` test files without an import cycle.
+
+The function takes `*testing.T` from `testing` — a tiny import in
+production code, in exchange for one suite that runs against every
+adapter.
+
+## Conventions
+
+- Each sub-test calls `newStorage()` once, so adapters that share state
+  between sub-tests can wipe it cleanly per case.
+- Postgres factories sit behind `//go:build integration` and call a local
+  table-wipe helper before returning the adapter.
+- Sub-test names follow `Verb_What` (`Create_RoundTripsViaFind`,
+  `Redeem_AtomicUnderConcurrency`) so a single `go test -run` regex can
+  target one clause across both adapters.
+- Concurrency tests use `t.Parallel` + a `sync.WaitGroup` barrier to prove
+  atomicity rather than relying on race-detector luck.
+
+## Adopt the pattern in a new context
+
+1. Decide what contract guarantees the `Storage` interface makes — read
+   the application service to see what it relies on.
+2. Add `conformance.go` next to the interface with one sub-test per
+   guarantee.
+3. Add `adapter/inmemory_test.go` (default build) and
+   `adapter/postgres_test.go` (`//go:build integration`) that each call
+   `RunStorageConformance`.
+4. Delete any drift-prone duplicated adapter tests that the suite now
+   covers.
+
+The in-repo exemplar is the **promo** context — see
+[`backend/promo/app/conformance.go`](../../promo/app/conformance.go) and
+the two adapter test files alongside `inmemory.go` / `postgres.go`.

--- a/backend/internal/storagetest/storagetest.go
+++ b/backend/internal/storagetest/storagetest.go
@@ -1,0 +1,82 @@
+// Package storagetest documents the storage-conformance test pattern used
+// by this codebase and hosts cross-context helpers for it. It deliberately
+// holds no Go types today: each bounded context owns its own Storage
+// interface and so each owns its own conformance suite. What lives here is
+// the shape — the convention — so a reader can find one canonical place
+// that explains why every adapter test file looks the way it does.
+//
+// # The pattern in one paragraph
+//
+// Every adapter in this codebase is paired: a postgres implementation for
+// production and an in-memory implementation for fast unit tests. When the
+// two drift, bugs leak between layers — a fix lands in the in-memory store
+// the integration tests never exercise, or vice-versa. A storage
+// conformance test fixes that by defining ONE table-driven suite per
+// Storage interface and running it against BOTH adapters. One bug, one
+// fix, one place; Liskov substitution as enforceable code.
+//
+// # How a conformance suite looks
+//
+// Next to the Storage interface (in the same `app` package so it can refer
+// to the unexported error sentinels and the interface itself) add a file
+// like `conformance.go`:
+//
+//	// RunStorageConformance exercises every contract guarantee of Storage.
+//	// Adapters call it from their own test files with a factory that
+//	// hands back a freshly initialised store.
+//	func RunStorageConformance(t *testing.T, newStorage func() Storage) {
+//	    t.Helper()
+//	    t.Run("Create_RoundTripsViaFind", func(t *testing.T) { ... })
+//	    t.Run("Update_OverwritesPersistedState", func(t *testing.T) { ... })
+//	    // ...one sub-test per contract clause...
+//	}
+//
+// Each adapter then has a thin test file that supplies its factory:
+//
+//	// promo/adapter/inmemory_test.go (default build tag)
+//	func TestInMemory_Conformance(t *testing.T) {
+//	    promoapp.RunStorageConformance(t, func() promoapp.Storage {
+//	        return NewInMemory()
+//	    })
+//	}
+//
+//	// promo/adapter/postgres_test.go (//go:build integration)
+//	func TestPostgres_Conformance(t *testing.T) {
+//	    promoapp.RunStorageConformance(t, func() promoapp.Storage {
+//	        wipePromoTables(t, db)
+//	        return NewPostgres(db)
+//	    })
+//	}
+//
+// Both files invoke the SAME suite. New contract tests added to the suite
+// apply to both adapters automatically.
+//
+// # Where to put the suite
+//
+// The suite lives next to the interface, in the `app` package, NOT in the
+// adapter package. Reasons:
+//
+//   - it needs access to the interface and the sentinel errors;
+//   - both adapter test files import it, so it must not depend on either
+//     adapter;
+//   - keeping it in `app` (rather than `app_test`) makes it importable
+//     from `package adapter` test files without an import cycle.
+//
+// The function takes `*testing.T` from `testing` — the cost is a tiny
+// import in production code; the win is one suite that runs against every
+// adapter.
+//
+// # Conventions
+//
+//   - Each sub-test calls `newStorage()` once, so adapters that share state
+//     between sub-tests can wipe it cleanly per case;
+//   - postgres factories live behind `//go:build integration` and call a
+//     local `wipeTables` helper before returning the adapter;
+//   - sub-test names follow `Verb_What` (e.g. `Create_RoundTripsViaFind`),
+//     so a single `go test -run` regex can target one clause across both
+//     adapters;
+//   - concurrency tests use `t.Parallel` + a barrier (`sync.WaitGroup`) to
+//     prove atomicity rather than relying on race-detector luck.
+//
+// See `backend/promo/app/conformance.go` for the in-repo exemplar.
+package storagetest

--- a/backend/promo/adapter/inmemory_test.go
+++ b/backend/promo/adapter/inmemory_test.go
@@ -1,0 +1,18 @@
+package adapter
+
+// In-memory side of the promo storage conformance test. The same suite
+// (app.RunStorageConformance) is invoked by the postgres adapter test
+// behind the `integration` build tag — both implementations exercise the
+// identical contract.
+
+import (
+	"testing"
+
+	"github.com/bkielbasa/go-ecommerce/backend/promo/app"
+)
+
+func TestInMemory_Conformance(t *testing.T) {
+	app.RunStorageConformance(t, func() app.Storage {
+		return NewInMemory()
+	})
+}

--- a/backend/promo/adapter/postgres_test.go
+++ b/backend/promo/adapter/postgres_test.go
@@ -1,0 +1,78 @@
+//go:build integration
+
+package adapter
+
+// Postgres side of the promo storage conformance test. The same suite
+// (app.RunStorageConformance) is invoked by the in-memory adapter under
+// the default build tag, so any contract clause we add to the suite is
+// enforced against both implementations.
+//
+// This file follows the convention established by cart and productcatalog:
+// connect via POSTGRES_* env vars (with sensible local defaults) and wipe
+// the promo tables before each adapter is handed back to the suite.
+
+import (
+	"database/sql"
+	"fmt"
+	"os"
+	"testing"
+
+	_ "github.com/lib/pq"
+
+	"github.com/bkielbasa/go-ecommerce/backend/promo/app"
+)
+
+func TestPostgres_Conformance(t *testing.T) {
+	db := openTestDB(t)
+	t.Cleanup(func() { _ = db.Close() })
+
+	app.RunStorageConformance(t, func() app.Storage {
+		wipePromoTables(t, db)
+		return NewPostgres(db)
+	})
+}
+
+// openTestDB opens a connection against the POSTGRES_* env vars; the
+// defaults match the project's docker-compose.yaml. The build-tag gate
+// keeps this file (and its DB dependency) out of the default `go test`
+// run.
+func openTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	pass := getEnv("POSTGRES_PASSWORD", "postgres")
+	conn := fmt.Sprintf(
+		"host=%s port=%s user=%s password=%s dbname=%s sslmode=disable",
+		getEnv("POSTGRES_HOST", "localhost"),
+		getEnv("POSTGRES_PORT", "5432"),
+		getEnv("POSTGRES_USER", "postgres"),
+		pass,
+		getEnv("POSTGRES_DB", "ecommerce"),
+	)
+	db, err := sql.Open("postgres", conn)
+	if err != nil {
+		t.Fatalf("open postgres: %v", err)
+	}
+	if err := db.Ping(); err != nil {
+		t.Fatalf("ping postgres: %v", err)
+	}
+	return db
+}
+
+// wipePromoTables clears the promo catalogue + ledger before each
+// conformance sub-test. ON DELETE CASCADE on promo_redemption means
+// truncating promo_code would also clear the ledger, but we wipe both
+// explicitly so a future schema change (e.g. dropping the cascade) does
+// not silently leave stale rows behind.
+func wipePromoTables(t *testing.T, db *sql.DB) {
+	t.Helper()
+	if _, err := db.Exec(`TRUNCATE TABLE promo_redemption, promo_code CASCADE`); err != nil {
+		t.Fatalf("wipe promo tables: %v", err)
+	}
+}
+
+func getEnv(name, def string) string {
+	v := os.Getenv(name)
+	if v == "" {
+		v = def
+	}
+	return v
+}

--- a/backend/promo/app/conformance.go
+++ b/backend/promo/app/conformance.go
@@ -1,0 +1,474 @@
+package app
+
+// This file is the storage-conformance suite for the promo Storage port.
+// One suite, two adapters: both promo/adapter/inmemory_test.go and
+// promo/adapter/postgres_test.go call RunStorageConformance with their own
+// factory, so every contract guarantee declared here is verified against
+// both implementations.
+//
+// Why this lives in `package app` and not `package app_test` or in a
+// dedicated testing package: the suite references the unexported Storage
+// interface and the sentinel errors (ErrCodeNotFound, ErrCodeMaxUsesReached
+// …) directly, and it has to be importable from the adapter test files
+// (which sit in `package adapter`). Putting it in app_test would hide it
+// from the adapters; putting it in a separate "promotest" package would
+// require either exporting more app internals or duplicating fixtures.
+//
+// See backend/internal/storagetest for the pattern's documentation.
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/bkielbasa/go-ecommerce/backend/promo/domain"
+)
+
+// RunStorageConformance exercises every contract guarantee promo.Storage
+// makes to the application service. The factory is invoked once per
+// sub-test so each clause starts against a clean store — postgres
+// factories are expected to wipe the relevant tables before returning.
+//
+// Sub-test naming follows Verb_What so a single `go test -run` regex
+// targets one clause across both adapters
+// (e.g. `-run Conformance/Redeem_AtomicUnderConcurrency`).
+func RunStorageConformance(t *testing.T, newStorage func() Storage) {
+	t.Helper()
+
+	t.Run("Create_RoundTripsViaFind", func(t *testing.T) {
+		s := newStorage()
+		ctx := context.Background()
+		code := newPercentCode(t, "CONF-CREATE", 10)
+		if err := s.Create(ctx, code); err != nil {
+			t.Fatalf("Create: %v", err)
+		}
+		got, err := s.Find(ctx, "CONF-CREATE")
+		if err != nil {
+			t.Fatalf("Find after Create: %v", err)
+		}
+		if got.CodeText() != code.CodeText() || got.Kind() != code.Kind() || got.ValueMinor() != code.ValueMinor() {
+			t.Errorf("round-trip mismatch: got code=%q kind=%q value=%d, want code=%q kind=%q value=%d",
+				got.CodeText(), got.Kind(), got.ValueMinor(),
+				code.CodeText(), code.Kind(), code.ValueMinor())
+		}
+	})
+
+	t.Run("Create_DuplicateReturnsAlreadyExists", func(t *testing.T) {
+		s := newStorage()
+		ctx := context.Background()
+		code := newPercentCode(t, "CONF-DUP", 10)
+		if err := s.Create(ctx, code); err != nil {
+			t.Fatalf("first Create: %v", err)
+		}
+		err := s.Create(ctx, code)
+		if !errors.Is(err, ErrCodeAlreadyExists) {
+			t.Errorf("duplicate Create err = %v, want ErrCodeAlreadyExists", err)
+		}
+	})
+
+	t.Run("Update_OverwritesPersistedState", func(t *testing.T) {
+		s := newStorage()
+		ctx := context.Background()
+		original := newPercentCode(t, "CONF-UPDATE", 10)
+		if err := s.Create(ctx, original); err != nil {
+			t.Fatalf("Create: %v", err)
+		}
+		updated := newPercentCode(t, "CONF-UPDATE", 25)
+		if err := s.Update(ctx, updated); err != nil {
+			t.Fatalf("Update: %v", err)
+		}
+		got, err := s.Find(ctx, "CONF-UPDATE")
+		if err != nil {
+			t.Fatalf("Find after Update: %v", err)
+		}
+		if got.ValueMinor() != 25 {
+			t.Errorf("value after Update = %d, want 25", got.ValueMinor())
+		}
+	})
+
+	t.Run("Update_MissingReturnsNotFound", func(t *testing.T) {
+		s := newStorage()
+		ctx := context.Background()
+		ghost := newPercentCode(t, "CONF-GHOST", 10)
+		err := s.Update(ctx, ghost)
+		if !errors.Is(err, ErrCodeNotFound) {
+			t.Errorf("Update on missing row err = %v, want ErrCodeNotFound", err)
+		}
+	})
+
+	t.Run("Delete_RemovesAndSubsequentFindNotFound", func(t *testing.T) {
+		s := newStorage()
+		ctx := context.Background()
+		if err := s.Create(ctx, newPercentCode(t, "CONF-DEL", 10)); err != nil {
+			t.Fatalf("Create: %v", err)
+		}
+		if err := s.Delete(ctx, "CONF-DEL"); err != nil {
+			t.Fatalf("Delete: %v", err)
+		}
+		if _, err := s.Find(ctx, "CONF-DEL"); !errors.Is(err, ErrCodeNotFound) {
+			t.Errorf("Find after Delete err = %v, want ErrCodeNotFound", err)
+		}
+	})
+
+	t.Run("Delete_MissingReturnsNotFound", func(t *testing.T) {
+		s := newStorage()
+		ctx := context.Background()
+		err := s.Delete(ctx, "CONF-GHOST")
+		if !errors.Is(err, ErrCodeNotFound) {
+			t.Errorf("Delete on missing row err = %v, want ErrCodeNotFound", err)
+		}
+	})
+
+	t.Run("Find_MissingReturnsNotFound", func(t *testing.T) {
+		s := newStorage()
+		ctx := context.Background()
+		_, err := s.Find(ctx, "CONF-MISSING")
+		if !errors.Is(err, ErrCodeNotFound) {
+			t.Errorf("Find on missing row err = %v, want ErrCodeNotFound", err)
+		}
+	})
+
+	t.Run("ListAll_NewestFirst", func(t *testing.T) {
+		s := newStorage()
+		ctx := context.Background()
+		// Insert three codes; assert ListAll returns them ordered by
+		// created_at DESC. The domain's NewCode stamps created_at = now,
+		// so a small sleep between inserts is enough to give them distinct
+		// timestamps for both adapters.
+		want := []string{"CONF-LIST-A", "CONF-LIST-B", "CONF-LIST-C"}
+		for _, c := range want {
+			if err := s.Create(ctx, newPercentCode(t, c, 10)); err != nil {
+				t.Fatalf("Create %s: %v", c, err)
+			}
+			time.Sleep(2 * time.Millisecond)
+		}
+		got, err := s.ListAll(ctx)
+		if err != nil {
+			t.Fatalf("ListAll: %v", err)
+		}
+		// Filter to just our codes so a postgres run against a non-wiped
+		// table won't blow up the assertion order.
+		got = filterCodes(got, want)
+		if len(got) != len(want) {
+			t.Fatalf("ListAll returned %d rows, want %d", len(got), len(want))
+		}
+		// Reverse-want is the expected order (newest-first).
+		expected := []string{"CONF-LIST-C", "CONF-LIST-B", "CONF-LIST-A"}
+		for i, c := range got {
+			if c.CodeText() != expected[i] {
+				t.Errorf("ListAll[%d] = %q, want %q (newest-first contract)", i, c.CodeText(), expected[i])
+			}
+		}
+	})
+
+	t.Run("CountRedemptionsByCustomer_ZeroWhenNeverRedeemed", func(t *testing.T) {
+		s := newStorage()
+		ctx := context.Background()
+		if err := s.Create(ctx, newPercentCode(t, "CONF-COUNT0", 10)); err != nil {
+			t.Fatalf("Create: %v", err)
+		}
+		n, err := s.CountRedemptionsByCustomer(ctx, "CONF-COUNT0", "jane@example.com")
+		if err != nil {
+			t.Fatalf("CountRedemptionsByCustomer: %v", err)
+		}
+		if n != 0 {
+			t.Errorf("count for unredeemed customer = %d, want 0", n)
+		}
+	})
+
+	t.Run("CountRedemptionsByCustomer_TalliesAndIsolatesPerCustomer", func(t *testing.T) {
+		s := newStorage()
+		ctx := context.Background()
+		// max_uses=0 (unlimited) and per_customer_max=0 (unlimited) so
+		// we can drive the count up freely.
+		c, err := domain.NewCode("CONF-COUNT", domain.KindPercent, 10, "USD", nil, nil, 0, 0)
+		if err != nil {
+			t.Fatalf("NewCode: %v", err)
+		}
+		if err := s.Create(ctx, c); err != nil {
+			t.Fatalf("Create: %v", err)
+		}
+		for i := 0; i < 3; i++ {
+			err := s.Redeem(ctx, Redemption{
+				Code:        "CONF-COUNT",
+				OrderID:     "jane-ord-" + itoa(i),
+				CustomerID:  "jane@example.com",
+				AmountMinor: 100,
+				Currency:    "USD",
+			})
+			if err != nil {
+				t.Fatalf("Redeem #%d: %v", i, err)
+			}
+		}
+		// John never redeems.
+		got, err := s.CountRedemptionsByCustomer(ctx, "CONF-COUNT", "jane@example.com")
+		if err != nil {
+			t.Fatalf("CountRedemptionsByCustomer(jane): %v", err)
+		}
+		if got != 3 {
+			t.Errorf("jane's count = %d, want 3", got)
+		}
+		gotJohn, err := s.CountRedemptionsByCustomer(ctx, "CONF-COUNT", "john@example.com")
+		if err != nil {
+			t.Fatalf("CountRedemptionsByCustomer(john): %v", err)
+		}
+		if gotJohn != 0 {
+			t.Errorf("john's count = %d, want 0 (per-customer isolation)", gotJohn)
+		}
+	})
+
+	t.Run("Redeem_BumpsUsedCount", func(t *testing.T) {
+		s := newStorage()
+		ctx := context.Background()
+		if err := s.Create(ctx, newPercentCode(t, "CONF-BUMP", 10)); err != nil {
+			t.Fatalf("Create: %v", err)
+		}
+		err := s.Redeem(ctx, Redemption{
+			Code:        "CONF-BUMP",
+			OrderID:     "ord-1",
+			CustomerID:  "jane@example.com",
+			AmountMinor: 100,
+			Currency:    "USD",
+		})
+		if err != nil {
+			t.Fatalf("Redeem: %v", err)
+		}
+		got, err := s.Find(ctx, "CONF-BUMP")
+		if err != nil {
+			t.Fatalf("Find: %v", err)
+		}
+		if got.UsedCount() != 1 {
+			t.Errorf("used_count after Redeem = %d, want 1", got.UsedCount())
+		}
+	})
+
+	t.Run("Redeem_IdempotentOnSameCodeOrder", func(t *testing.T) {
+		s := newStorage()
+		ctx := context.Background()
+		if err := s.Create(ctx, newPercentCode(t, "CONF-IDEMP", 10)); err != nil {
+			t.Fatalf("Create: %v", err)
+		}
+		r := Redemption{
+			Code:        "CONF-IDEMP",
+			OrderID:     "ord-1",
+			CustomerID:  "jane@example.com",
+			AmountMinor: 100,
+			Currency:    "USD",
+		}
+		if err := s.Redeem(ctx, r); err != nil {
+			t.Fatalf("first Redeem: %v", err)
+		}
+		if err := s.Redeem(ctx, r); err != nil {
+			t.Errorf("idempotent Redeem err = %v, want nil", err)
+		}
+		got, err := s.Find(ctx, "CONF-IDEMP")
+		if err != nil {
+			t.Fatalf("Find: %v", err)
+		}
+		if got.UsedCount() != 1 {
+			t.Errorf("used_count after idempotent retry = %d, want 1 (must not double-count)", got.UsedCount())
+		}
+	})
+
+	t.Run("Redeem_RespectsMaxUsesCap", func(t *testing.T) {
+		s := newStorage()
+		ctx := context.Background()
+		// max_uses=1, per_customer_max=0 (so the second redemption is
+		// blocked by the global cap, not the per-customer one).
+		c, err := domain.NewCode("CONF-CAPMAX", domain.KindPercent, 10, "USD", nil, nil, 1, 0)
+		if err != nil {
+			t.Fatalf("NewCode: %v", err)
+		}
+		if err := s.Create(ctx, c); err != nil {
+			t.Fatalf("Create: %v", err)
+		}
+		if err := s.Redeem(ctx, Redemption{
+			Code:        "CONF-CAPMAX",
+			OrderID:     "ord-1",
+			CustomerID:  "alice@example.com",
+			AmountMinor: 100,
+			Currency:    "USD",
+		}); err != nil {
+			t.Fatalf("first Redeem: %v", err)
+		}
+		err = s.Redeem(ctx, Redemption{
+			Code:        "CONF-CAPMAX",
+			OrderID:     "ord-2",
+			CustomerID:  "bob@example.com",
+			AmountMinor: 100,
+			Currency:    "USD",
+		})
+		if !errors.Is(err, ErrCodeMaxUsesReached) {
+			t.Errorf("over-cap Redeem err = %v, want ErrCodeMaxUsesReached", err)
+		}
+	})
+
+	t.Run("Redeem_RespectsPerCustomerCap", func(t *testing.T) {
+		s := newStorage()
+		ctx := context.Background()
+		// max_uses=0 (unlimited globally), per_customer_max=1 — the
+		// customer's second redemption must be rejected, but a different
+		// customer can still redeem.
+		c, err := domain.NewCode("CONF-PERCUS", domain.KindPercent, 10, "USD", nil, nil, 0, 1)
+		if err != nil {
+			t.Fatalf("NewCode: %v", err)
+		}
+		if err := s.Create(ctx, c); err != nil {
+			t.Fatalf("Create: %v", err)
+		}
+		if err := s.Redeem(ctx, Redemption{
+			Code:        "CONF-PERCUS",
+			OrderID:     "ord-1",
+			CustomerID:  "alice@example.com",
+			AmountMinor: 100,
+			Currency:    "USD",
+		}); err != nil {
+			t.Fatalf("first Redeem: %v", err)
+		}
+		err = s.Redeem(ctx, Redemption{
+			Code:        "CONF-PERCUS",
+			OrderID:     "ord-2",
+			CustomerID:  "alice@example.com",
+			AmountMinor: 100,
+			Currency:    "USD",
+		})
+		if !errors.Is(err, ErrCodeCustomerLimit) {
+			t.Errorf("alice's second Redeem err = %v, want ErrCodeCustomerLimit", err)
+		}
+		// Bob is a different customer, so the per-customer cap doesn't
+		// apply to him — global cap is unlimited here.
+		if err := s.Redeem(ctx, Redemption{
+			Code:        "CONF-PERCUS",
+			OrderID:     "ord-3",
+			CustomerID:  "bob@example.com",
+			AmountMinor: 100,
+			Currency:    "USD",
+		}); err != nil {
+			t.Errorf("bob's first Redeem err = %v, want nil (per-customer cap is per customer)", err)
+		}
+	})
+
+	t.Run("Redeem_AtomicUnderConcurrency", func(t *testing.T) {
+		// Atomicity test: N goroutines hammer Redeem on a code with
+		// max_uses=1. Exactly one must succeed; the rest must fail with
+		// ErrCodeMaxUsesReached. The barrier (WaitGroup) makes all
+		// goroutines start as close to simultaneously as possible, so
+		// the postgres SELECT ... FOR UPDATE and the in-memory mutex
+		// both face real contention.
+		s := newStorage()
+		ctx := context.Background()
+		c, err := domain.NewCode("CONF-ATOMIC", domain.KindPercent, 10, "USD", nil, nil, 1, 0)
+		if err != nil {
+			t.Fatalf("NewCode: %v", err)
+		}
+		if err := s.Create(ctx, c); err != nil {
+			t.Fatalf("Create: %v", err)
+		}
+		const goroutines = 8
+		var start sync.WaitGroup
+		start.Add(1)
+		var done sync.WaitGroup
+		done.Add(goroutines)
+		results := make(chan error, goroutines)
+		for i := 0; i < goroutines; i++ {
+			go func(i int) {
+				defer done.Done()
+				start.Wait()
+				results <- s.Redeem(ctx, Redemption{
+					Code:        "CONF-ATOMIC",
+					OrderID:     "ord-" + itoa(i),
+					CustomerID:  "racer-" + itoa(i) + "@example.com",
+					AmountMinor: 100,
+					Currency:    "USD",
+				})
+			}(i)
+		}
+		start.Done()
+		done.Wait()
+		close(results)
+		successes, capHits, other := 0, 0, 0
+		for err := range results {
+			switch {
+			case err == nil:
+				successes++
+			case errors.Is(err, ErrCodeMaxUsesReached):
+				capHits++
+			default:
+				other++
+				t.Errorf("unexpected Redeem error under contention: %v", err)
+			}
+		}
+		if successes != 1 {
+			t.Errorf("successful redemptions = %d, want exactly 1 (max_uses=1 atomicity)", successes)
+		}
+		if capHits != goroutines-1 {
+			t.Errorf("ErrCodeMaxUsesReached count = %d, want %d", capHits, goroutines-1)
+		}
+		got, err := s.Find(ctx, "CONF-ATOMIC")
+		if err != nil {
+			t.Fatalf("Find: %v", err)
+		}
+		if got.UsedCount() != 1 {
+			t.Errorf("used_count after race = %d, want 1 (no oversubscription)", got.UsedCount())
+		}
+	})
+}
+
+// newPercentCode is a fixture helper for the common case: a percent-off
+// code with no validity bounds, no global cap, no per-customer cap. Tests
+// that need different settings call domain.NewCode directly.
+func newPercentCode(t *testing.T, code string, percent int64) domain.Code {
+	t.Helper()
+	c, err := domain.NewCode(code, domain.KindPercent, percent, "USD", nil, nil, 0, 0)
+	if err != nil {
+		t.Fatalf("NewCode(%q): %v", code, err)
+	}
+	return c
+}
+
+// filterCodes keeps the rows whose CodeText appears in want. The
+// postgres adapter test owns its own table wipe, but having the suite
+// filter defensively keeps ListAll's order assertion meaningful even
+// when run against a non-empty database by mistake.
+func filterCodes(in []domain.Code, want []string) []domain.Code {
+	keep := make(map[string]struct{}, len(want))
+	for _, w := range want {
+		keep[w] = struct{}{}
+	}
+	out := make([]domain.Code, 0, len(want))
+	for _, c := range in {
+		if _, ok := keep[c.CodeText()]; ok {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+// itoa is a tiny, allocation-free int->string for sub-test fixtures. The
+// production code already has its own copy in domain/code.go for its own
+// reasons; replicating it here keeps the test suite free of strconv churn
+// and matches the surrounding style.
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var buf [20]byte
+	i := len(buf)
+	negative := n < 0
+	if negative {
+		n = -n
+	}
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	if negative {
+		i--
+		buf[i] = '-'
+	}
+	return strings.Clone(string(buf[i:]))
+}

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -117,6 +117,20 @@ the codec (see [Upcaster](#upcaster)). Today every producer passes "web",
 but the parameter is wired through so a future iOS / API entry point
 needs no schema change.
 
+### Conformance test [cross-context]
+A single test suite per `Storage` port that is run against EVERY adapter
+implementing the port. Encodes [Liskov substitution](https://en.wikipedia.org/wiki/Liskov_substitution_principle)
+as enforceable code: if the in-memory and postgres adapters diverge on
+any contract clause, the suite fails on the offender. The in-repo
+exemplar is `RunStorageConformance` in
+[backend/promo/app/conformance.go](../backend/promo/app/conformance.go):
+both `promo/adapter/inmemory_test.go` (default build) and
+`promo/adapter/postgres_test.go` (`//go:build integration`) invoke the
+same function with their own factory. The pattern is documented under
+[backend/internal/storagetest/](../backend/internal/storagetest/Readme.md)
+and is the recommended approach for any new bounded context that ships
+paired adapters.
+
 ### Conformist [cross-context]
 A strategic-design relationship where the downstream context accepts the
 upstream's model and vocabulary as-is, without a translation layer. Cheap


### PR DESCRIPTION
## Summary
- Adds `promo/app/conformance.go` exposing `RunStorageConformance(t, newStorage)` with 15 sub-tests covering every contract guarantee of the `Storage` interface (round-trip, list ordering, redemption atomicity under concurrency, idempotent re-redeem, max-uses + per-customer caps).
- Both adapter test files (`promo/adapter/inmemory_test.go` default + `promo/adapter/postgres_test.go` with `//go:build integration`) call the same function with their own factory — Liskov substitution as enforceable tests.
- `internal/storagetest/` documents the pattern for future contexts.
- New `docs/glossary.md` entry for "Conformance test".

## Test plan
- [ ] CI green
- [ ] `go test ./promo/...` runs the in-memory conformance suite
- [ ] `go test -tags integration ./promo/...` runs the postgres suite against a live DB