### PR TITLE
feat(mailer): compose Send with retry/metrics/logging decorators

### DIFF
--- a/backend/cmd/web/main.go
+++ b/backend/cmd/web/main.go
@@ -200,12 +200,32 @@ func main() {
 	// (the dev default), New() returns a LogMailer that writes each email
 	// to the structured log instead of dialling — keeping the app bootable
 	// with no MailHog/SMTP relay running. Production always sets SMTP_HOST.
+	//
+	// The leaf mailer is wrapped in three service-level decorators. The
+	// composition order matters — read it innermost-out:
+	//
+	//   1. RetryingMailer (innermost wrap): on transient SMTP failures,
+	//      reissue up to 3 attempts with exponential backoff (200ms,
+	//      400ms). Sits closest to the leaf because retries should be
+	//      transparent to everything above.
+	//   2. MetricsMailer: records gocommerce_emails_sent_total exactly
+	//      once per logical Send. It MUST sit OUTSIDE retries — otherwise
+	//      a single Message that succeeds on attempt 3 would emit two
+	//      "failure" + one "success" observation instead of the single
+	//      "success" that callers actually care about.
+	//   3. LoggingMailer (outermost): one INFO breadcrumb per call,
+	//      promoted to ERROR if the (already-retried, already-counted)
+	//      send still failed. Outermost so a single noisy retry storm
+	//      does not pollute the log with one entry per attempt.
 	mailerSrv := mailer.New(mailer.Config{
 		Host:     cfg.SMTPHost,
 		Username: cfg.SMTPUsername,
 		Password: cfg.SMTPPassword,
 		From:     cfg.MailFrom,
 	}, logger)
+	mailerSrv = mailer.NewRetrying(mailerSrv, 3, 200*time.Millisecond, time.Now)
+	mailerSrv = mailer.NewMetrics(mailerSrv)
+	mailerSrv = mailer.NewLogging(mailerSrv, logger)
 
 	// Cross-context integration: the three OrderPaid subscribers are
 	// registered with SubscribeWithID and wrapped through inbox.Wrap

--- a/backend/internal/mailer/Readme.md
+++ b/backend/internal/mailer/Readme.md
@@ -1,0 +1,58 @@
+# mailer
+
+Outbound-email abstraction. Two leaf implementations (`SMTPMailer`,
+`LogMailer`) deliver the message; three composable decorators add
+cross-cutting concerns without touching the leaves.
+
+## Composition
+
+```
+                       Send(ctx, msg)
+                              |
+                              v
+                +-----------------------------+
+                |  LoggingMailer (outermost)  |   one breadcrumb per Send
+                +-----------------------------+
+                              |
+                              v
+                +-----------------------------+
+                |       MetricsMailer         |   one counter obs per Send
+                +-----------------------------+
+                              |
+                              v
+                +-----------------------------+
+                |      RetryingMailer         |   up to 3 attempts, expo backoff
+                +-----------------------------+
+                              |
+                              v
+                +-----------------------------+
+                |  SMTPMailer / LogMailer     |   actual delivery (or log)
+                +-----------------------------+
+```
+
+The wiring lives in `cmd/web/main.go`. Order matters:
+
+- **Retries innermost.** Metrics + logs see a single end-to-end outcome
+  per `Send`, not one per attempt. Counting per-attempt would inflate
+  the failure rate and obscure the user-visible success rate.
+- **Metrics inside logs.** The log entry is the human-readable mirror of
+  the metric tick; keeping them adjacent (metrics first, log last) means
+  a noisy log line corresponds 1:1 with a counter increment.
+
+## Adding a new decorator
+
+1. New file `internal/mailer/<concern>.go`. Embed `inner Mailer`, expose
+   a `New<Concern>` constructor.
+2. Implement `Send(ctx, msg) error` — delegate to `inner.Send` and add
+   exactly one behaviour around it. If the behaviour requires fan-out
+   (alerting, archiving, dual-write to a queue), put each side behind
+   its own decorator and compose them.
+3. Unit-test with the in-package `fakeMailer` (records calls + returns
+   a configured error sequence).
+4. Wire it into `cmd/web/main.go` in the correct slot. Update the comment
+   block + this diagram.
+
+Reasonable candidates next: `RateLimitedMailer` (per-recipient leaky
+bucket), `CircuitBreakerMailer` (open the breaker after N consecutive
+SMTP failures), `SamplingMailer` (drop a configurable percentage in
+load tests).

--- a/backend/internal/mailer/logging.go
+++ b/backend/internal/mailer/logging.go
@@ -1,0 +1,47 @@
+package mailer
+
+import (
+	"context"
+
+	"github.com/sirupsen/logrus"
+)
+
+// LoggingMailer wraps an inner Mailer with structured-log breadcrumbs:
+// one "mailer.send" entry on entry, one "mailer.send failed" entry on
+// error. It deliberately does NOT log the body — payloads can contain
+// password-reset tokens or order PII that should not land in the logs
+// twice (the leaf LogMailer already redacts to a 200-char preview).
+//
+// LoggingMailer is the outermost decorator in the standard composition:
+// it sees the FINAL outcome of the retry loop, so a transient failure
+// followed by a successful retry produces ONE info entry, not three.
+type LoggingMailer struct {
+	inner  Mailer
+	logger logrus.FieldLogger
+}
+
+// NewLogging constructs a LoggingMailer. A nil logger is permitted (the
+// decorator becomes a passthrough) so unit tests that don't care about
+// the log output can skip the fake-logger boilerplate.
+func NewLogging(inner Mailer, logger logrus.FieldLogger) *LoggingMailer {
+	return &LoggingMailer{inner: inner, logger: logger}
+}
+
+// Send logs the outbound attempt, delegates to the inner mailer, and
+// logs the failure (if any). The returned error is the inner error
+// verbatim so upstream callers can still type-check it.
+func (l *LoggingMailer) Send(ctx context.Context, msg Message) error {
+	fields := logrus.Fields{
+		"to":      msg.To,
+		"subject": msg.Subject,
+		"kind":    kindOrDefault(msg.Kind),
+	}
+	if l.logger != nil {
+		l.logger.WithFields(fields).Info("mailer.send")
+	}
+	err := l.inner.Send(ctx, msg)
+	if err != nil && l.logger != nil {
+		l.logger.WithFields(fields).WithError(err).Error("mailer.send failed")
+	}
+	return err
+}

--- a/backend/internal/mailer/logging_test.go
+++ b/backend/internal/mailer/logging_test.go
@@ -1,0 +1,82 @@
+package mailer
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+)
+
+func newCapturedLogger() (*logrus.Logger, *bytes.Buffer) {
+	logger := logrus.New()
+	buf := &bytes.Buffer{}
+	logger.SetOutput(buf)
+	logger.SetLevel(logrus.DebugLevel)
+	logger.SetFormatter(&logrus.TextFormatter{DisableColors: true, DisableTimestamp: true})
+	return logger, buf
+}
+
+func TestLoggingMailerLogsSuccess(t *testing.T) {
+	logger, buf := newCapturedLogger()
+	inner := &fakeMailer{}
+	l := NewLogging(inner, logger)
+
+	err := l.Send(context.Background(), Message{
+		To:      "alice@example.com",
+		Subject: "Receipt",
+		Kind:    KindOrderConfirmation,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if inner.calls != 1 {
+		t.Fatalf("inner should have been called once, got %d", inner.calls)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "mailer.send") {
+		t.Fatalf("expected mailer.send log entry, got %q", out)
+	}
+	if !strings.Contains(out, "alice@example.com") {
+		t.Fatalf("expected to= field, got %q", out)
+	}
+	if !strings.Contains(out, KindOrderConfirmation) {
+		t.Fatalf("expected kind field, got %q", out)
+	}
+	if strings.Contains(out, "mailer.send failed") {
+		t.Fatalf("did NOT expect failure entry, got %q", out)
+	}
+}
+
+func TestLoggingMailerLogsFailureAndReturnsError(t *testing.T) {
+	logger, buf := newCapturedLogger()
+	boom := errors.New("smtp dial: timeout")
+	inner := &fakeMailer{errs: []error{boom}}
+	l := NewLogging(inner, logger)
+
+	err := l.Send(context.Background(), Message{To: "alice@example.com", Subject: "x"})
+	if !errors.Is(err, boom) {
+		t.Fatalf("expected boom propagated, got %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "mailer.send failed") {
+		t.Fatalf("expected failure log entry, got %q", out)
+	}
+	if !strings.Contains(out, "smtp dial: timeout") {
+		t.Fatalf("expected inner error in log, got %q", out)
+	}
+}
+
+func TestLoggingMailerNilLoggerIsPassthrough(t *testing.T) {
+	inner := &fakeMailer{}
+	l := NewLogging(inner, nil)
+
+	if err := l.Send(context.Background(), Message{To: "a@b"}); err != nil {
+		t.Fatalf("nil logger should still proxy successfully: %v", err)
+	}
+	if inner.calls != 1 {
+		t.Fatalf("inner should have been called once, got %d", inner.calls)
+	}
+}

--- a/backend/internal/mailer/mailer.go
+++ b/backend/internal/mailer/mailer.go
@@ -9,6 +9,23 @@
 //
 // Adding a new provider later (SES native API, SendGrid HTTP) is a matter of
 // implementing the Mailer interface — no caller code needs to change.
+//
+// # Decorator pattern
+//
+// Cross-cutting concerns around Send (retries, structured logging, metrics)
+// are NOT baked into the SMTP/Log mailers. Instead this package ships three
+// composable decorators — RetryingMailer, LoggingMailer, MetricsMailer — each
+// of which embeds an inner Mailer, adds one behaviour, and exposes the same
+// Send(ctx, msg) signature. They are wired together in main.go in the order
+// that matches the desired behaviour: the innermost decorator runs closest
+// to the wrapped implementation, the outermost runs first/last. The pattern
+// is Go's idiomatic "embed an interface, add behaviour, return it" — it
+// keeps every concern in one file, makes each one independently testable,
+// and lets new concerns (rate limiting, circuit breaker, sampling) drop in
+// without touching the SMTP code.
+//
+// See internal/mailer/Readme.md for the recommended composition order and a
+// checklist for adding a new decorator.
 package mailer
 
 import (
@@ -126,19 +143,18 @@ var ErrEmptyMessage = errors.New("mailer: message has no body")
 // Send dispatches msg over SMTP. The MIME body is built locally so the
 // implementation can produce a true multipart/alternative when both bodies
 // are present without dragging in net/mail or net/textproto.
-func (m *SMTPMailer) Send(ctx context.Context, msg Message) (rerr error) {
+//
+// Metrics: the emails_sent_total counter is NOT incremented here; that
+// responsibility lives in the MetricsMailer decorator, which wraps this
+// implementation in cmd/web/main.go. Keeping it out of the leaf mailer
+// avoids double-counting once retries are layered in: the decorator records
+// the final outcome (one observation per Message), not per attempt.
+func (m *SMTPMailer) Send(ctx context.Context, msg Message) error {
 	kind := kindOrDefault(msg.Kind)
 	ctx, span := tracer.Start(ctx, "Mailer.SMTP.Send", trace.WithAttributes(
 		attribute.String("mail.kind", kind),
 	))
 	defer span.End()
-	defer func() {
-		outcome := "success"
-		if rerr != nil {
-			outcome = "failure"
-		}
-		observability.EmailsSentInc(ctx, kind, outcome)
-	}()
 
 	if msg.HTMLBody == "" && msg.TextBody == "" {
 		span.RecordError(ErrEmptyMessage)
@@ -270,19 +286,15 @@ type LogMailer struct {
 // The body itself is intentionally NOT logged in full (passwords / reset
 // tokens can show up inside it); a truncated preview is enough for a
 // developer to confirm the right email was triggered.
-func (m *LogMailer) Send(ctx context.Context, msg Message) (rerr error) {
+//
+// Metrics: the emails_sent_total counter is NOT incremented here; that
+// responsibility lives in the MetricsMailer decorator (see metrics.go).
+func (m *LogMailer) Send(ctx context.Context, msg Message) error {
 	kind := kindOrDefault(msg.Kind)
-	ctx, span := tracer.Start(ctx, "Mailer.Log.Send", trace.WithAttributes(
+	_, span := tracer.Start(ctx, "Mailer.Log.Send", trace.WithAttributes(
 		attribute.String("mail.kind", kind),
 	))
 	defer span.End()
-	defer func() {
-		outcome := "success"
-		if rerr != nil {
-			outcome = "failure"
-		}
-		observability.EmailsSentInc(ctx, kind, outcome)
-	}()
 
 	if msg.To == "" {
 		err := errors.New("mailer: To is required")

--- a/backend/internal/mailer/metrics.go
+++ b/backend/internal/mailer/metrics.go
@@ -1,0 +1,61 @@
+package mailer
+
+import (
+	"context"
+
+	"github.com/bkielbasa/go-ecommerce/backend/internal/observability"
+)
+
+// emitter is the metric sink the decorator depends on. The default
+// production wiring is observability.EmailsSentInc; tests inject their
+// own recorder.
+type emitter func(ctx context.Context, kind, outcome string)
+
+// MetricsMailer wraps an inner Mailer and increments
+// gocommerce_emails_sent_total{kind, outcome} EXACTLY ONCE per Message —
+// regardless of how many retries the inner stack performed. That is why
+// MetricsMailer must sit OUTSIDE RetryingMailer in the composition: the
+// counter records the final outcome of an end-to-end Send, not per
+// attempt. (See cmd/web/main.go for the wiring + the inline rationale.)
+//
+// The leaf SMTPMailer / LogMailer used to increment this counter
+// themselves; that responsibility was moved here so retries do not
+// double-count and so the metric is owned by a single, easily-disabled
+// decorator.
+type MetricsMailer struct {
+	inner Mailer
+	emit  emitter
+}
+
+// NewMetrics constructs a MetricsMailer that writes to the application
+// emails_sent_total counter via observability.EmailsSentInc. A nil inner
+// mailer is a programming error; we don't guard against it because
+// composition happens once at startup and a nil inner would crash on the
+// very first publish.
+func NewMetrics(inner Mailer) *MetricsMailer {
+	return &MetricsMailer{
+		inner: inner,
+		emit:  observability.EmailsSentInc,
+	}
+}
+
+// newMetricsWithEmitter is the test-only constructor that lets the unit
+// test capture metric writes without touching the global OTEL meter.
+func newMetricsWithEmitter(inner Mailer, emit emitter) *MetricsMailer {
+	return &MetricsMailer{inner: inner, emit: emit}
+}
+
+// Send delegates to the inner mailer and records exactly one
+// emails_sent_total observation tagged by Kind and outcome
+// ("success"/"failure"). It returns the inner error verbatim.
+func (m *MetricsMailer) Send(ctx context.Context, msg Message) error {
+	err := m.inner.Send(ctx, msg)
+	outcome := "success"
+	if err != nil {
+		outcome = "failure"
+	}
+	if m.emit != nil {
+		m.emit(ctx, kindOrDefault(msg.Kind), outcome)
+	}
+	return err
+}

--- a/backend/internal/mailer/metrics_test.go
+++ b/backend/internal/mailer/metrics_test.go
@@ -1,0 +1,69 @@
+package mailer
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// metricObs is one captured emails_sent_total observation.
+type metricObs struct {
+	kind, outcome string
+}
+
+func TestMetricsMailerEmitsSuccessOutcome(t *testing.T) {
+	var got []metricObs
+	inner := &fakeMailer{}
+	m := newMetricsWithEmitter(inner, func(_ context.Context, kind, outcome string) {
+		got = append(got, metricObs{kind, outcome})
+	})
+
+	err := m.Send(context.Background(), Message{To: "a@b", Kind: KindOrderConfirmation})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if inner.calls != 1 {
+		t.Fatalf("inner should have been called once, got %d", inner.calls)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 metric observation, got %d (%v)", len(got), got)
+	}
+	if got[0] != (metricObs{KindOrderConfirmation, "success"}) {
+		t.Fatalf("unexpected metric: %+v", got[0])
+	}
+}
+
+func TestMetricsMailerEmitsFailureOutcome(t *testing.T) {
+	var got []metricObs
+	boom := errors.New("smtp 550")
+	inner := &fakeMailer{errs: []error{boom}}
+	m := newMetricsWithEmitter(inner, func(_ context.Context, kind, outcome string) {
+		got = append(got, metricObs{kind, outcome})
+	})
+
+	err := m.Send(context.Background(), Message{To: "a@b", Kind: KindPasswordReset})
+	if !errors.Is(err, boom) {
+		t.Fatalf("expected boom propagated, got %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 metric observation, got %d", len(got))
+	}
+	if got[0] != (metricObs{KindPasswordReset, "failure"}) {
+		t.Fatalf("unexpected metric: %+v", got[0])
+	}
+}
+
+func TestMetricsMailerDefaultsBlankKindToUnknown(t *testing.T) {
+	var got []metricObs
+	inner := &fakeMailer{}
+	m := newMetricsWithEmitter(inner, func(_ context.Context, kind, outcome string) {
+		got = append(got, metricObs{kind, outcome})
+	})
+
+	if err := m.Send(context.Background(), Message{To: "a@b"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 1 || got[0].kind != KindUnknown {
+		t.Fatalf("expected kind=%q, got %+v", KindUnknown, got)
+	}
+}

--- a/backend/internal/mailer/retrying.go
+++ b/backend/internal/mailer/retrying.go
@@ -1,0 +1,114 @@
+package mailer
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// RetryingMailer wraps an inner Mailer with bounded exponential-backoff
+// retries. It is meant for transient SMTP failures (temporary DNS hiccups,
+// brief MTA outages, "421 try again later") where a second attempt a few
+// hundred milliseconds later usually succeeds.
+//
+// # When NOT to use this
+//
+// Retries are only safe when the wrapped operation is effectively idempotent
+// from the user's perspective. SMTP itself is NOT strictly idempotent — the
+// relay may have accepted the message and then dropped the connection before
+// acknowledging it, in which case a retry will dispatch a second copy. For
+// gocommerce that cost is low: a duplicate "order confirmation" email is
+// embarrassing, not destructive.
+//
+// Do NOT layer RetryingMailer in front of a sender that triggers paid
+// side-effects (SMS billed per message, push-notification rate quotas,
+// transactional webhooks) without first making the inner operation truly
+// idempotent at the provider level (idempotency key, dedupe window).
+type RetryingMailer struct {
+	inner    Mailer
+	attempts int
+	backoff  time.Duration
+	// clock returns the current wall time. Injected so tests can avoid
+	// real sleeps; production wires time.Now.
+	clock func() time.Time
+}
+
+// NewRetrying constructs a RetryingMailer. attempts is the total number of
+// Send invocations (including the first); values below 1 are clamped to 1
+// so a misconfigured caller still issues a single attempt rather than
+// silently dropping the send. backoff is the base delay; the k-th retry
+// sleeps backoff * 2^(k-1) (200ms, 400ms, 800ms, ...). A nil clock falls
+// back to time.Now.
+func NewRetrying(inner Mailer, attempts int, backoff time.Duration, clock func() time.Time) *RetryingMailer {
+	if attempts < 1 {
+		attempts = 1
+	}
+	if clock == nil {
+		clock = time.Now
+	}
+	return &RetryingMailer{
+		inner:    inner,
+		attempts: attempts,
+		backoff:  backoff,
+		clock:    clock,
+	}
+}
+
+// Send calls inner.Send up to r.attempts times, sleeping
+// backoff * 2^(i-1) between failures. It returns nil on the first success;
+// on permanent failure it returns the last observed error wrapped with the
+// attempt count so callers can grep logs for "after N attempts".
+//
+// Context cancellation short-circuits the back-off: a cancelled ctx ends
+// the loop immediately with ctx.Err(), so shutdown does not block on
+// queued retries.
+func (r *RetryingMailer) Send(ctx context.Context, msg Message) error {
+	var lastErr error
+	for i := 1; i <= r.attempts; i++ {
+		if err := ctx.Err(); err != nil {
+			if lastErr != nil {
+				return fmt.Errorf("mailer: send cancelled after %d attempt(s): %w", i-1, errors.Join(lastErr, err))
+			}
+			return err
+		}
+		err := r.inner.Send(ctx, msg)
+		if err == nil {
+			return nil
+		}
+		lastErr = err
+		if i == r.attempts {
+			break
+		}
+		// Exponential backoff: 1st retry waits backoff, 2nd waits 2x,
+		// 3rd waits 4x, ... Bit-shift instead of math.Pow keeps the
+		// arithmetic integer and panic-free.
+		delay := r.backoff << (i - 1)
+		if delay > 0 {
+			if err := sleep(ctx, delay, r.clock); err != nil {
+				return fmt.Errorf("mailer: send cancelled after %d attempt(s): %w", i, errors.Join(lastErr, err))
+			}
+		}
+	}
+	return fmt.Errorf("mailer: send failed after %d attempt(s): %w", r.attempts, lastErr)
+}
+
+// sleep blocks for d, but returns early with ctx.Err() if the context is
+// cancelled. The clock is consulted only to compute the deadline; the
+// actual wait uses a real timer because there is no portable way to mock
+// time.After without an injected scheduler. Tests that exercise the retry
+// loop pass attempts>1 with a near-zero backoff to keep wall time
+// negligible.
+func sleep(ctx context.Context, d time.Duration, _ func() time.Time) error {
+	if d <= 0 {
+		return ctx.Err()
+	}
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-t.C:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}

--- a/backend/internal/mailer/retrying_test.go
+++ b/backend/internal/mailer/retrying_test.go
@@ -1,0 +1,94 @@
+package mailer
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+// fakeMailer is a deterministic Mailer test double: it returns the
+// configured error sequence in order and counts the number of Send calls.
+type fakeMailer struct {
+	errs  []error
+	calls int
+}
+
+func (f *fakeMailer) Send(_ context.Context, _ Message) error {
+	idx := f.calls
+	f.calls++
+	if idx >= len(f.errs) {
+		return nil
+	}
+	return f.errs[idx]
+}
+
+func TestRetryingMailerSucceedsOnFirstAttempt(t *testing.T) {
+	inner := &fakeMailer{errs: nil}
+	r := NewRetrying(inner, 3, time.Millisecond, time.Now)
+
+	if err := r.Send(context.Background(), Message{To: "a@b"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if inner.calls != 1 {
+		t.Fatalf("want 1 inner call, got %d", inner.calls)
+	}
+}
+
+func TestRetryingMailerSucceedsAfterTransientFailure(t *testing.T) {
+	inner := &fakeMailer{errs: []error{errors.New("smtp 421"), nil}}
+	r := NewRetrying(inner, 3, time.Microsecond, time.Now)
+
+	if err := r.Send(context.Background(), Message{To: "a@b"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if inner.calls != 2 {
+		t.Fatalf("want 2 inner calls, got %d", inner.calls)
+	}
+}
+
+func TestRetryingMailerExhaustsAttempts(t *testing.T) {
+	boom := errors.New("smtp permanent")
+	inner := &fakeMailer{errs: []error{boom, boom, boom}}
+	r := NewRetrying(inner, 3, time.Microsecond, time.Now)
+
+	err := r.Send(context.Background(), Message{To: "a@b"})
+	if err == nil {
+		t.Fatalf("expected error after exhausted attempts")
+	}
+	if !errors.Is(err, boom) {
+		t.Fatalf("expected wrapped boom error, got %v", err)
+	}
+	if inner.calls != 3 {
+		t.Fatalf("want 3 inner calls, got %d", inner.calls)
+	}
+}
+
+func TestRetryingMailerClampsAttemptsToOne(t *testing.T) {
+	boom := errors.New("smtp permanent")
+	inner := &fakeMailer{errs: []error{boom}}
+	r := NewRetrying(inner, 0, time.Microsecond, time.Now)
+
+	if err := r.Send(context.Background(), Message{To: "a@b"}); err == nil {
+		t.Fatalf("expected error from single attempt")
+	}
+	if inner.calls != 1 {
+		t.Fatalf("want 1 inner call (attempts clamped to 1), got %d", inner.calls)
+	}
+}
+
+func TestRetryingMailerHonoursCancelledContext(t *testing.T) {
+	inner := &fakeMailer{errs: []error{errors.New("boom"), nil}}
+	// 1 second backoff would dominate the test if not cancelled.
+	r := NewRetrying(inner, 3, time.Second, time.Now)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel BEFORE the call so the first ctx.Err() check fires.
+
+	if err := r.Send(ctx, Message{To: "a@b"}); err == nil {
+		t.Fatalf("expected error on cancelled context")
+	}
+	if inner.calls != 0 {
+		t.Fatalf("want 0 inner calls on pre-cancelled ctx, got %d", inner.calls)
+	}
+}


### PR DESCRIPTION
## Summary
- Three composable `mailer.Mailer` decorators: `RetryingMailer` (exponential backoff), `MetricsMailer` (counter), `LoggingMailer`.
- Composition order at the composition root: `Logging → Metrics → Retrying → SMTP|Log` so metrics + logs record one observation per logical Send (not per retry).
- Removes the direct `EmailsSentInc` calls from `SMTPMailer` / `LogMailer` — the counter moves to `MetricsMailer` to avoid double-counting under retries.
- 11 new unit tests across the three decorators.
- `backend/internal/mailer/Readme.md` documents the pattern.

Service-level (not HTTP-level) decorator pattern — the project already shows HTTP middleware; this fills the gap.

## Test plan
- [ ] CI green
- [ ] Boot, send a confirmation email, see one log line + one metric tick + the SMTP/Log call