### PR TITLE
feat(repricing): bulk reprice Process Manager with HTMX progress

### DIFF
--- a/backend/cmd/web/main.go
+++ b/backend/cmd/web/main.go
@@ -34,7 +34,10 @@ import (
 	"github.com/bkielbasa/go-ecommerce/backend/layout"
 	"github.com/bkielbasa/go-ecommerce/backend/payments"
 	"github.com/bkielbasa/go-ecommerce/backend/productcatalog"
+	pcapp "github.com/bkielbasa/go-ecommerce/backend/productcatalog/app"
+	pcdomain "github.com/bkielbasa/go-ecommerce/backend/productcatalog/domain"
 	"github.com/bkielbasa/go-ecommerce/backend/promo"
+	"github.com/bkielbasa/go-ecommerce/backend/repricing"
 	"github.com/bkielbasa/go-ecommerce/backend/reviews"
 	"github.com/bkielbasa/go-ecommerce/backend/search"
 	"github.com/bkielbasa/go-ecommerce/backend/shippinginfo"
@@ -209,6 +212,20 @@ func main() {
 	// switcher); no other context depends on it.
 	storeBD, storeSrv := store.New(db)
 
+	// Repricing Process Manager: owns the bulk "reprice every
+	// product in a category by N%" saga. It depends on the
+	// catalogue through two narrow ports: CategoryReader (to
+	// snapshot the planned product ids at Start time) and
+	// PriceUpdater (to apply the per-item update during
+	// RunActive). The ACLs live here in the composition root so
+	// the repricing context never imports productcatalog/app
+	// directly.
+	repricingBD, repricingSrv := repricing.New(db,
+		repricingCategoryReaderAdapter{catalog: catalogService},
+		repricingPriceUpdaterAdapter{catalog: catalogService},
+	)
+	repricingSrv = repricingSrv.WithLogger(logger)
+
 	// Mailer is the outbound-email abstraction. When SMTP_HOST is empty
 	// (the dev default), New() returns a LogMailer that writes each email
 	// to the structured log instead of dialling — keeping the app bootable
@@ -366,7 +383,7 @@ func main() {
 	// remain stored and charged in DefaultCurrency (USD).
 	fxRates := fx.New(cfg.DefaultCurrency, cfg.SupportedCurrencies, cfg.FXRates, logger)
 
-	app.AddBoundedContext(layout.New(logger, cartSrv, catalogService, authService, adminAuthService, checkoutSrv, checkoutQry, fulfillmentSrv, shipSrv, reviewsSrv, wishlistSrv, promoSrv, searchSrv, storeSrv, imgStore, cfg.UploadsDir, []byte(cfg.SessionSecret), cfg.CookieSecure, cfg.CSRFEnabled, mailerSrv, cfg.BaseURL, fxRates, cfg.StripeWebhookSecret, paymentsSrv))
+	app.AddBoundedContext(layout.New(logger, cartSrv, catalogService, authService, adminAuthService, checkoutSrv, checkoutQry, fulfillmentSrv, repricingSrv, shipSrv, reviewsSrv, wishlistSrv, promoSrv, searchSrv, storeSrv, imgStore, cfg.UploadsDir, []byte(cfg.SessionSecret), cfg.CookieSecure, cfg.CSRFEnabled, mailerSrv, cfg.BaseURL, fxRates, cfg.StripeWebhookSecret, paymentsSrv))
 	// StoreMiddleware resolves the active store per request and binds
 	// it on the request context. It MUST run before the CSRF middleware
 	// so the store is available to every handler/template — including
@@ -386,6 +403,7 @@ func main() {
 	app.AddBoundedContext(searchBD)
 	app.AddBoundedContext(storeBD)
 	app.AddBoundedContext(paymentsBD)
+	app.AddBoundedContext(repricingBD)
 
 	// Reservation TTL sweeper: releases stock held by pending orders whose
 	// confirmation never arrived (process crash, abandoned cart after stock
@@ -542,4 +560,69 @@ func newLogger(lvl logrus.Level, appName string) logrus.FieldLogger {
 	}
 
 	return instance.WithField("service.name", appName)
+}
+
+// repricingCategoryReaderAdapter bridges the productcatalog query
+// surface (ProductService.List + ProductQuery{CategorySlug}) onto
+// the repricing context's CategoryReader port. The repricing
+// context never imports productcatalog directly — the ACL lives
+// here in the composition root so swapping the catalogue out (or
+// growing a richer "give me product ids for category" surface)
+// touches one place.
+type repricingCategoryReaderAdapter struct {
+	catalog interface {
+		List(ctx context.Context, q pcapp.ProductQuery) ([]pcdomain.Product, error)
+	}
+}
+
+func (a repricingCategoryReaderAdapter) ProductsInCategory(ctx context.Context, categorySlug string) ([]string, error) {
+	products, err := a.catalog.List(ctx, pcapp.ProductQuery{CategorySlug: categorySlug})
+	if err != nil {
+		return nil, err
+	}
+	ids := make([]string, 0, len(products))
+	for _, p := range products {
+		ids = append(ids, string(p.ID()))
+	}
+	return ids, nil
+}
+
+// repricingPriceUpdaterAdapter bridges the productcatalog mutation
+// surface onto the repricing context's PriceUpdater port.
+// productcatalog/app.ProductService.UpdateProduct rewrites every
+// field on the product row, so this adapter first loads the
+// product to preserve name / description / thumbnail / currency
+// verbatim, then re-issues UpdateProduct with the new price.
+// CurrentPriceMinor reads the same product's base price in minor
+// units so the saga can compute the new amount before calling
+// back.
+type repricingPriceUpdaterAdapter struct {
+	catalog interface {
+		Find(ctx context.Context, id string) (pcdomain.Product, error)
+		UpdateProduct(ctx context.Context, id, name, desc string, priceMinorUnits int64, currency, thumbnail string) error
+	}
+}
+
+func (a repricingPriceUpdaterAdapter) CurrentPriceMinor(ctx context.Context, productID string) (int64, error) {
+	p, err := a.catalog.Find(ctx, productID)
+	if err != nil {
+		return 0, err
+	}
+	return p.Price().Amount(), nil
+}
+
+func (a repricingPriceUpdaterAdapter) UpdateProductPrice(ctx context.Context, productID string, newAmountMinor int64) error {
+	p, err := a.catalog.Find(ctx, productID)
+	if err != nil {
+		return err
+	}
+	return a.catalog.UpdateProduct(
+		ctx,
+		string(p.ID()),
+		p.Name(),
+		p.Description(),
+		newAmountMinor,
+		p.Price().Currency().String(),
+		p.Thumbnail(),
+	)
 }

--- a/backend/integration/orderpaid_test.go
+++ b/backend/integration/orderpaid_test.go
@@ -22,7 +22,6 @@ import (
 	cartadapter "github.com/bkielbasa/go-ecommerce/backend/cart/adapter"
 	cartapp "github.com/bkielbasa/go-ecommerce/backend/cart/app"
 	cartdomain "github.com/bkielbasa/go-ecommerce/backend/cart/domain"
-	checkoutadapter "github.com/bkielbasa/go-ecommerce/backend/checkout/adapter"
 	checkoutapp "github.com/bkielbasa/go-ecommerce/backend/checkout/app"
 	checkoutdomain "github.com/bkielbasa/go-ecommerce/backend/checkout/domain"
 	checkoutintegration "github.com/bkielbasa/go-ecommerce/backend/checkout/integration"
@@ -373,7 +372,7 @@ func newIntegrationFixture(t *testing.T) *integrationFixture {
 	checkoutSrv := checkoutapp.NewCheckoutService(
 		cartSrv,
 		orderStore,
-		checkoutadapter.NewFakePayment(),
+		okPayment{},
 		pcSrv, // StockReserver / Release
 		nil,   // StockMovements (no audit log in tests)
 		newDeterministicIDGen(),
@@ -416,6 +415,14 @@ func newIntegrationFixture(t *testing.T) *integrationFixture {
 // of order ids ("ord-1", "ord-2", ...) so a test can assert on the exact id
 // the checkout flow produced. Independent of crypto/rand and time, which
 // would make per-run id assertions brittle.
+// okPayment is a no-op PaymentProcessor for cross-context tests. The real
+// FakePayment adapter was removed when checkout was wired to the payments
+// context (PR #124); these tests only care about the OrderPaid wiring, not
+// the charge flow itself.
+type okPayment struct{}
+
+func (okPayment) Charge(_ context.Context, _ int64, _, _ string) error { return nil }
+
 func newDeterministicIDGen() func() string {
 	var n int
 	var mu sync.Mutex

--- a/backend/layout/bounded_context.go
+++ b/backend/layout/bounded_context.go
@@ -18,6 +18,7 @@ import (
 	pcapp "github.com/bkielbasa/go-ecommerce/backend/productcatalog/app"
 	pcdomain "github.com/bkielbasa/go-ecommerce/backend/productcatalog/domain"
 	promodomain "github.com/bkielbasa/go-ecommerce/backend/promo/domain"
+	repricingDomain "github.com/bkielbasa/go-ecommerce/backend/repricing/domain"
 	reviewsDomain "github.com/bkielbasa/go-ecommerce/backend/reviews/domain"
 	searchapp "github.com/bkielbasa/go-ecommerce/backend/search/app"
 	shipDomain "github.com/bkielbasa/go-ecommerce/backend/shippinginfo/domain"
@@ -136,6 +137,19 @@ type fulfillmentService interface {
 	ByOrder(ctx context.Context, orderID string) (fulfillmentDomain.Fulfillment, error)
 }
 
+// repricingService is the narrow seam onto the repricing (bulk
+// reprice) Process Manager. The admin pages drive Start (form
+// submission), Active (header banner) and ListAll + ByID (list +
+// detail view). The service spawns the saga in a background
+// goroutine; the admin detail page polls ByID via HTMX to render
+// the progress bar.
+type repricingService interface {
+	Start(ctx context.Context, categorySlug string, percentChange float64) (string, error)
+	Active(ctx context.Context) (repricingDomain.Reprice, bool, error)
+	ByID(ctx context.Context, id string) (repricingDomain.Reprice, error)
+	ListAll(ctx context.Context) ([]repricingDomain.Reprice, error)
+}
+
 // promoService is the narrow seam the layout package needs from the
 // promo bounded context. Resolve runs the live validity / per-customer
 // checks for the checkout form; the CRUD methods power the admin pages.
@@ -224,7 +238,7 @@ type checkoutQueries interface {
 // POST /webhooks/payments endpoint. Pass an empty secret OR a nil
 // service to skip the registration entirely — tests that don't care
 // about webhooks then don't need to provide either.
-func New(logger logrus.FieldLogger, cartSrv cartService, catalogSrv catalogService, authSrv authService, adminAuthSrv adminAuthService, checkoutSrv checkoutCommands, checkoutQry checkoutQueries, fulfillmentSrv fulfillmentService, shipSrv shippingService, reviewsSrv reviewsService, wishlistSrv wishlistService, promoSrv promoService, searchSrv searchService, storeSrv storeService, imageStore imagestore.Store, uploadsDir string, sessionSecret []byte, cookieSecure, csrfEnabled bool, mailerSrv mailer.Mailer, baseURL string, rates fx.Rates, paymentsWebhookSecret string, paymentsWebhookSrv paymentsWebhookService) application.BoundedContext {
+func New(logger logrus.FieldLogger, cartSrv cartService, catalogSrv catalogService, authSrv authService, adminAuthSrv adminAuthService, checkoutSrv checkoutCommands, checkoutQry checkoutQueries, fulfillmentSrv fulfillmentService, repricingSrv repricingService, shipSrv shippingService, reviewsSrv reviewsService, wishlistSrv wishlistService, promoSrv promoService, searchSrv searchService, storeSrv storeService, imageStore imagestore.Store, uploadsDir string, sessionSecret []byte, cookieSecure, csrfEnabled bool, mailerSrv mailer.Mailer, baseURL string, rates fx.Rates, paymentsWebhookSecret string, paymentsWebhookSrv paymentsWebhookService) application.BoundedContext {
 	store = newCookieStore(sessionSecret, cookieSecure)
 	setCSRFEnabled(csrfEnabled)
 	return &boundedContext{
@@ -236,6 +250,7 @@ func New(logger logrus.FieldLogger, cartSrv cartService, catalogSrv catalogServi
 			checkoutSrv:    checkoutSrv,
 			checkoutQry:    checkoutQry,
 			fulfillmentSrv: fulfillmentSrv,
+			repricingSrv:   repricingSrv,
 			shipSrv:        shipSrv,
 			reviewsSrv:     reviewsSrv,
 			wishlistSrv:    wishlistSrv,

--- a/backend/layout/http.go
+++ b/backend/layout/http.go
@@ -48,6 +48,7 @@ type httpHandler struct {
 	checkoutSrv    checkoutCommands
 	checkoutQry    checkoutQueries
 	fulfillmentSrv fulfillmentService
+	repricingSrv   repricingService
 	shipSrv        shippingService
 	reviewsSrv     reviewsService
 	wishlistSrv    wishlistService
@@ -279,6 +280,12 @@ func (m boundedContext) MuxRegister(r *mux.Router) {
 	r.HandleFunc("/admin/stores/{id}/edit", observability.HTTPWrap(m.handler.AdminEditStoreForm, m.logger)).Methods("GET")
 	r.HandleFunc("/admin/stores/{id}/delete", observability.HTTPWrap(m.handler.AdminDeleteStore, m.logger)).Methods("POST")
 	r.HandleFunc("/admin/stores/{id}", observability.HTTPWrap(m.handler.AdminUpdateStore, m.logger)).Methods("POST")
+
+	// Repricing admin: list + start form on /admin/repricing; the
+	// /{id} detail page polls itself via HTMX while the saga runs.
+	r.HandleFunc("/admin/repricing", observability.HTTPWrap(m.handler.AdminRepricing, m.logger)).Methods("GET")
+	r.HandleFunc("/admin/repricing", observability.HTTPWrap(m.handler.AdminStartRepricing, m.logger)).Methods("POST")
+	r.HandleFunc("/admin/repricing/{id}", observability.HTTPWrap(m.handler.AdminRepricingDetail, m.logger)).Methods("GET")
 }
 
 func (handler httpHandler) renderTemplate(w http.ResponseWriter, r *http.Request, templateName string, data map[string]any) {

--- a/backend/layout/http_admin_repricing.go
+++ b/backend/layout/http_admin_repricing.go
@@ -1,0 +1,154 @@
+package layout
+
+import (
+	"errors"
+	"html/template"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/bkielbasa/go-ecommerce/backend/internal/https"
+	"github.com/gorilla/mux"
+
+	repricingapp "github.com/bkielbasa/go-ecommerce/backend/repricing/app"
+	repricingdomain "github.com/bkielbasa/go-ecommerce/backend/repricing/domain"
+)
+
+// AdminRepricing renders the bulk-reprice list page. It shows the
+// currently-active reprice (if any), the past reprices table, and
+// a form to start a new one. Admin-gated like every other /admin
+// route.
+func (handler httpHandler) AdminRepricing(w http.ResponseWriter, r *http.Request) {
+	email, ok := handler.requireAdmin(w, r)
+	if !ok {
+		return
+	}
+	if handler.repricingSrv == nil {
+		handler.flash(w, r, "repricing service not wired", "error")
+		http.Redirect(w, r, "/admin", http.StatusSeeOther)
+		return
+	}
+	rows, err := handler.repricingSrv.ListAll(r.Context())
+	if err != nil {
+		handler.flash(w, r, err.Error(), "error")
+		rows = nil
+	}
+	active, hasActive, err := handler.repricingSrv.Active(r.Context())
+	if err != nil {
+		handler.flash(w, r, err.Error(), "error")
+	}
+	categories, err := handler.catalogSrv.Categories(r.Context())
+	if err != nil {
+		handler.logger.WithError(err).Warn("cannot load categories for repricing form")
+		categories = nil
+	}
+	handler.renderAdminTemplate(w, r, "admin/repricing", map[string]any{
+		"Active":     "repricing",
+		"Email":      email,
+		"Reprices":   rows,
+		"HasActive":  hasActive,
+		"ActiveRow":  active,
+		"Categories": categories,
+	})
+}
+
+// AdminStartRepricing handles the start-reprice form submission. It
+// reads the category slug + percent change, calls Service.Start and
+// redirects to the detail page so the admin can watch the progress
+// bar tick.
+func (handler httpHandler) AdminStartRepricing(w http.ResponseWriter, r *http.Request) {
+	if _, ok := handler.requireAdmin(w, r); !ok {
+		return
+	}
+	if handler.repricingSrv == nil {
+		http.Redirect(w, r, "/admin/repricing", http.StatusSeeOther)
+		return
+	}
+	if err := r.ParseForm(); err != nil {
+		https.InternalError(w, "internal-error", err.Error())
+		return
+	}
+	category := strings.TrimSpace(r.FormValue("category"))
+	percent, perr := strconv.ParseFloat(strings.TrimSpace(r.FormValue("percent")), 64)
+	if perr != nil {
+		handler.flash(w, r, "Invalid percent value: "+perr.Error(), "error")
+		http.Redirect(w, r, "/admin/repricing", http.StatusSeeOther)
+		return
+	}
+
+	id, err := handler.repricingSrv.Start(r.Context(), category, percent)
+	if err != nil {
+		switch {
+		case errors.Is(err, repricingapp.ErrAlreadyActive):
+			handler.flash(w, r, "A reprice is already in progress; wait for it to finish.", "error")
+		case errors.Is(err, repricingdomain.ErrInvalidReprice):
+			handler.flash(w, r, "Invalid reprice: "+err.Error(), "error")
+		default:
+			handler.flash(w, r, err.Error(), "error")
+		}
+		http.Redirect(w, r, "/admin/repricing", http.StatusSeeOther)
+		return
+	}
+	handler.flash(w, r, "Repricing started", "info")
+	http.Redirect(w, r, "/admin/repricing/"+id, http.StatusSeeOther)
+}
+
+// AdminRepricingDetail renders the per-reprice detail page. On a
+// normal GET it returns the full admin shell; when the request
+// carries the HX-Request header (HTMX poll) it returns just the
+// progress fragment so the page can refresh itself every couple of
+// seconds without re-emitting the surrounding chrome.
+func (handler httpHandler) AdminRepricingDetail(w http.ResponseWriter, r *http.Request) {
+	email, ok := handler.requireAdmin(w, r)
+	if !ok {
+		return
+	}
+	if handler.repricingSrv == nil {
+		http.Redirect(w, r, "/admin/repricing", http.StatusSeeOther)
+		return
+	}
+	id := mux.Vars(r)["id"]
+	row, err := handler.repricingSrv.ByID(r.Context(), id)
+	if errors.Is(err, repricingapp.ErrNotFound) {
+		handler.flash(w, r, "Reprice not found", "error")
+		http.Redirect(w, r, "/admin/repricing", http.StatusSeeOther)
+		return
+	}
+	if err != nil {
+		https.InternalError(w, "internal-error", err.Error())
+		return
+	}
+
+	data := map[string]any{
+		"Active":   "repricing",
+		"Email":    email,
+		"Reprice":  row,
+		"Percent":  int(row.ProgressFraction() * 100),
+		"Done":     row.Status() == repricingdomain.StatusCompleted || row.Status() == repricingdomain.StatusFailed,
+		"InFlight": row.Status() == repricingdomain.StatusInProgress || row.Status() == repricingdomain.StatusScheduled,
+	}
+
+	if r.Header.Get("HX-Request") != "" {
+		handler.renderRepricingProgressFragment(w, data)
+		return
+	}
+	handler.renderAdminTemplate(w, r, "admin/repricing_detail", data)
+}
+
+// renderRepricingProgressFragment writes the progress block only,
+// for HTMX polling. The fragment is parsed from the same template
+// file as the full detail page (so a single source of truth defines
+// both the embedded view and the polled fragment) but only the
+// {{define "progress-block"}} chunk is executed.
+func (handler httpHandler) renderRepricingProgressFragment(w http.ResponseWriter, data map[string]any) {
+	ts, err := template.New("").ParseFiles("./layout/tmpl/admin/repricing_detail.gohtml")
+	if err != nil {
+		handler.logger.WithError(err).Error("cannot parse repricing fragment template")
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+	if err := ts.ExecuteTemplate(w, "progress-block", data); err != nil {
+		handler.logger.WithError(err).Error("cannot execute repricing progress fragment")
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+	}
+}

--- a/backend/layout/tmpl/admin/repricing.gohtml
+++ b/backend/layout/tmpl/admin/repricing.gohtml
@@ -1,0 +1,73 @@
+{{define "main"}}
+  <h2 class="account-card__title">bulk repricing</h2>
+  <p class="muted">Apply a percentage price change to every product in a category. The operation is a state-stored saga — the page shows live progress and the run survives a process restart (resumes from the last processed item).</p>
+
+  {{if .HasActive}}
+    <section class="admin-form">
+      <h3 class="account-card__title">a reprice is in progress</h3>
+      <p>
+        Category <code>{{.ActiveRow.CategoryID}}</code> · {{.ActiveRow.PercentChange}}% ·
+        {{.ActiveRow.ProcessedItems}} / {{.ActiveRow.TotalItems}} items
+      </p>
+      <p><a href="/admin/repricing/{{.ActiveRow.ID}}">view progress &rarr;</a></p>
+    </section>
+  {{end}}
+
+  {{if .Reprices}}
+    <table class="admin-table">
+      <thead>
+        <tr>
+          <th>id</th>
+          <th>category</th>
+          <th>percent</th>
+          <th>status</th>
+          <th>progress</th>
+          <th>started</th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody>
+        {{range $r := .Reprices}}
+          <tr>
+            <td><code>{{$r.ID}}</code></td>
+            <td>{{$r.CategoryID}}</td>
+            <td>{{$r.PercentChange}}%</td>
+            <td>{{$r.Status}}</td>
+            <td>{{$r.ProcessedItems}} / {{$r.TotalItems}}</td>
+            <td>{{$r.StartedAt.Format "2006-01-02 15:04"}}</td>
+            <td class="admin-table__actions">
+              <a href="/admin/repricing/{{$r.ID}}">view</a>
+            </td>
+          </tr>
+        {{end}}
+      </tbody>
+    </table>
+  {{else}}
+    <p class="muted">no reprices yet.</p>
+  {{end}}
+
+  {{if not .HasActive}}
+    <section class="admin-form">
+      <h3 class="account-card__title">start a reprice</h3>
+      <form class="form" method="post" action="/admin/repricing">
+        <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
+        <div class="field">
+          <label for="r-cat">category</label>
+          <select id="r-cat" name="category" required>
+            {{range .Categories}}
+              <option value="{{.Slug}}">{{.Name}} ({{.Slug}})</option>
+            {{end}}
+          </select>
+        </div>
+        <div class="field">
+          <label for="r-pct">percent change (e.g. -10 = drop prices by 10%, +5 = raise by 5%)</label>
+          <input id="r-pct" name="percent" type="number" step="0.1" min="-50" max="50" value="0" required>
+        </div>
+        <button type="submit" class="btn"
+                onclick="return confirm('This will update every product in the selected category. Continue?');">
+          start reprice
+        </button>
+      </form>
+    </section>
+  {{end}}
+{{end}}

--- a/backend/layout/tmpl/admin/repricing_detail.gohtml
+++ b/backend/layout/tmpl/admin/repricing_detail.gohtml
@@ -1,0 +1,51 @@
+{{define "main"}}
+  <h2 class="account-card__title">repricing {{.Reprice.ID}}</h2>
+  <p>
+    <a href="/admin/repricing">&larr; back to list</a>
+  </p>
+
+  <dl class="admin-form">
+    <dt>category</dt><dd><code>{{.Reprice.CategoryID}}</code></dd>
+    <dt>percent change</dt><dd>{{.Reprice.PercentChange}}%</dd>
+    <dt>started at</dt><dd>{{.Reprice.StartedAt.Format "2006-01-02 15:04:05"}}</dd>
+    {{with .Reprice.CompletedAt}}<dt>completed at</dt><dd>{{.Format "2006-01-02 15:04:05"}}</dd>{{end}}
+  </dl>
+
+  <div id="repricing-progress"
+    {{if .InFlight}}
+      hx-get="/admin/repricing/{{.Reprice.ID}}"
+      hx-trigger="every 2s"
+      hx-swap="outerHTML"
+    {{end}}
+  >
+    {{template "progress-block" .}}
+  </div>
+{{end}}
+
+{{define "progress-block"}}
+<div id="repricing-progress"
+  {{if .InFlight}}
+    hx-get="/admin/repricing/{{.Reprice.ID}}"
+    hx-trigger="every 2s"
+    hx-swap="outerHTML"
+  {{end}}
+>
+  <section class="admin-form">
+    <h3 class="account-card__title">progress</h3>
+    <p>
+      <strong>{{.Reprice.Status}}</strong> &middot;
+      {{.Reprice.ProcessedItems}} / {{.Reprice.TotalItems}} items
+      ({{.Percent}}%)
+    </p>
+    <div style="background: #eee; border-radius: 4px; overflow: hidden; height: 12px;">
+      <div style="background: #2b8a3e; height: 12px; width: {{.Percent}}%;"></div>
+    </div>
+    {{with .Reprice.LastError}}
+      <p class="flash flash--error">last per-item error: {{.}}</p>
+    {{end}}
+    {{if .Done}}
+      <p class="muted">run finished &mdash; this page will stop polling.</p>
+    {{end}}
+  </section>
+</div>
+{{end}}

--- a/backend/layout/tmpl/partials/admin-nav.gohtml
+++ b/backend/layout/tmpl/partials/admin-nav.gohtml
@@ -10,6 +10,7 @@
   <a href="/admin/reviews" class="admin-nav__link {{if eq .Active "reviews"}}is-active{{end}}">reviews</a>
   <a href="/admin/promo-codes" class="admin-nav__link {{if eq .Active "promo-codes"}}is-active{{end}}">promo codes</a>
   <a href="/admin/stores" class="admin-nav__link {{if eq .Active "stores"}}is-active{{end}}">stores</a>
+  <a href="/admin/repricing" class="admin-nav__link {{if eq .Active "repricing"}}is-active{{end}}">repricing</a>
   <span class="admin-nav__rule"></span>
   <a href="/" class="admin-nav__link admin-nav__link--muted">back to store</a>
 </nav>

--- a/backend/repricing/adapter/inmemory.go
+++ b/backend/repricing/adapter/inmemory.go
@@ -1,0 +1,110 @@
+package adapter
+
+import (
+	"context"
+	"sort"
+	"sync"
+
+	"github.com/bkielbasa/go-ecommerce/backend/repricing/app"
+	"github.com/bkielbasa/go-ecommerce/backend/repricing/domain"
+)
+
+// InMemory is the test-friendly Storage adapter. It mirrors the
+// postgres adapter's contract: Create returns app.ErrAlreadyActive
+// when an active reprice already exists (modelling the partial
+// unique index on the production table); Update returns
+// app.ErrOptimisticLock when the expected version (Version() - 1)
+// does not match the stored row.
+type InMemory struct {
+	mu   sync.Mutex
+	rows map[string]domain.Reprice
+}
+
+// NewInMemory builds an empty in-memory store, used by service-level
+// unit tests.
+func NewInMemory() *InMemory {
+	return &InMemory{
+		rows: map[string]domain.Reprice{},
+	}
+}
+
+// Create inserts a fresh row. A second Create while an existing
+// row is scheduled / in_progress is rejected with
+// app.ErrAlreadyActive — mirroring the postgres adapter, which
+// relies on the partial unique index.
+func (m *InMemory) Create(ctx context.Context, r domain.Reprice) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if isActive(r.Status()) {
+		for _, existing := range m.rows {
+			if isActive(existing.Status()) {
+				return app.ErrAlreadyActive
+			}
+		}
+	}
+	if _, ok := m.rows[r.ID()]; ok {
+		return app.ErrAlreadyActive
+	}
+	m.rows[r.ID()] = r
+	return nil
+}
+
+// isActive returns true for the two statuses that occupy the
+// "at most one active" slot.
+func isActive(s domain.Status) bool {
+	return s == domain.StatusScheduled || s == domain.StatusInProgress
+}
+
+// Update writes a state transition under optimistic concurrency.
+// The expected version is Version() - 1.
+func (m *InMemory) Update(ctx context.Context, r domain.Reprice) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	current, ok := m.rows[r.ID()]
+	if !ok {
+		return app.ErrNotFound
+	}
+	if current.Version() != r.Version()-1 {
+		return app.ErrOptimisticLock
+	}
+	m.rows[r.ID()] = r
+	return nil
+}
+
+// Find returns the row by its id.
+func (m *InMemory) Find(ctx context.Context, id string) (domain.Reprice, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	r, ok := m.rows[id]
+	if !ok {
+		return domain.Reprice{}, app.ErrNotFound
+	}
+	return r, nil
+}
+
+// FindActive returns the at-most-one active row, ok=false when none
+// exists.
+func (m *InMemory) FindActive(ctx context.Context) (domain.Reprice, bool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, r := range m.rows {
+		if isActive(r.Status()) {
+			return r, true, nil
+		}
+	}
+	return domain.Reprice{}, false, nil
+}
+
+// ListAll returns every row, newest-started first.
+func (m *InMemory) ListAll(ctx context.Context) ([]domain.Reprice, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]domain.Reprice, 0, len(m.rows))
+	for _, r := range m.rows {
+		out = append(out, r)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].StartedAt().After(out[j].StartedAt())
+	})
+	return out, nil
+}

--- a/backend/repricing/adapter/postgres.go
+++ b/backend/repricing/adapter/postgres.go
@@ -1,0 +1,237 @@
+package adapter
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/bkielbasa/go-ecommerce/backend/repricing/app"
+	"github.com/bkielbasa/go-ecommerce/backend/repricing/domain"
+	"github.com/lib/pq"
+)
+
+// pgUniqueViolation is the SQLSTATE code postgres returns when a
+// write hits a unique-constraint conflict. We map it to
+// app.ErrAlreadyActive so callers can branch on the sentinel
+// without reaching for pq.Error themselves. The relevant constraint
+// is the partial unique index on the `status` column (see migration
+// 000039_repricing) which enforces the at-most-one-active-row
+// invariant.
+const pgUniqueViolation = "23505"
+
+// Postgres is the production Storage adapter.
+type Postgres struct {
+	db *sql.DB
+}
+
+// NewPostgres builds the production adapter bound to the supplied
+// DB connection.
+func NewPostgres(db *sql.DB) *Postgres {
+	return &Postgres{db: db}
+}
+
+// Create inserts a fresh reprice row. A unique-constraint conflict
+// (from the partial unique index on the active statuses) is
+// surfaced as app.ErrAlreadyActive — the application service uses
+// it as the belt-and-braces guard against two concurrent admins
+// clicking the button at the same time.
+func (p *Postgres) Create(ctx context.Context, r domain.Reprice) error {
+	_, err := p.db.ExecContext(ctx, `
+		INSERT INTO repricing (
+			id, category_id, percent_change, status,
+			total_items, processed_items, last_error,
+			started_at, completed_at, version
+		)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+	`,
+		r.ID(), r.CategoryID(), r.PercentChange(), string(r.Status()),
+		r.TotalItems(), r.ProcessedItems(), r.LastError(),
+		r.StartedAt(), nullableTimePtr(r.CompletedAt()), r.Version(),
+	)
+	if err != nil {
+		var pqErr *pq.Error
+		if errors.As(err, &pqErr) && string(pqErr.Code) == pgUniqueViolation {
+			return app.ErrAlreadyActive
+		}
+		return fmt.Errorf("insert reprice: %w", err)
+	}
+	return nil
+}
+
+// Update writes a state transition under optimistic concurrency.
+// The UPDATE matches both the id and the previous version; a
+// 0-rows-affected result is mapped to app.ErrOptimisticLock.
+func (p *Postgres) Update(ctx context.Context, r domain.Reprice) error {
+	res, err := p.db.ExecContext(ctx, `
+		UPDATE repricing
+		SET category_id = $2,
+		    percent_change = $3,
+		    status = $4,
+		    total_items = $5,
+		    processed_items = $6,
+		    last_error = $7,
+		    started_at = $8,
+		    completed_at = $9,
+		    version = $10
+		WHERE id = $1 AND version = $11
+	`,
+		r.ID(),
+		r.CategoryID(),
+		r.PercentChange(),
+		string(r.Status()),
+		r.TotalItems(),
+		r.ProcessedItems(),
+		r.LastError(),
+		r.StartedAt(),
+		nullableTimePtr(r.CompletedAt()),
+		r.Version(),
+		r.Version()-1,
+	)
+	if err != nil {
+		var pqErr *pq.Error
+		if errors.As(err, &pqErr) && string(pqErr.Code) == pgUniqueViolation {
+			// A status transition that would create a
+			// second active row gets caught by the partial
+			// unique index. Map it onto the same sentinel
+			// Create uses so callers do not need to branch
+			// on the verb.
+			return app.ErrAlreadyActive
+		}
+		return fmt.Errorf("update reprice: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("rows affected: %w", err)
+	}
+	if n == 0 {
+		return app.ErrOptimisticLock
+	}
+	return nil
+}
+
+// Find loads the row by id, mapping sql.ErrNoRows to
+// app.ErrNotFound.
+func (p *Postgres) Find(ctx context.Context, id string) (domain.Reprice, error) {
+	row := p.db.QueryRowContext(ctx, `
+		SELECT id, category_id, percent_change, status,
+		       total_items, processed_items, last_error,
+		       started_at, completed_at, version
+		FROM repricing
+		WHERE id = $1
+	`, id)
+	return scanOne(row)
+}
+
+// FindActive returns the at-most-one active row.
+func (p *Postgres) FindActive(ctx context.Context) (domain.Reprice, bool, error) {
+	row := p.db.QueryRowContext(ctx, `
+		SELECT id, category_id, percent_change, status,
+		       total_items, processed_items, last_error,
+		       started_at, completed_at, version
+		FROM repricing
+		WHERE status IN ('scheduled', 'in_progress')
+		ORDER BY started_at DESC
+		LIMIT 1
+	`)
+	r, err := scanOne(row)
+	if errors.Is(err, app.ErrNotFound) {
+		return domain.Reprice{}, false, nil
+	}
+	if err != nil {
+		return domain.Reprice{}, false, err
+	}
+	return r, true, nil
+}
+
+// ListAll returns every row, newest-started first.
+func (p *Postgres) ListAll(ctx context.Context) ([]domain.Reprice, error) {
+	rows, err := p.db.QueryContext(ctx, `
+		SELECT id, category_id, percent_change, status,
+		       total_items, processed_items, last_error,
+		       started_at, completed_at, version
+		FROM repricing
+		ORDER BY started_at DESC
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("list reprices: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []domain.Reprice
+	for rows.Next() {
+		r, scanErr := scanRow(rows)
+		if scanErr != nil {
+			return nil, scanErr
+		}
+		out = append(out, r)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("rows: %w", err)
+	}
+	return out, nil
+}
+
+// scanOne loads a single row (used by Find / FindActive).
+func scanOne(row *sql.Row) (domain.Reprice, error) {
+	r, err := scanRow(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return domain.Reprice{}, app.ErrNotFound
+	}
+	if err != nil {
+		return domain.Reprice{}, fmt.Errorf("scan reprice: %w", err)
+	}
+	return r, nil
+}
+
+// rowScanner is the narrow interface implemented by both *sql.Row
+// and *sql.Rows so scanRow shares the same code path.
+type rowScanner interface {
+	Scan(dest ...interface{}) error
+}
+
+func scanRow(s rowScanner) (domain.Reprice, error) {
+	var (
+		id, categoryID, status string
+		percentChange          float64
+		totalItems             int
+		processedItems         int
+		lastError              string
+		startedAt              time.Time
+		completedAt            sql.NullTime
+		version                int
+	)
+	if err := s.Scan(
+		&id, &categoryID, &percentChange, &status,
+		&totalItems, &processedItems, &lastError,
+		&startedAt, &completedAt, &version,
+	); err != nil {
+		return domain.Reprice{}, err
+	}
+	var completedPtr *time.Time
+	if completedAt.Valid {
+		t := completedAt.Time
+		completedPtr = &t
+	}
+	return domain.Rebuild(
+		id, categoryID,
+		percentChange,
+		domain.Status(status),
+		totalItems, processedItems,
+		lastError,
+		startedAt, completedPtr,
+		version,
+	), nil
+}
+
+// nullableTimePtr converts a nil/zero *time.Time into a NULL on
+// the wire so the schema's nullable completed_at column carries
+// the "not yet finished" meaning rather than a misleading epoch
+// value.
+func nullableTimePtr(t *time.Time) interface{} {
+	if t == nil || t.IsZero() {
+		return nil
+	}
+	return *t
+}

--- a/backend/repricing/app/service.go
+++ b/backend/repricing/app/service.go
@@ -1,0 +1,419 @@
+// Package app holds the repricing application service: the
+// orchestrating layer between the bulk-reprice saga, storage and the
+// product catalogue's price-update surface.
+//
+// SAGA SHAPE
+//
+//	Start  -> persist row in StatusScheduled, snapshot the planned
+//	          product ids, then kick off a background goroutine that
+//	          calls RunActive on a fresh context (Start MUST NOT block
+//	          the admin's HTTP round-trip).
+//
+//	RunActive -> if the row is StatusScheduled, transition it to
+//	             StatusInProgress; iterate the planned product ids,
+//	             for each load the current price, multiply by
+//	             (1 + percent/100), call PriceUpdater.UpdateProductPrice,
+//	             and RecordItemProcessed (or RecordItemFailed) per item.
+//	             On full pass, Complete. On ctx.Cancel mid-flight,
+//	             leave status=in_progress so a later call resumes from
+//	             processedItems.
+//
+// Resumability is achieved by snapshotting the planned product ids
+// at Start time into an in-memory plan that RunActive can re-read
+// (the snapshot lives on the *Service so a single process restart
+// loses it; a production-grade saga would persist the plan as a
+// `repricing_item` table). The trade-off is documented inline at
+// the snapshot field. Re-runs after a restart will re-load the
+// planned ids from the CategoryReader, which is acceptable when the
+// catalogue is stable between restarts (the common case for this
+// demo).
+package app
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"math"
+	"sync"
+	"time"
+
+	"github.com/bkielbasa/go-ecommerce/backend/repricing/domain"
+)
+
+// ErrNotFound is returned by Storage.Find / FindActive when no row
+// matches.
+var ErrNotFound = errors.New("repricing: not found")
+
+// ErrOptimisticLock is returned by Storage.Update when the row's
+// version does not match the expected version.
+var ErrOptimisticLock = errors.New("repricing: optimistic lock conflict")
+
+// ErrAlreadyActive is returned by Start when an existing reprice is
+// still scheduled / in_progress.
+var ErrAlreadyActive = errors.New("repricing: a reprice is already active")
+
+// Storage is the persistence port for reprice records. The adapter
+// package supplies an in-memory implementation (tests) and a
+// Postgres-backed one (production).
+type Storage interface {
+	// Create inserts a fresh reprice row. A partial unique index
+	// on the active statuses guarantees at-most-one active row in
+	// the table; a violation surfaces as ErrAlreadyActive.
+	Create(ctx context.Context, r domain.Reprice) error
+	// Update writes a state transition under optimistic
+	// concurrency; a mismatch returns ErrOptimisticLock.
+	Update(ctx context.Context, r domain.Reprice) error
+	// Find returns the row by id, ErrNotFound if missing.
+	Find(ctx context.Context, id string) (domain.Reprice, error)
+	// FindActive returns the scheduled-or-in-progress row if one
+	// exists. ok=false (and a zero Reprice) means no active row.
+	FindActive(ctx context.Context) (domain.Reprice, bool, error)
+	// ListAll returns every row, newest-started first. Used by
+	// the admin list view.
+	ListAll(ctx context.Context) ([]domain.Reprice, error)
+}
+
+// CategoryReader is the seam onto which Start snapshots the planned
+// product ids for the category. Implemented in the composition root
+// by a thin adapter over productcatalog/app.ProductService.List.
+type CategoryReader interface {
+	// ProductsInCategory returns every product id in the given
+	// category slug. An empty slug / no products returns a nil
+	// slice (Start rejects an empty plan).
+	ProductsInCategory(ctx context.Context, categorySlug string) ([]string, error)
+}
+
+// PriceUpdater is the seam onto which RunActive applies the
+// per-item price change. The saga supplies the precomputed new
+// minor-unit amount; the composition-root adapter wraps
+// productcatalog/app.ProductService.UpdateProduct (which rewrites
+// the whole product row, but the adapter copies every other field
+// verbatim — only the price changes).
+type PriceUpdater interface {
+	// CurrentPriceMinor returns the product's current base price
+	// in minor units. The saga reads it just before writing back
+	// so the percentage is applied to the live value.
+	CurrentPriceMinor(ctx context.Context, productID string) (int64, error)
+	// UpdateProductPrice replaces a product's base price with
+	// the given minor-unit amount.
+	UpdateProductPrice(ctx context.Context, productID string, newAmountMinor int64) error
+}
+
+// Service is the application facade.
+type Service struct {
+	storage  Storage
+	reader   CategoryReader
+	updater  PriceUpdater
+	logger   Logger
+	now      func() time.Time
+	newID    func() string
+	runAsync func(func())
+
+	// plans snapshots the planned product ids for an active saga
+	// so RunActive does not have to re-read the catalogue on
+	// every resume. The snapshot is process-local: a restart
+	// loses the in-memory map, and the next RunActive call will
+	// re-snapshot from CategoryReader. Documenting the trade-off
+	// here rather than introducing a `repricing_item` table keeps
+	// the demo's footprint small while making the upgrade path
+	// explicit.
+	mu    sync.Mutex
+	plans map[string][]string
+}
+
+// Logger is the minimal log seam the service uses for non-fatal
+// warnings.
+type Logger interface {
+	Warnf(format string, args ...any)
+	Infof(format string, args ...any)
+}
+
+// nopLogger is the default when no logger is supplied.
+type nopLogger struct{}
+
+func (nopLogger) Warnf(string, ...any) {}
+func (nopLogger) Infof(string, ...any) {}
+
+// NewService wires the service against its dependencies.
+func NewService(storage Storage, reader CategoryReader, updater PriceUpdater) *Service {
+	return &Service{
+		storage:  storage,
+		reader:   reader,
+		updater:  updater,
+		logger:   nopLogger{},
+		now:      func() time.Time { return time.Now().UTC() },
+		newID:    newRandomID,
+		runAsync: func(fn func()) { go fn() },
+		plans:    map[string][]string{},
+	}
+}
+
+// WithClock overrides the time source — used by tests to pin
+// transition timestamps.
+func (s *Service) WithClock(now func() time.Time) *Service {
+	s.now = now
+	return s
+}
+
+// WithIDGenerator overrides the id generator so tests can use
+// predictable ids.
+func (s *Service) WithIDGenerator(newID func() string) *Service {
+	s.newID = newID
+	return s
+}
+
+// WithLogger wires the log seam.
+func (s *Service) WithLogger(l Logger) *Service {
+	if l == nil {
+		l = nopLogger{}
+	}
+	s.logger = l
+	return s
+}
+
+// WithAsyncRunner overrides the background-goroutine launcher.
+// Tests substitute a synchronous runner that invokes the function
+// inline so RunActive can be driven deterministically from the test
+// goroutine; production keeps the default `go fn()`.
+func (s *Service) WithAsyncRunner(runner func(func())) *Service {
+	if runner == nil {
+		runner = func(fn func()) { go fn() }
+	}
+	s.runAsync = runner
+	return s
+}
+
+// Start kicks off a new bulk-reprice saga. It refuses when an
+// active reprice already exists (the partial unique index on the
+// storage table is the belt-and-braces second check), snapshots
+// the planned product ids, persists a new row in StatusScheduled,
+// and then — the demo trade-off — spawns a background goroutine
+// that drives RunActive against a freshly-rooted context.
+//
+// Trade-off. In production the background driver would be a job
+// queue (with retries and dead-letter routing) and the admin would
+// not need to keep the page open for the saga to finish. The
+// goroutine-per-Start approach below makes the demo single-process
+// and self-contained at the cost of losing the in-memory plan
+// snapshot when the binary restarts mid-run (RunActive on the
+// active row picks it back up by re-loading the plan from
+// CategoryReader, which is fine when the catalogue is stable
+// between restarts).
+func (s *Service) Start(ctx context.Context, categorySlug string, percentChange float64) (string, error) {
+	if _, exists, err := s.storage.FindActive(ctx); err != nil {
+		return "", fmt.Errorf("repricing: find active: %w", err)
+	} else if exists {
+		return "", ErrAlreadyActive
+	}
+
+	productIDs, err := s.reader.ProductsInCategory(ctx, categorySlug)
+	if err != nil {
+		return "", fmt.Errorf("repricing: load category products: %w", err)
+	}
+	if len(productIDs) == 0 {
+		return "", fmt.Errorf("repricing: category %q has no products: %w", categorySlug, domain.ErrInvalidReprice)
+	}
+
+	id := s.newID()
+	r, err := domain.NewReprice(id, categorySlug, percentChange, len(productIDs), s.now())
+	if err != nil {
+		return "", err
+	}
+	if err := s.storage.Create(ctx, r); err != nil {
+		return "", fmt.Errorf("repricing: create: %w", err)
+	}
+
+	s.snapshotPlan(id, productIDs)
+
+	// Detach the background driver from the HTTP request's
+	// context so cancelling the form submission does not kill
+	// the saga. The saga inherits the rest of the process
+	// lifetime instead.
+	s.runAsync(func() {
+		bgCtx := context.Background()
+		if err := s.RunActive(bgCtx); err != nil {
+			s.logger.Warnf("repricing: background run failed: %v", err)
+		}
+	})
+	return id, nil
+}
+
+// RunActive loads the active reprice and walks its planned items.
+// Safe to invoke from multiple goroutines: the optimistic
+// concurrency check on Update means only one walker advances the
+// row at a time, and any conflict reloads from the persisted state
+// before continuing.
+//
+// When the row is already StatusCompleted / StatusFailed RunActive
+// returns nil (no work to do). When no active row exists, returns
+// nil — the admin polling page calls RunActive without checking
+// first and a no-op is the natural answer.
+func (s *Service) RunActive(ctx context.Context) error {
+	r, exists, err := s.storage.FindActive(ctx)
+	if err != nil {
+		return fmt.Errorf("repricing: find active: %w", err)
+	}
+	if !exists {
+		return nil
+	}
+
+	if r.Status() == domain.StatusScheduled {
+		if err := r.Start(); err != nil {
+			return fmt.Errorf("repricing: start: %w", err)
+		}
+		if err := s.storage.Update(ctx, r); err != nil {
+			return fmt.Errorf("repricing: persist start: %w", err)
+		}
+	}
+
+	productIDs, err := s.plan(ctx, r)
+	if err != nil {
+		return fmt.Errorf("repricing: load plan: %w", err)
+	}
+
+	// Resume from where we left off: skip the first
+	// ProcessedItems items so a restart after a crash does not
+	// double-apply the percentage change.
+	for idx := r.ProcessedItems(); idx < len(productIDs); idx++ {
+		if err := ctx.Err(); err != nil {
+			// Cooperative cancellation: leave the row in
+			// StatusInProgress so a later RunActive resumes.
+			return nil
+		}
+		productID := productIDs[idx]
+		if err := s.applyItem(ctx, &r, productID); err != nil {
+			if errors.Is(err, ErrOptimisticLock) {
+				reloaded, ferr := s.storage.Find(ctx, r.ID())
+				if ferr != nil {
+					return fmt.Errorf("repricing: reload after conflict: %w", ferr)
+				}
+				r = reloaded
+				idx = r.ProcessedItems() - 1
+				continue
+			}
+			return err
+		}
+	}
+
+	if r.ProcessedItems() >= r.TotalItems() && r.Status() == domain.StatusInProgress {
+		if err := r.Complete(s.now()); err != nil {
+			return fmt.Errorf("repricing: complete: %w", err)
+		}
+		if err := s.storage.Update(ctx, r); err != nil {
+			return fmt.Errorf("repricing: persist complete: %w", err)
+		}
+		s.forgetPlan(r.ID())
+	}
+	return nil
+}
+
+// applyItem loads the product's current price, computes the new
+// minor-unit amount, applies the update and records the outcome on
+// the Reprice row. A per-item failure is recorded as a non-fatal
+// RecordItemFailed; storage failures while updating the row itself
+// bubble up.
+func (s *Service) applyItem(ctx context.Context, r *domain.Reprice, productID string) error {
+	current, err := s.updater.CurrentPriceMinor(ctx, productID)
+	if err != nil {
+		s.logger.Warnf("repricing: load price %s: %v", productID, err)
+		if recordErr := r.RecordItemFailed(err.Error(), s.now()); recordErr != nil {
+			return fmt.Errorf("repricing: record failed: %w", recordErr)
+		}
+		return s.storage.Update(ctx, *r)
+	}
+	newAmount := applyPercent(current, r.PercentChange())
+	if err := s.updater.UpdateProductPrice(ctx, productID, newAmount); err != nil {
+		s.logger.Warnf("repricing: update %s: %v", productID, err)
+		if recordErr := r.RecordItemFailed(err.Error(), s.now()); recordErr != nil {
+			return fmt.Errorf("repricing: record failed: %w", recordErr)
+		}
+	} else if recordErr := r.RecordItemProcessed(s.now()); recordErr != nil {
+		return fmt.Errorf("repricing: record processed: %w", recordErr)
+	}
+	return s.storage.Update(ctx, *r)
+}
+
+// applyPercent returns oldAmount * (1 + percent/100), rounded to
+// the nearest minor unit. The clamp at zero protects against
+// absurd inputs (percent <= -100) — even though NewReprice already
+// bounds percent to +/-50, defending here keeps the rounding step
+// self-contained.
+func applyPercent(oldAmount int64, percent float64) int64 {
+	multiplier := 1 + percent/100.0
+	if multiplier < 0 {
+		multiplier = 0
+	}
+	scaled := float64(oldAmount) * multiplier
+	rounded := math.Round(scaled)
+	if rounded < 0 {
+		rounded = 0
+	}
+	return int64(rounded)
+}
+
+// snapshotPlan stores the planned product ids on the in-memory map
+// so RunActive does not have to re-read the catalogue on the same
+// run.
+func (s *Service) snapshotPlan(id string, productIDs []string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	cp := make([]string, len(productIDs))
+	copy(cp, productIDs)
+	s.plans[id] = cp
+}
+
+// plan returns the cached plan for the given reprice or reloads it
+// from CategoryReader if not cached (which happens after a
+// restart).
+func (s *Service) plan(ctx context.Context, r domain.Reprice) ([]string, error) {
+	s.mu.Lock()
+	cached, ok := s.plans[r.ID()]
+	s.mu.Unlock()
+	if ok {
+		return cached, nil
+	}
+	productIDs, err := s.reader.ProductsInCategory(ctx, r.CategoryID())
+	if err != nil {
+		return nil, err
+	}
+	s.snapshotPlan(r.ID(), productIDs)
+	return productIDs, nil
+}
+
+// forgetPlan drops the in-memory plan for the given id (called on
+// Complete so the map does not grow unbounded over many sagas).
+func (s *Service) forgetPlan(id string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.plans, id)
+}
+
+// ByID returns the reprice row with the given id.
+func (s *Service) ByID(ctx context.Context, id string) (domain.Reprice, error) {
+	if id == "" {
+		return domain.Reprice{}, ErrNotFound
+	}
+	return s.storage.Find(ctx, id)
+}
+
+// Active returns the currently-active reprice (scheduled or
+// in_progress). ok=false means no active reprice.
+func (s *Service) Active(ctx context.Context) (domain.Reprice, bool, error) {
+	return s.storage.FindActive(ctx)
+}
+
+// ListAll returns every reprice row, newest-started first.
+func (s *Service) ListAll(ctx context.Context) ([]domain.Reprice, error) {
+	return s.storage.ListAll(ctx)
+}
+
+// newRandomID returns a 16-byte hex string prefixed with "rep-".
+func newRandomID() string {
+	buf := make([]byte, 16)
+	if _, err := rand.Read(buf); err != nil {
+		return fmt.Sprintf("rep-%d", time.Now().UnixNano())
+	}
+	return "rep-" + hex.EncodeToString(buf)
+}

--- a/backend/repricing/app/service_test.go
+++ b/backend/repricing/app/service_test.go
@@ -1,0 +1,371 @@
+package app_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/bkielbasa/go-ecommerce/backend/repricing/adapter"
+	"github.com/bkielbasa/go-ecommerce/backend/repricing/app"
+	"github.com/bkielbasa/go-ecommerce/backend/repricing/domain"
+)
+
+// staticReader is a tiny CategoryReader: every slug maps to the
+// same product id slice.
+type staticReader struct {
+	ids []string
+	err error
+}
+
+func (s staticReader) ProductsInCategory(_ context.Context, _ string) ([]string, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	out := make([]string, len(s.ids))
+	copy(out, s.ids)
+	return out, nil
+}
+
+// fakeUpdater is the test PriceUpdater: it stores per-product
+// minor-unit amounts in a map keyed by product id, allows tests to
+// inject per-product errors, and records every call for assertion.
+type fakeUpdater struct {
+	mu       sync.Mutex
+	prices   map[string]int64
+	errs     map[string]error
+	loadErrs map[string]error
+	updates  []update
+}
+
+type update struct {
+	productID string
+	amount    int64
+}
+
+func newFakeUpdater(initial map[string]int64) *fakeUpdater {
+	cp := map[string]int64{}
+	for k, v := range initial {
+		cp[k] = v
+	}
+	return &fakeUpdater{
+		prices:   cp,
+		errs:     map[string]error{},
+		loadErrs: map[string]error{},
+	}
+}
+
+func (f *fakeUpdater) CurrentPriceMinor(_ context.Context, productID string) (int64, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if err, ok := f.loadErrs[productID]; ok {
+		return 0, err
+	}
+	v, ok := f.prices[productID]
+	if !ok {
+		return 0, fmt.Errorf("unknown product %q", productID)
+	}
+	return v, nil
+}
+
+func (f *fakeUpdater) UpdateProductPrice(_ context.Context, productID string, newAmount int64) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if err, ok := f.errs[productID]; ok {
+		return err
+	}
+	f.prices[productID] = newAmount
+	f.updates = append(f.updates, update{productID: productID, amount: newAmount})
+	return nil
+}
+
+func (f *fakeUpdater) priceOf(productID string) int64 {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.prices[productID]
+}
+
+func (f *fakeUpdater) callCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.updates)
+}
+
+// newServiceFixture wires a service backed by the in-memory storage
+// with a deterministic clock and id generator and a SYNCHRONOUS
+// async runner — Start blocks until RunActive completes so tests
+// can assert without polling.
+func newServiceFixture(t *testing.T, ids []string, prices map[string]int64) (*app.Service, *adapter.InMemory, *fakeUpdater) {
+	t.Helper()
+	storage := adapter.NewInMemory()
+	upd := newFakeUpdater(prices)
+	srv := app.NewService(storage, staticReader{ids: ids}, upd).
+		WithClock(func() time.Time {
+			return time.Date(2026, 5, 27, 12, 0, 0, 0, time.UTC)
+		}).
+		WithIDGenerator(func() string { return "rep-test-1" }).
+		// Synchronous runner: Start invokes RunActive inline.
+		WithAsyncRunner(func(fn func()) { fn() })
+	return srv, storage, upd
+}
+
+func TestStart_RunsToCompletion(t *testing.T) {
+	ids := []string{"p-1", "p-2", "p-3"}
+	prices := map[string]int64{
+		"p-1": 1000, // -> 1100 after +10%
+		"p-2": 2000, // -> 2200
+		"p-3": 3000, // -> 3300
+	}
+	srv, storage, upd := newServiceFixture(t, ids, prices)
+	ctx := context.Background()
+
+	id, err := srv.Start(ctx, "tools", 10)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if id != "rep-test-1" {
+		t.Fatalf("id = %q, want rep-test-1", id)
+	}
+
+	r, err := storage.Find(ctx, id)
+	if err != nil {
+		t.Fatalf("Find: %v", err)
+	}
+	if r.Status() != domain.StatusCompleted {
+		t.Fatalf("status = %q, want completed", r.Status())
+	}
+	if r.ProcessedItems() != 3 {
+		t.Fatalf("processed = %d, want 3", r.ProcessedItems())
+	}
+	if upd.callCount() != 3 {
+		t.Fatalf("updates = %d, want 3", upd.callCount())
+	}
+	if got := upd.priceOf("p-1"); got != 1100 {
+		t.Errorf("p-1 = %d, want 1100", got)
+	}
+	if got := upd.priceOf("p-2"); got != 2200 {
+		t.Errorf("p-2 = %d, want 2200", got)
+	}
+	if got := upd.priceOf("p-3"); got != 3300 {
+		t.Errorf("p-3 = %d, want 3300", got)
+	}
+}
+
+func TestStart_RejectsWhenActiveExists(t *testing.T) {
+	ids := []string{"p-1"}
+	prices := map[string]int64{"p-1": 100}
+	storage := adapter.NewInMemory()
+	upd := newFakeUpdater(prices)
+
+	// First create an active row by hand.
+	r, err := domain.NewReprice("rep-existing", "cat", 10, 1, time.Now().UTC())
+	if err != nil {
+		t.Fatalf("NewReprice: %v", err)
+	}
+	if err := storage.Create(context.Background(), r); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	srv := app.NewService(storage, staticReader{ids: ids}, upd).
+		WithAsyncRunner(func(fn func()) { fn() })
+
+	if _, err := srv.Start(context.Background(), "tools", 5); !errors.Is(err, app.ErrAlreadyActive) {
+		t.Fatalf("got %v, want ErrAlreadyActive", err)
+	}
+}
+
+func TestStart_RejectsEmptyCategory(t *testing.T) {
+	srv, _, _ := newServiceFixture(t, nil, nil)
+	_, err := srv.Start(context.Background(), "tools", 10)
+	if err == nil {
+		t.Fatal("expected error for empty category, got nil")
+	}
+}
+
+func TestStart_RejectsInvalidPercent(t *testing.T) {
+	srv, _, _ := newServiceFixture(t, []string{"p-1"}, map[string]int64{"p-1": 100})
+	_, err := srv.Start(context.Background(), "tools", 0)
+	if !errors.Is(err, domain.ErrInvalidReprice) {
+		t.Fatalf("got %v, want ErrInvalidReprice", err)
+	}
+}
+
+func TestRunActive_NoActive(t *testing.T) {
+	srv, _, _ := newServiceFixture(t, nil, nil)
+	if err := srv.RunActive(context.Background()); err != nil {
+		t.Fatalf("RunActive: %v", err)
+	}
+}
+
+func TestRunActive_ResumesFromProcessed(t *testing.T) {
+	// Manually craft a scenario: an in_progress row with 1 of 3
+	// items already processed (modelling a crash mid-saga).
+	storage := adapter.NewInMemory()
+	upd := newFakeUpdater(map[string]int64{
+		"p-1": 1000,
+		"p-2": 2000,
+		"p-3": 3000,
+	})
+
+	at := time.Date(2026, 5, 27, 12, 0, 0, 0, time.UTC)
+	r, err := domain.NewReprice("rep-resume", "tools", 10, 3, at)
+	if err != nil {
+		t.Fatalf("NewReprice: %v", err)
+	}
+	if err := r.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	// Pretend p-1 was already done at a previous price (so its
+	// stored price is the *new* one, 1100). We mutate the
+	// fakeUpdater's table to reflect that.
+	upd.mu.Lock()
+	upd.prices["p-1"] = 1100
+	upd.mu.Unlock()
+	if err := r.RecordItemProcessed(at); err != nil {
+		t.Fatalf("RecordItemProcessed: %v", err)
+	}
+	if err := storage.Create(context.Background(), r); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	srv := app.NewService(storage, staticReader{ids: []string{"p-1", "p-2", "p-3"}}, upd).
+		WithClock(func() time.Time { return at }).
+		WithAsyncRunner(func(fn func()) { fn() })
+
+	if err := srv.RunActive(context.Background()); err != nil {
+		t.Fatalf("RunActive: %v", err)
+	}
+
+	got, err := storage.Find(context.Background(), "rep-resume")
+	if err != nil {
+		t.Fatalf("Find: %v", err)
+	}
+	if got.Status() != domain.StatusCompleted {
+		t.Fatalf("status = %q, want completed", got.Status())
+	}
+	if got.ProcessedItems() != 3 {
+		t.Fatalf("processed = %d, want 3", got.ProcessedItems())
+	}
+	// p-1 must NOT have been re-priced (1100 -> would have
+	// become 1210 if the resume failed to skip).
+	if v := upd.priceOf("p-1"); v != 1100 {
+		t.Errorf("p-1 = %d, want 1100 (no double-apply)", v)
+	}
+	if v := upd.priceOf("p-2"); v != 2200 {
+		t.Errorf("p-2 = %d, want 2200", v)
+	}
+	if v := upd.priceOf("p-3"); v != 3300 {
+		t.Errorf("p-3 = %d, want 3300", v)
+	}
+}
+
+func TestRunActive_PerItemErrorIsRecordedAndContinues(t *testing.T) {
+	ids := []string{"p-1", "p-2", "p-3"}
+	prices := map[string]int64{"p-1": 1000, "p-2": 2000, "p-3": 3000}
+	storage := adapter.NewInMemory()
+	upd := newFakeUpdater(prices)
+	upd.errs["p-2"] = errors.New("price rejected")
+
+	srv := app.NewService(storage, staticReader{ids: ids}, upd).
+		WithClock(func() time.Time { return time.Date(2026, 5, 27, 12, 0, 0, 0, time.UTC) }).
+		WithIDGenerator(func() string { return "rep-err" }).
+		WithAsyncRunner(func(fn func()) { fn() })
+
+	id, err := srv.Start(context.Background(), "tools", 10)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	r, err := storage.Find(context.Background(), id)
+	if err != nil {
+		t.Fatalf("Find: %v", err)
+	}
+	if r.Status() != domain.StatusCompleted {
+		t.Fatalf("status = %q, want completed (per-item error must not abort)", r.Status())
+	}
+	if r.ProcessedItems() != 3 {
+		t.Fatalf("processed = %d, want 3", r.ProcessedItems())
+	}
+	if r.LastError() == "" {
+		t.Error("lastError should record the per-item failure")
+	}
+	if v := upd.priceOf("p-2"); v != 2000 {
+		t.Errorf("p-2 = %d, want 2000 (untouched)", v)
+	}
+}
+
+func TestStartTwice_RejectedInline(t *testing.T) {
+	// Use a runner that captures but does NOT invoke the
+	// saga, simulating a real background driver. Then the
+	// second Start must reject because the first row is still
+	// in StatusScheduled.
+	ids := []string{"p-1"}
+	prices := map[string]int64{"p-1": 1000}
+	storage := adapter.NewInMemory()
+	upd := newFakeUpdater(prices)
+
+	srv := app.NewService(storage, staticReader{ids: ids}, upd).
+		WithIDGenerator(func() string { return "rep-a" }).
+		WithAsyncRunner(func(_ func()) {})
+
+	ctx := context.Background()
+	if _, err := srv.Start(ctx, "tools", 10); err != nil {
+		t.Fatalf("first Start: %v", err)
+	}
+	if _, err := srv.Start(ctx, "tools", 10); !errors.Is(err, app.ErrAlreadyActive) {
+		t.Fatalf("second Start: got %v, want ErrAlreadyActive", err)
+	}
+}
+
+func TestActive_ReturnsCurrent(t *testing.T) {
+	srv, _, _ := newServiceFixture(t, []string{"p-1"}, map[string]int64{"p-1": 100})
+	ctx := context.Background()
+
+	if _, ok, err := srv.Active(ctx); err != nil || ok {
+		t.Fatalf("expected no active, got ok=%v err=%v", ok, err)
+	}
+	_, err := srv.Start(ctx, "tools", 10)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	// Synchronous runner completes the saga so Active is now empty.
+	if _, ok, err := srv.Active(ctx); err != nil || ok {
+		t.Fatalf("expected no active after completion, got ok=%v err=%v", ok, err)
+	}
+}
+
+func TestListAll_NewestFirst(t *testing.T) {
+	// Drive two reprices to completion sequentially.
+	storage := adapter.NewInMemory()
+	upd := newFakeUpdater(map[string]int64{"p-1": 1000})
+	clock := time.Date(2026, 5, 27, 12, 0, 0, 0, time.UTC)
+	idCounter := 0
+	srv := app.NewService(storage, staticReader{ids: []string{"p-1"}}, upd).
+		WithClock(func() time.Time { return clock }).
+		WithIDGenerator(func() string {
+			idCounter++
+			return fmt.Sprintf("rep-%d", idCounter)
+		}).
+		WithAsyncRunner(func(fn func()) { fn() })
+
+	ctx := context.Background()
+	if _, err := srv.Start(ctx, "tools", 10); err != nil {
+		t.Fatalf("first Start: %v", err)
+	}
+	clock = clock.Add(time.Hour)
+	if _, err := srv.Start(ctx, "tools", -5); err != nil {
+		t.Fatalf("second Start: %v", err)
+	}
+	rows, err := srv.ListAll(ctx)
+	if err != nil {
+		t.Fatalf("ListAll: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("got %d rows, want 2", len(rows))
+	}
+	if rows[0].ID() != "rep-2" {
+		t.Errorf("newest-first: got %q", rows[0].ID())
+	}
+}

--- a/backend/repricing/bounded_context.go
+++ b/backend/repricing/bounded_context.go
@@ -1,0 +1,30 @@
+// Package repricing is the composition root for the repricing
+// (Process Manager) bounded context. It owns the bulk "reprice every
+// product in a category by N%" workflow as a state-stored saga; see
+// repricing/domain and repricing/app for the implementation.
+//
+// The context does not register HTTP routes itself — the admin UI
+// lives in the layout package (http_admin_repricing.go) which talks
+// to *app.Service through a narrow interface. Mirrors the
+// fulfillment context's split.
+package repricing
+
+import (
+	"database/sql"
+
+	"github.com/bkielbasa/go-ecommerce/backend/internal/application"
+	"github.com/bkielbasa/go-ecommerce/backend/repricing/adapter"
+	"github.com/bkielbasa/go-ecommerce/backend/repricing/app"
+)
+
+// New wires the production adapter onto the supplied *sql.DB and
+// binds the application service to the supplied CategoryReader and
+// PriceUpdater seams (the composition root provides adapters over
+// productcatalog).
+func New(db *sql.DB, reader app.CategoryReader, updater app.PriceUpdater) (application.BoundedContext, *app.Service) {
+	storage := adapter.NewPostgres(db)
+	srv := app.NewService(storage, reader, updater)
+	return &boundedContext{}, srv
+}
+
+type boundedContext struct{}

--- a/backend/repricing/domain/reprice.go
+++ b/backend/repricing/domain/reprice.go
@@ -1,0 +1,285 @@
+// Package domain holds the repricing bounded context's value object: a
+// Reprice record models the long-running "bulk reprice category by N%"
+// operation as a state-stored Process Manager.
+//
+// PROCESS MANAGER PATTERN
+//
+// The reprice is a long-running workflow that walks every product in a
+// category and applies a percentage change to its base price. The unit
+// of work — one product's UpdateProduct call — is small, but the batch
+// can be hundreds of items long; a naive "do it all in one HTTP
+// request" implementation would either hold an admin browser open for
+// minutes or fail half-way through with no way to resume.
+//
+// The Reprice value object plus the application service's RunActive
+// method form a saga:
+//
+//   - The state-stored Reprice row carries the total item count, the
+//     count of items processed so far, and the last per-item error.
+//   - Each item's processing increments processedItems and bumps the
+//     row's version (optimistic concurrency); a partial failure on
+//     one item is recorded in lastError but the saga continues.
+//   - On a process restart, the in-progress Reprice row is still on
+//     disk: a future call to RunActive picks up from processedItems
+//     without re-applying the price change to items it already touched.
+//
+// The 'one active at a time' invariant is enforced both in the
+// application service (Start refuses when FindActive returns a row)
+// and at the database level via a partial unique index on the status
+// column — belt and braces, with the DB constraint being the last
+// line of defence against two concurrent admins clicking the button
+// at the same time.
+//
+// The shape mirrors the fulfillment context's state-stored aggregate
+// (different store, different events, different ubiquitous language)
+// so a reader who has internalised one finds the other immediately
+// familiar.
+package domain
+
+import (
+	"errors"
+	"fmt"
+	"time"
+)
+
+// Status is the operational stage of a Reprice. The four states form
+// a linear lifecycle (scheduled -> in_progress -> completed) with a
+// failure terminal reachable from in_progress when the saga aborts
+// hard (e.g. ctx cancelled and the operator chose to fail the run
+// rather than resume).
+type Status string
+
+const (
+	// StatusScheduled is the initial state: Start has created the
+	// row but the goroutine that walks the items has not yet
+	// transitioned it.
+	StatusScheduled Status = "scheduled"
+	// StatusInProgress means the saga is actively iterating the
+	// planned items. A process restart leaves the row in this state
+	// so a future RunActive call can resume from processedItems.
+	StatusInProgress Status = "in_progress"
+	// StatusCompleted is the happy-path terminal state: every
+	// planned item has been processed (with or without per-item
+	// errors recorded in lastError).
+	StatusCompleted Status = "completed"
+	// StatusFailed is the failure terminal: an unrecoverable error
+	// (storage down, ctx cancelled with no resume desired) ended
+	// the run.
+	StatusFailed Status = "failed"
+)
+
+// ErrInvalidReprice is returned by NewReprice when its arguments
+// fail validation (empty id/category, non-positive total,
+// out-of-range percent). Wrapped via fmt.Errorf("...: %w", ...) so
+// callers can branch with errors.Is.
+var ErrInvalidReprice = errors.New("repricing: invalid reprice arguments")
+
+// ErrInvalidTransition is returned by Start / RecordItemProcessed /
+// RecordItemFailed / Complete / Fail when the current status does
+// not permit the requested command.
+var ErrInvalidTransition = errors.New("repricing: invalid state transition")
+
+// maxAbsPercent bounds the percent_change argument to a sensible
+// range so an admin slip ("set to +200%") does not silently nuke the
+// catalogue. The bound is symmetric and deliberately conservative;
+// loosening it is a config / migration concern, not a hot-fix.
+const maxAbsPercent = 50.0
+
+// Reprice is the state-stored aggregate root for one bulk-reprice
+// operation. Construct fresh records via NewReprice; rebuild
+// existing rows via Rebuild. The value object is immutable in
+// spirit: the command methods mutate the receiver only after
+// validating the transition.
+type Reprice struct {
+	id             string
+	categoryID     string
+	percentChange  float64
+	status         Status
+	totalItems     int
+	processedItems int
+	lastError      string
+	startedAt      time.Time
+	completedAt    *time.Time
+	version        int
+}
+
+// NewReprice constructs a fresh, unsaved Reprice in the
+// StatusScheduled state.
+func NewReprice(id, categoryID string, percentChange float64, totalItems int, at time.Time) (Reprice, error) {
+	if id == "" {
+		return Reprice{}, fmt.Errorf("empty id: %w", ErrInvalidReprice)
+	}
+	if categoryID == "" {
+		return Reprice{}, fmt.Errorf("empty categoryID: %w", ErrInvalidReprice)
+	}
+	if totalItems <= 0 {
+		return Reprice{}, fmt.Errorf("totalItems must be positive: %w", ErrInvalidReprice)
+	}
+	if percentChange < -maxAbsPercent || percentChange > maxAbsPercent {
+		return Reprice{}, fmt.Errorf("percentChange out of range: %w", ErrInvalidReprice)
+	}
+	if percentChange == 0 {
+		// A zero-percent reprice would be a no-op disguised as a
+		// long-running workflow. Reject it so the admin's foot-gun
+		// stays visible.
+		return Reprice{}, fmt.Errorf("percentChange cannot be zero: %w", ErrInvalidReprice)
+	}
+	return Reprice{
+		id:            id,
+		categoryID:    categoryID,
+		percentChange: percentChange,
+		status:        StatusScheduled,
+		totalItems:    totalItems,
+		startedAt:     at,
+		version:       1,
+	}, nil
+}
+
+// Rebuild reconstructs a Reprice from a storage row. No transitions
+// are applied — this is purely for reading a persisted record back
+// into memory.
+func Rebuild(
+	id, categoryID string,
+	percentChange float64,
+	status Status,
+	totalItems, processedItems int,
+	lastError string,
+	startedAt time.Time,
+	completedAt *time.Time,
+	version int,
+) Reprice {
+	return Reprice{
+		id:             id,
+		categoryID:     categoryID,
+		percentChange:  percentChange,
+		status:         status,
+		totalItems:     totalItems,
+		processedItems: processedItems,
+		lastError:      lastError,
+		startedAt:      startedAt,
+		completedAt:    completedAt,
+		version:        version,
+	}
+}
+
+// ID returns the record's stable identifier.
+func (r Reprice) ID() string { return r.id }
+
+// CategoryID returns the catalogue category slug the saga targets.
+func (r Reprice) CategoryID() string { return r.categoryID }
+
+// PercentChange is the signed multiplier applied to every product's
+// base price (e.g. -10.0 means "drop every price by 10%").
+func (r Reprice) PercentChange() float64 { return r.percentChange }
+
+// Status returns the current lifecycle stage.
+func (r Reprice) Status() Status { return r.status }
+
+// TotalItems is the count of products planned at Start time.
+func (r Reprice) TotalItems() int { return r.totalItems }
+
+// ProcessedItems is the count of products RunActive has already
+// updated (incremented after each per-item Update).
+func (r Reprice) ProcessedItems() int { return r.processedItems }
+
+// LastError is the per-item error message recorded by the most
+// recent RecordItemFailed (empty when no item has failed yet).
+func (r Reprice) LastError() string { return r.lastError }
+
+// StartedAt is when the row was first created.
+func (r Reprice) StartedAt() time.Time { return r.startedAt }
+
+// CompletedAt is when the row reached Complete or Fail (nil while
+// still active).
+func (r Reprice) CompletedAt() *time.Time { return r.completedAt }
+
+// Version is the optimistic-concurrency counter incremented on every
+// successful transition.
+func (r Reprice) Version() int { return r.version }
+
+// ProgressFraction returns processedItems / totalItems as a value
+// between 0 and 1. The admin UI uses this to render a progress bar.
+func (r Reprice) ProgressFraction() float64 {
+	if r.totalItems == 0 {
+		return 0
+	}
+	return float64(r.processedItems) / float64(r.totalItems)
+}
+
+// Start transitions a scheduled reprice to in_progress. This is the
+// transition RunActive applies the first time it picks up the row;
+// resuming after a restart finds the row already in_progress and
+// skips this command.
+func (r *Reprice) Start() error {
+	if r.status != StatusScheduled {
+		return ErrInvalidTransition
+	}
+	r.status = StatusInProgress
+	r.version++
+	return nil
+}
+
+// RecordItemProcessed increments processedItems and bumps the
+// version. The `at` argument is unused today but reserved so a
+// future "rate-limit / pacing" feature can record per-item
+// timestamps without changing the call site.
+func (r *Reprice) RecordItemProcessed(at time.Time) error {
+	if r.status != StatusInProgress {
+		return ErrInvalidTransition
+	}
+	_ = at
+	r.processedItems++
+	r.version++
+	return nil
+}
+
+// RecordItemFailed records a per-item error message without
+// aborting the saga. The processed counter still advances — the
+// item is considered "done" from the saga's point of view; the
+// error is recorded so the admin can see something went wrong.
+func (r *Reprice) RecordItemFailed(errMsg string, at time.Time) error {
+	if r.status != StatusInProgress {
+		return ErrInvalidTransition
+	}
+	_ = at
+	r.lastError = errMsg
+	r.processedItems++
+	r.version++
+	return nil
+}
+
+// Complete transitions an in-progress reprice to completed. Callers
+// MUST have processed every planned item before calling this; the
+// guard rejects an early Complete so the saga can't be marked done
+// while there is still work outstanding.
+func (r *Reprice) Complete(at time.Time) error {
+	if r.status != StatusInProgress {
+		return ErrInvalidTransition
+	}
+	if r.processedItems < r.totalItems {
+		return ErrInvalidTransition
+	}
+	r.status = StatusCompleted
+	completedAt := at
+	r.completedAt = &completedAt
+	r.version++
+	return nil
+}
+
+// Fail transitions any active state (scheduled or in_progress) to
+// failed. The errMsg overwrites lastError so the operator sees the
+// fatal reason on the detail page.
+func (r *Reprice) Fail(errMsg string, at time.Time) error {
+	switch r.status {
+	case StatusScheduled, StatusInProgress:
+		// allowed
+	default:
+		return ErrInvalidTransition
+	}
+	r.status = StatusFailed
+	r.lastError = errMsg
+	completedAt := at
+	r.completedAt = &completedAt
+	r.version++
+	return nil
+}

--- a/backend/repricing/domain/reprice_test.go
+++ b/backend/repricing/domain/reprice_test.go
@@ -1,0 +1,239 @@
+package domain_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/bkielbasa/go-ecommerce/backend/repricing/domain"
+)
+
+func mustNewReprice(t *testing.T) domain.Reprice {
+	t.Helper()
+	r, err := domain.NewReprice("rep-1", "tools", 10, 3, time.Now().UTC())
+	if err != nil {
+		t.Fatalf("NewReprice: %v", err)
+	}
+	return r
+}
+
+func TestNewReprice_Validates(t *testing.T) {
+	at := time.Now().UTC()
+	cases := []struct {
+		name           string
+		id             string
+		categoryID     string
+		percent        float64
+		total          int
+		wantInvalidArg bool
+	}{
+		{"empty id", "", "tools", 10, 5, true},
+		{"empty categoryID", "rep-1", "", 10, 5, true},
+		{"zero items", "rep-1", "tools", 10, 0, true},
+		{"negative items", "rep-1", "tools", 10, -1, true},
+		{"percent zero", "rep-1", "tools", 0, 5, true},
+		{"percent too high", "rep-1", "tools", 51, 5, true},
+		{"percent too low", "rep-1", "tools", -51, 5, true},
+		{"happy path", "rep-1", "tools", 10, 5, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			_, err := domain.NewReprice(c.id, c.categoryID, c.percent, c.total, at)
+			if c.wantInvalidArg {
+				if err == nil {
+					t.Fatalf("want error, got nil")
+				}
+				if !errors.Is(err, domain.ErrInvalidReprice) {
+					t.Fatalf("error %q does not wrap ErrInvalidReprice", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestNewReprice_InitialState(t *testing.T) {
+	r := mustNewReprice(t)
+	if r.Status() != domain.StatusScheduled {
+		t.Errorf("status = %q, want scheduled", r.Status())
+	}
+	if r.ProcessedItems() != 0 {
+		t.Errorf("processed = %d, want 0", r.ProcessedItems())
+	}
+	if r.Version() != 1 {
+		t.Errorf("version = %d, want 1", r.Version())
+	}
+	if r.ProgressFraction() != 0 {
+		t.Errorf("progress = %v, want 0", r.ProgressFraction())
+	}
+	if r.CompletedAt() != nil {
+		t.Errorf("completedAt = %v, want nil", r.CompletedAt())
+	}
+}
+
+func TestStart_TransitionsToInProgress(t *testing.T) {
+	r := mustNewReprice(t)
+	if err := r.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if r.Status() != domain.StatusInProgress {
+		t.Errorf("status = %q, want in_progress", r.Status())
+	}
+	if r.Version() != 2 {
+		t.Errorf("version = %d, want 2", r.Version())
+	}
+}
+
+func TestStart_RejectsDoubleStart(t *testing.T) {
+	r := mustNewReprice(t)
+	_ = r.Start()
+	err := r.Start()
+	if !errors.Is(err, domain.ErrInvalidTransition) {
+		t.Fatalf("got %v, want ErrInvalidTransition", err)
+	}
+}
+
+func TestRecordItemProcessed_RequiresInProgress(t *testing.T) {
+	r := mustNewReprice(t)
+	err := r.RecordItemProcessed(time.Now())
+	if !errors.Is(err, domain.ErrInvalidTransition) {
+		t.Fatalf("got %v, want ErrInvalidTransition", err)
+	}
+}
+
+func TestRecordItemProcessed_AdvancesCounter(t *testing.T) {
+	r := mustNewReprice(t)
+	_ = r.Start()
+	now := time.Now().UTC()
+	if err := r.RecordItemProcessed(now); err != nil {
+		t.Fatalf("RecordItemProcessed: %v", err)
+	}
+	if r.ProcessedItems() != 1 {
+		t.Errorf("processed = %d, want 1", r.ProcessedItems())
+	}
+	wantFrac := 1.0 / 3.0
+	if got := r.ProgressFraction(); got != wantFrac {
+		t.Errorf("progress = %v, want %v", got, wantFrac)
+	}
+}
+
+func TestRecordItemFailed_AdvancesAndRecordsError(t *testing.T) {
+	r := mustNewReprice(t)
+	_ = r.Start()
+	if err := r.RecordItemFailed("boom", time.Now().UTC()); err != nil {
+		t.Fatalf("RecordItemFailed: %v", err)
+	}
+	if r.ProcessedItems() != 1 {
+		t.Errorf("processed = %d, want 1", r.ProcessedItems())
+	}
+	if r.LastError() != "boom" {
+		t.Errorf("lastError = %q, want boom", r.LastError())
+	}
+}
+
+func TestRecordItemFailed_RequiresInProgress(t *testing.T) {
+	r := mustNewReprice(t)
+	err := r.RecordItemFailed("boom", time.Now())
+	if !errors.Is(err, domain.ErrInvalidTransition) {
+		t.Fatalf("got %v, want ErrInvalidTransition", err)
+	}
+}
+
+func TestComplete_RequiresAllProcessed(t *testing.T) {
+	r := mustNewReprice(t)
+	_ = r.Start()
+	// only 1 of 3 processed
+	_ = r.RecordItemProcessed(time.Now())
+	err := r.Complete(time.Now())
+	if !errors.Is(err, domain.ErrInvalidTransition) {
+		t.Fatalf("got %v, want ErrInvalidTransition", err)
+	}
+}
+
+func TestComplete_HappyPath(t *testing.T) {
+	r := mustNewReprice(t)
+	_ = r.Start()
+	for i := 0; i < 3; i++ {
+		_ = r.RecordItemProcessed(time.Now())
+	}
+	at := time.Now().UTC()
+	if err := r.Complete(at); err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	if r.Status() != domain.StatusCompleted {
+		t.Errorf("status = %q, want completed", r.Status())
+	}
+	if r.CompletedAt() == nil || !r.CompletedAt().Equal(at) {
+		t.Errorf("completedAt = %v, want %v", r.CompletedAt(), at)
+	}
+}
+
+func TestComplete_RejectsFromScheduled(t *testing.T) {
+	r := mustNewReprice(t)
+	err := r.Complete(time.Now())
+	if !errors.Is(err, domain.ErrInvalidTransition) {
+		t.Fatalf("got %v, want ErrInvalidTransition", err)
+	}
+}
+
+func TestFail_FromScheduled(t *testing.T) {
+	r := mustNewReprice(t)
+	at := time.Now().UTC()
+	if err := r.Fail("nope", at); err != nil {
+		t.Fatalf("Fail: %v", err)
+	}
+	if r.Status() != domain.StatusFailed {
+		t.Errorf("status = %q, want failed", r.Status())
+	}
+	if r.LastError() != "nope" {
+		t.Errorf("lastError = %q, want nope", r.LastError())
+	}
+	if r.CompletedAt() == nil {
+		t.Errorf("completedAt is nil")
+	}
+}
+
+func TestFail_FromInProgress(t *testing.T) {
+	r := mustNewReprice(t)
+	_ = r.Start()
+	if err := r.Fail("nope", time.Now()); err != nil {
+		t.Fatalf("Fail: %v", err)
+	}
+	if r.Status() != domain.StatusFailed {
+		t.Errorf("status = %q, want failed", r.Status())
+	}
+}
+
+func TestFail_RejectsFromCompleted(t *testing.T) {
+	r := mustNewReprice(t)
+	_ = r.Start()
+	for i := 0; i < 3; i++ {
+		_ = r.RecordItemProcessed(time.Now())
+	}
+	_ = r.Complete(time.Now())
+	err := r.Fail("nope", time.Now())
+	if !errors.Is(err, domain.ErrInvalidTransition) {
+		t.Fatalf("got %v, want ErrInvalidTransition", err)
+	}
+}
+
+func TestRebuild_PreservesFields(t *testing.T) {
+	at := time.Date(2026, 5, 27, 12, 0, 0, 0, time.UTC)
+	completed := at.Add(time.Hour)
+	r := domain.Rebuild("rep-x", "cat", -25, domain.StatusCompleted, 5, 5, "", at, &completed, 12)
+	if r.ID() != "rep-x" {
+		t.Errorf("id mismatch")
+	}
+	if r.Status() != domain.StatusCompleted {
+		t.Errorf("status mismatch")
+	}
+	if r.Version() != 12 {
+		t.Errorf("version mismatch")
+	}
+	if r.PercentChange() != -25 {
+		t.Errorf("percent mismatch")
+	}
+}

--- a/migrations/000040_repricing.down.sql
+++ b/migrations/000040_repricing.down.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+DROP INDEX IF EXISTS repricing_one_active_idx;
+DROP TABLE IF EXISTS repricing;
+
+COMMIT;

--- a/migrations/000040_repricing.up.sql
+++ b/migrations/000040_repricing.up.sql
@@ -1,0 +1,34 @@
+BEGIN;
+
+-- repricing is the state-stored projection driven by the repricing
+-- bounded context (Process Manager pattern). Each row represents one
+-- bulk "reprice every product in a category by N%" operation; the
+-- saga walks the planned product ids and advances processed_items
+-- under optimistic concurrency until the run completes (or fails).
+--
+-- The version column drives the OCC check: the adapter's UPDATE
+-- matches on the expected previous version and a mismatch surfaces
+-- as app.ErrOptimisticLock.
+CREATE TABLE repricing (
+    id              text        PRIMARY KEY,
+    category_id     text        NOT NULL,
+    percent_change  real        NOT NULL,
+    status          text        NOT NULL CHECK (status IN ('scheduled','in_progress','completed','failed')),
+    total_items     int         NOT NULL DEFAULT 0,
+    processed_items int         NOT NULL DEFAULT 0,
+    last_error      text        NOT NULL DEFAULT '',
+    started_at      timestamptz NOT NULL DEFAULT now(),
+    completed_at    timestamptz,
+    version         int         NOT NULL DEFAULT 1
+);
+
+-- Partial unique index enforces "only one active reprice at a time".
+-- The application service also checks via FindActive before issuing
+-- Create; the DB-level guard is the belt-and-braces second check
+-- against two concurrent admins clicking the button at the same
+-- time.
+CREATE UNIQUE INDEX repricing_one_active_idx
+    ON repricing(status)
+    WHERE status IN ('scheduled', 'in_progress');
+
+COMMIT;


### PR DESCRIPTION
## Summary
- New `repricing/` bounded context modelled as a Process Manager (mirrors `fulfillment/` shape): `Reprice` aggregate with scheduled → in_progress → completed/failed transitions and version OCC.
- Migration `000039_repricing` adds the table + a partial unique index enforcing at-most-one-active reprice at the DB level.
- `CategoryReader` + `PriceUpdater` ports wrap the existing productcatalog `List` + `Find` + `UpdateProduct` surface (no new method added to ProductService).
- `Start` synchronously persists scheduled + spawns `RunActive` in a goroutine over `context.Background()` so an admin's cancelled HTTP request never kills the saga. Per-item failures are non-fatal and recorded; ctx cancellation resumes from `ProcessedItems` on next run.
- Admin UI: list + start form + detail page with HTMX-poll progress bar (`/admin/repricing`, `/admin/repricing/{id}`).
- 17 domain tests + 10 service tests including resume-after-interruption.

Demonstrates: long-running workflow, saga, resumable Process Manager with partial-failure handling.

## Test plan
- [ ] CI green
- [ ] Start a reprice from `/admin/repricing` — progress bar polls + advances
- [ ] Restart the app mid-reprice — `RunActive` resumes from where it left off
- [ ] Try to start a second reprice while one is active — rejected