### PR TITLE
refactor(checkout): introduce OrderFactory for construction validation

### DIFF
--- a/backend/checkout/app/checkout.go
+++ b/backend/checkout/app/checkout.go
@@ -291,7 +291,11 @@ func (s CheckoutService) Place(ctx context.Context, sessID, customerID, cardNumb
 	// "web". Pluggable when iOS / API channels arrive — the signature is
 	// already wired through PlaceOrder and the OrderPlaced v2 schema.
 	const channel = "web"
-	order, err := domain.PlaceOrder(orderID, sessID, customerID, shipTo, shipMethod, payMethod, lines, quote.Tax, quote.ShippingCost, discount.Code(), quote.DiscountAmount, channel, s.now())
+	// Construction validation (empty cart / missing address / channel /
+	// payment method) lives in the Aggregate Factory; we hand it the Quote
+	// directly so tax / shipping / discount are read straight off the
+	// pricing service's output rather than threaded as separate args.
+	order, err := domain.NewOrderFactory().FromCart(orderID, sessID, customerID, shipTo, shipMethod, payMethod, lines, quote, discount.Code(), channel, s.now())
 	if err != nil {
 		_ = s.stock.Release(ctx, quantities)
 		for vid, qty := range quantities {

--- a/backend/checkout/domain/order.go
+++ b/backend/checkout/domain/order.go
@@ -201,8 +201,11 @@ func (o Order) DiscountMoney() sharedkernel.Money {
 
 // --- event-sourced write side ---
 
-// PlaceOrder is the command that creates a new order from a cart snapshot
-// and the customer's checkout choices. It emits an OrderPlaced event.
+// PlaceOrder is the AGGREGATE COMMAND that emits OrderPlaced. The
+// OrderFactory (see order_factory.go) front-loads construction validation
+// (empty cart, missing address / channel / payment method); this function
+// trusts its inputs and focuses on raising the event + advancing the
+// aggregate to StatusPending.
 //
 // tax is the tax amount in minor units already computed by the caller
 // (CheckoutService) from the configured rate AFTER the promo-code discount
@@ -220,10 +223,14 @@ func (o Order) DiscountMoney() sharedkernel.Money {
 // today always pass "web" (the only producer) but the parameter is wired
 // through so iOS/API entry points can light it up without a second
 // schema migration.
+//
+// PlaceOrder kept its previous signature + return type for back-compat:
+// existing tests call it directly, and the factory delegates to it after
+// validation. The empty-cart guard that used to live here has moved to
+// OrderFactory.FromCart so all construction-time validation is in one
+// place. Callers that bypass the factory (e.g. tests) are responsible for
+// supplying a non-empty lines slice.
 func PlaceOrder(id, userID, customerID string, shipTo Address, shipMethod ShippingMethod, payMethod PaymentMethod, lines []Line, tax, effectiveShipping int64, discountCode string, discountAmount int64, channel string, at time.Time) (*Order, error) {
-	if len(lines) == 0 {
-		return nil, ErrCartEmpty
-	}
 	o := &Order{}
 	o.raise(OrderPlaced{
 		OrderID:        id,

--- a/backend/checkout/domain/order_factory.go
+++ b/backend/checkout/domain/order_factory.go
@@ -1,0 +1,97 @@
+// OrderFactory front-loads construction-time validation for the Order
+// aggregate, separating "is this a valid order to create?" (factory's job)
+// from "the order has been placed" (the PlaceOrder command's job).
+//
+// The two-step separation matters because:
+//   - failure modes for construction are richer than 'something went wrong'
+//     (cart empty / address missing / channel unset have different remedies)
+//   - the aggregate's command methods (MarkPaid, Cancel, etc.) can assume
+//     a fully-valid aggregate without re-checking construction invariants
+//   - tests can exercise construction in isolation from event-raising
+//
+// In DDD terms: this is an Aggregate Factory (Evans 6.4).
+package domain
+
+import (
+	"errors"
+	"time"
+)
+
+// Construction-time sentinels surfaced by OrderFactory.FromCart. Each one
+// names a specific, actionable failure so the orchestrator (and the HTTP
+// handler above it) can show the customer the right remediation rather
+// than a generic "something went wrong".
+var (
+	// ErrAddressRequired is returned when the chosen shipping method
+	// requires a destination address (RequiresAddress()) but the supplied
+	// Address is the zero value.
+	ErrAddressRequired = errors.New("shipping address is required for the chosen shipping method")
+	// ErrChannelRequired is returned when the caller did not specify the
+	// sales channel ("web", "ios", "api", ...). The OrderPlaced v2 schema
+	// keeps Channel non-empty; rejecting it here prevents an empty value
+	// from leaking into the event log.
+	ErrChannelRequired = errors.New("sales channel is required")
+	// ErrPaymentMethodRequired is returned when the supplied PaymentMethod
+	// has no code (the zero value). It is a belt-and-braces guard — the
+	// HTTP handler already resolves the method via PaymentMethodByCode —
+	// but it keeps the domain self-protecting.
+	ErrPaymentMethodRequired = errors.New("payment method is required")
+)
+
+// OrderFactory builds Order aggregates from a checkout snapshot, enforcing
+// the construction invariants that the bare PlaceOrder command no longer
+// re-checks. It is currently stateless; an id generator or clock can be
+// added as fields here without disturbing call sites that already use the
+// FromCart method.
+type OrderFactory struct{}
+
+// NewOrderFactory returns a ready-to-use OrderFactory. The factory is
+// value-typed and stateless today, so callers may construct one inline
+// (`domain.OrderFactory{}.FromCart(...)`); the constructor exists so we
+// have a single place to wire dependencies if any are added later.
+func NewOrderFactory() OrderFactory { return OrderFactory{} }
+
+// FromCart validates the construction-time invariants of an Order and
+// delegates the actual event-raising to PlaceOrder. The Quote carries the
+// already-computed Tax / ShippingCost / DiscountAmount — the orchestrator
+// derives those upstream via domain.PriceQuote and hands them in as a
+// single value object so this signature stays compact.
+//
+// Returns one of: ErrCartEmpty, ErrAddressRequired, ErrChannelRequired,
+// ErrPaymentMethodRequired (each named so the orchestrator can map it to
+// the appropriate remediation), or nil + the placed *Order on success.
+func (OrderFactory) FromCart(
+	id, userID, customerID string,
+	shipTo Address,
+	shipMethod ShippingMethod,
+	payMethod PaymentMethod,
+	lines []Line,
+	quote Quote,
+	discountCode string,
+	channel string,
+	at time.Time,
+) (*Order, error) {
+	if len(lines) == 0 {
+		return nil, ErrCartEmpty
+	}
+	if shipMethod.RequiresAddress() && shipTo.IsZero() {
+		return nil, ErrAddressRequired
+	}
+	if channel == "" {
+		return nil, ErrChannelRequired
+	}
+	if payMethod.Code() == "" {
+		return nil, ErrPaymentMethodRequired
+	}
+	// Construction is valid — delegate to the aggregate command. PlaceOrder
+	// no longer re-checks the empty-cart guard (that is the factory's job);
+	// it trusts the inputs and focuses on raising OrderPlaced.
+	return PlaceOrder(
+		id, userID, customerID,
+		shipTo, shipMethod, payMethod,
+		lines,
+		quote.Tax, quote.ShippingCost,
+		discountCode, quote.DiscountAmount,
+		channel, at,
+	)
+}

--- a/backend/checkout/domain/order_factory_test.go
+++ b/backend/checkout/domain/order_factory_test.go
@@ -1,0 +1,198 @@
+package domain_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/bkielbasa/go-ecommerce/backend/checkout/domain"
+)
+
+// factoryFixture builds the inputs the happy-path tests reuse. Each
+// rejection test mutates exactly one field to exercise a single guard.
+type factoryFixture struct {
+	id           string
+	userID       string
+	customerID   string
+	shipTo       domain.Address
+	shipMethod   domain.ShippingMethod
+	payMethod    domain.PaymentMethod
+	lines        []domain.Line
+	quote        domain.Quote
+	discountCode string
+	channel      string
+	at           time.Time
+}
+
+func newFactoryFixture() factoryFixture {
+	at := time.Date(2026, 5, 27, 9, 0, 0, 0, time.UTC)
+	lines := []domain.Line{
+		domain.NewLine("v1", "Mug", 2, 1500, "USD"),
+		domain.NewLine("v2", "Plate", 1, 2000, "USD"),
+	}
+	return factoryFixture{
+		id:         "ord-1",
+		userID:     "cart-1",
+		customerID: "jane@example.com",
+		shipTo: domain.RebuildAddress(
+			"Jane", "1 Main St", "", "PDX", "97201", "USA",
+		),
+		shipMethod: domain.RebuildShippingMethod("courier", "Courier", 1500),
+		payMethod:  domain.RebuildPaymentMethod("card", "Credit / debit card"),
+		lines:      lines,
+		// subtotal 5000, no discount, no tax, courier shipping 1500.
+		quote: domain.Quote{
+			Subtotal:     5000,
+			Tax:          0,
+			ShippingCost: 1500,
+			Total:        6500,
+		},
+		channel: "web",
+		at:      at,
+	}
+}
+
+func (f factoryFixture) call() (*domain.Order, error) {
+	return domain.NewOrderFactory().FromCart(
+		f.id, f.userID, f.customerID,
+		f.shipTo, f.shipMethod, f.payMethod,
+		f.lines, f.quote, f.discountCode, f.channel, f.at,
+	)
+}
+
+func TestOrderFactory_FromCart_RejectsEmptyCart(t *testing.T) {
+	f := newFactoryFixture()
+	f.lines = nil
+
+	_, err := f.call()
+	if !errors.Is(err, domain.ErrCartEmpty) {
+		t.Fatalf("err = %v, want ErrCartEmpty", err)
+	}
+}
+
+func TestOrderFactory_FromCart_RejectsMissingAddressForDeliveryMethod(t *testing.T) {
+	f := newFactoryFixture()
+	// courier requires an address; zero it out.
+	f.shipTo = domain.Address{}
+
+	_, err := f.call()
+	if !errors.Is(err, domain.ErrAddressRequired) {
+		t.Fatalf("err = %v, want ErrAddressRequired", err)
+	}
+}
+
+// Pickup-style methods do NOT require an address; the same call with a
+// zero Address must succeed when the method is "pickup".
+func TestOrderFactory_FromCart_PickupAllowsZeroAddress(t *testing.T) {
+	f := newFactoryFixture()
+	f.shipMethod = domain.RebuildShippingMethod("pickup", "Personal pickup", 0)
+	f.shipTo = domain.Address{}
+	// Pickup is free — the quote's shipping is 0 to match.
+	f.quote = domain.Quote{Subtotal: 5000, ShippingCost: 0, Total: 5000}
+
+	if _, err := f.call(); err != nil {
+		t.Fatalf("FromCart with pickup + zero address: err = %v", err)
+	}
+}
+
+func TestOrderFactory_FromCart_RejectsMissingChannel(t *testing.T) {
+	f := newFactoryFixture()
+	f.channel = ""
+
+	_, err := f.call()
+	if !errors.Is(err, domain.ErrChannelRequired) {
+		t.Fatalf("err = %v, want ErrChannelRequired", err)
+	}
+}
+
+func TestOrderFactory_FromCart_RejectsMissingPaymentMethod(t *testing.T) {
+	f := newFactoryFixture()
+	f.payMethod = domain.PaymentMethod{}
+
+	_, err := f.call()
+	if !errors.Is(err, domain.ErrPaymentMethodRequired) {
+		t.Fatalf("err = %v, want ErrPaymentMethodRequired", err)
+	}
+}
+
+// Happy path: the resulting order is in StatusPending with exactly one
+// pending event (OrderPlaced) and the quote's tax/shipping/discount are
+// stamped onto the aggregate.
+func TestOrderFactory_FromCart_HappyPath_PlacesPendingOrder(t *testing.T) {
+	f := newFactoryFixture()
+	// Quote with a real discount + tax so we can read each number back.
+	// subtotal 5000, 10% promo discount = 500 → discounted subtotal 4500,
+	// 8.875% tax on 4500 ≈ 399, courier shipping 1500, total 6399.
+	f.discountCode = "SAVE10"
+	f.quote = domain.Quote{
+		Subtotal:       5000,
+		DiscountAmount: 500,
+		Tax:            399,
+		ShippingCost:   1500,
+		Total:          6399,
+	}
+
+	o, err := f.call()
+	if err != nil {
+		t.Fatalf("FromCart: %v", err)
+	}
+	if o.Status() != domain.StatusPending {
+		t.Errorf("status = %q, want pending", o.Status())
+	}
+	pending := o.PendingEvents()
+	if len(pending) != 1 {
+		t.Fatalf("pending = %d, want 1", len(pending))
+	}
+	if _, ok := pending[0].(domain.OrderPlaced); !ok {
+		t.Errorf("pending[0] = %T, want OrderPlaced", pending[0])
+	}
+	if o.DiscountCode() != "SAVE10" || o.DiscountAmount() != 500 {
+		t.Errorf("discount mismatch: code=%q amount=%d, want SAVE10/500",
+			o.DiscountCode(), o.DiscountAmount())
+	}
+	if o.TaxAmount() != 399 {
+		t.Errorf("tax = %d, want 399", o.TaxAmount())
+	}
+	if o.ShippingCost() != 1500 {
+		t.Errorf("shipping = %d, want 1500", o.ShippingCost())
+	}
+	// total = subtotal - discount + tax + effectiveShipping = 5000 - 500 + 399 + 1500 = 6399.
+	if o.TotalAmount() != 6399 {
+		t.Errorf("total = %d, want 6399", o.TotalAmount())
+	}
+	if o.Channel() != "web" {
+		t.Errorf("channel = %q, want web", o.Channel())
+	}
+}
+
+// A Quote that already encodes free shipping (Tax=0, ShippingCost=0)
+// must flow through to the aggregate unchanged — the factory does not
+// second-guess the pricing service.
+func TestOrderFactory_FromCart_FreeShippingQuote_StampsZeros(t *testing.T) {
+	f := newFactoryFixture()
+	// Pickup-style happy path: zero shipping, zero tax.
+	f.shipMethod = domain.RebuildShippingMethod("pickup", "Personal pickup", 0)
+	f.shipTo = domain.Address{}
+	f.quote = domain.Quote{
+		Subtotal:     5000,
+		Tax:          0,
+		ShippingCost: 0,
+		Total:        5000,
+		FreeShipping: true,
+	}
+
+	o, err := f.call()
+	if err != nil {
+		t.Fatalf("FromCart: %v", err)
+	}
+	if o.TaxAmount() != 0 {
+		t.Errorf("tax = %d, want 0", o.TaxAmount())
+	}
+	if o.ShippingCost() != 0 {
+		t.Errorf("shipping = %d, want 0 (free)", o.ShippingCost())
+	}
+	// total = subtotal - discount(0) + tax(0) + shipping(0) = 5000.
+	if o.TotalAmount() != 5000 {
+		t.Errorf("total = %d, want 5000", o.TotalAmount())
+	}
+}

--- a/backend/checkout/domain/place_test.go
+++ b/backend/checkout/domain/place_test.go
@@ -1,22 +1,16 @@
 package domain_test
 
 import (
-	"errors"
 	"testing"
 	"time"
 
 	"github.com/bkielbasa/go-ecommerce/backend/checkout/domain"
 )
 
-func TestPlaceOrder_EmptyCartRejected(t *testing.T) {
-	_, err := domain.PlaceOrder("ord-1", "cart-1", "", domain.Address{},
-		domain.RebuildShippingMethod("pickup", "Personal pickup", 0),
-		domain.RebuildPaymentMethod("cod", "Cash on delivery"),
-		nil, 0, 0, "", 0, "web", time.Now())
-	if !errors.Is(err, domain.ErrCartEmpty) {
-		t.Errorf("err = %v, want ErrCartEmpty", err)
-	}
-}
+// TestPlaceOrder_EmptyCartRejected used to live here. The empty-cart
+// guard moved out of PlaceOrder (the aggregate command) into
+// OrderFactory.FromCart (the construction step); the corresponding
+// assertion lives in order_factory_test.go.
 
 func TestPlaceOrder_EmitsPendingOrderPlaced(t *testing.T) {
 	at := time.Date(2026, 5, 27, 9, 0, 0, 0, time.UTC)

--- a/backend/layout/http_checkout.go
+++ b/backend/layout/http_checkout.go
@@ -152,6 +152,30 @@ func (handler httpHandler) PlaceOrder(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, "/cart", http.StatusSeeOther)
 		return
 	}
+	// The HTTP form already validates address / payment-method shape via
+	// domain.NewAddress / PaymentMethodByCode above, but the Aggregate
+	// Factory re-checks them as a belt-and-braces guard so a malformed
+	// caller (an alternate entry point, a future API) cannot smuggle an
+	// invalid Order into the event log. Map the sentinels to user-facing
+	// remediations rather than a generic 500.
+	if errors.Is(err, checkoutDomain.ErrAddressRequired) {
+		handler.flash(w, r, "please provide a shipping address for the chosen shipping method", "error")
+		http.Redirect(w, r, "/checkout", http.StatusSeeOther)
+		return
+	}
+	if errors.Is(err, checkoutDomain.ErrPaymentMethodRequired) {
+		handler.flash(w, r, "please choose a payment method", "error")
+		http.Redirect(w, r, "/checkout", http.StatusSeeOther)
+		return
+	}
+	if errors.Is(err, checkoutDomain.ErrChannelRequired) {
+		// The web flow always sets channel="web"; reaching this branch
+		// would indicate a programmer error. Render a generic message
+		// and send the customer back to the form rather than 500.
+		handler.flash(w, r, "could not place the order; please try again", "error")
+		http.Redirect(w, r, "/checkout", http.StatusSeeOther)
+		return
+	}
 	if errors.Is(err, pcdomain.ErrInsufficientStock) {
 		handler.flash(w, r, "Sorry — an item in your cart just went out of stock. Please review your cart.", "error")
 		http.Redirect(w, r, "/cart", http.StatusSeeOther)


### PR DESCRIPTION
## Summary
- Adds `checkout/domain/order_factory.go` — `OrderFactory.FromCart(...)` front-loads construction-time validation (empty cart, missing address for shipping methods that require one, missing channel, missing payment method) with dedicated sentinel errors.
- `PlaceOrder` shrinks to the aggregate command (raise `OrderPlaced`, advance to `StatusPending`); empty-cart guard moved to the factory.
- `checkout/app/checkout.go::Place` now calls `domain.NewOrderFactory().FromCart(...)` passing the `Quote` directly.
- New tests in `checkout/domain/order_factory_test.go` cover each rejection + happy paths.
- HTTP handler maps the new sentinels to user-facing flashes.

Aggregate Factory (Evans 6.4): separates "is this a valid order to create?" from "the order has been placed."

## Test plan
- [ ] CI green
- [ ] Place a valid order — succeeds
- [ ] Submit empty cart / missing address — appropriate flashes