### PR TITLE
fix: add default value to StripeFailCardEndingIn

### DIFF
--- a/backend/cmd/web/config.go
+++ b/backend/cmd/web/config.go
@@ -106,7 +106,7 @@ type config struct {
 	// declined charge (status "failed"); leave empty and every charge
 	// the fake provider sees succeeds. Dev/test only — production
 	// payment failures come from the real provider's logic.
-	StripeFailCardEndingIn string `conf:"default:,STRIPE_FAIL_CARD_ENDING_IN"`
+	StripeFailCardEndingIn string `conf:"default:0000,STRIPE_FAIL_CARD_ENDING_IN"`
 }
 
 // defaultSessionSecret is the placeholder value SessionSecret must NOT keep


### PR DESCRIPTION
Couldn't run `docker compose up` without this value being set. Let me know if there's a better way to handle it and I'll make it happen. Thanks for all the hard work! ✨ 